### PR TITLE
fix(spider-pie-label-events): 修复spider pie监听label事件失效

### DIFF
--- a/__tests__/unit/pie.spec2.js
+++ b/__tests__/unit/pie.spec2.js
@@ -8,68 +8,40 @@ describe('Pie plot', () => {
   canvasDiv.style.top = '30px';
   canvasDiv.id = 'canvas1';
   document.body.appendChild(canvasDiv);
+  const data2 = [
+    {
+      x: '分类一',
+      y: 385,
+      serie: 'default',
+    },
+    {
+      x: '分类二',
+      y: 888,
+      serie: 'default',
+    },
+    {
+      x: '分类三',
+      y: 349,
+      serie: 'default',
+    },
+    {
+      x: '分类四',
+      y: 468,
+      serie: 'default',
+    },
+    {
+      x: '分类五',
+      y: 477,
+      serie: 'default',
+    },
+  ];
 
   it('创建饼图', () => {
-    const data = [
-      {
-        type: '分类一',
-        value: 27,
-      },
-      {
-        type: '分类二',
-        value: 25,
-      },
-      {
-        type: '分类三',
-        value: 18,
-      },
-      {
-        type: '分类四',
-        value: 15,
-      },
-      {
-        type: '分类五',
-        value: 10,
-      },
-      {
-        type: 'Other',
-        value: 5,
-      },
-    ];
-
-    const data2 = [
-      {
-        x: '分类一',
-        y: 385,
-        serie: 'default',
-      },
-      {
-        x: '分类二',
-        y: 888,
-        serie: 'default',
-      },
-      {
-        x: '分类三',
-        y: 349,
-        serie: 'default',
-      },
-      {
-        x: '分类四',
-        y: 468,
-        serie: 'default',
-      },
-      {
-        x: '分类五',
-        y: 477,
-        serie: 'default',
-      },
-    ];
-
     const pie = new Pie(canvasDiv, {
       width: 600,
       height: 600,
       data: data2,
-      label: {  
+      label: {
         visible: true,
         type: 'spider',
       },
@@ -90,6 +62,43 @@ describe('Pie plot', () => {
       legend: {
         visible: true,
         // position: 'right-bottom'
+      },
+    });
+
+    pie.render();
+  });
+
+  it('Events in spider pie', () => {
+    const pie = new Pie(canvasDiv, {
+      width: 600,
+      height: 600,
+      data: data2,
+      label: {
+        visible: true,
+        type: 'spider',
+      },
+      tooltip: {
+        visible: false,
+      },
+      angleField: 'y',
+      colorField: 'x',
+      padding: 'auto',
+      animation: false,
+      radius: 1,
+      title: {
+        text: 'spider-pie with events',
+      },
+      legend: {
+        visible: true,
+      },
+      events: {
+        'label:mouseenter': (e) => {
+          console.log('label:mouseenter');
+        },
+        // 两种写法都可以
+        onLabelMouseenter: (e) => {
+          console.log('onLabelMouseenter');
+        },
       },
     });
 

--- a/src/plots/pie/component/label/spiderLabel.ts
+++ b/src/plots/pie/component/label/spiderLabel.ts
@@ -136,7 +136,7 @@ export default class SpiderLabel {
       if (this.formatter) {
         lowerText = texts[0];
       }
-      textGroup.addShape('text', {
+      const topTextShape = textGroup.addShape('text', {
         attrs: _.mix(
           {
             textBaseline: 'top',
@@ -148,9 +148,10 @@ export default class SpiderLabel {
         offsetY: LABEL1_OFFSETY,
         name: 'label',
       });
+      topTextShape.name = 'label'; // 用于事件标记 shapeName
       /** label2:上部label */
       if (this.fields.length === 2) {
-        textGroup.addShape('text', {
+        const bottomTextShape = textGroup.addShape('text', {
           attrs: _.mix(
             {
               textBaseline: 'bottom',
@@ -162,6 +163,7 @@ export default class SpiderLabel {
           offsetY: LABEL2_OFFSETY,
           name: 'label',
         });
+        bottomTextShape.name = 'label'; // 用于事件标记 shapeName
       }
 
       label.textGroup = textGroup;


### PR DESCRIPTION
1. 主要原因在于G层的shape没有用配置cfg.name对Shape name赋值，因此上层需要手动标注
2. 此为临时方案，后续建议下沉到shape处理，或者shape提供setter的方式，如`setName` 而不是直接赋值

closes #110