### PR TITLE
fix: config all meta scale in meta config

### DIFF
--- a/src/base/ViewLayer.ts
+++ b/src/base/ViewLayer.ts
@@ -242,15 +242,8 @@ export default abstract class ViewLayer<T extends Config = Config> extends Layer
   protected _scale(): void {
     /** scale meta配置 */
     const props = this.initialProps;
-    const scales = _.mapValues(this.config.scales, (scaleConfig: any, field: string) => {
-      const meta: Config['meta']['key'] = _.get(props.meta, field);
-      const type = scaleConfig.type;
-      // meta中存在对应配置，则补充入
-      if (meta) {
-        return _.assign({}, scaleConfig, type ? { ...meta, type } : meta);
-      }
-      return scaleConfig;
-    });
+    // this.config.scales中已有子图形在处理xAxis/yAxis是写入的xField/yField对应的scale信息，这里再检查用户设置的meta，将meta信息合并到默认的scale中
+    const scales = _.assign({}, this.config.scales, props.meta || {});
     this.setConfig('scales', scales);
   }
 


### PR DESCRIPTION
之前的写法会导致用户在meta中设置的meta信息没有传到到g2，因为在子图形中只处理了xField/yField的scale信息，用户可能还设置其他字段的scale信息，也需要传递下去