### PR TITLE
docs: Upgrade theme config

### DIFF
--- a/docs/manual/introduction.zh.md
+++ b/docs/manual/introduction.zh.md
@@ -1,7 +1,8 @@
 ---
 title: 简介
 order: 0
-icon: none
+redirect_from:
+  - /zh/docs/manual
 ---
 
 g2plot 是一套简单、易用、并具备一定扩展能力和组合能力的统计图表库，基于图形语法理论搭建而成，"g2plot"中的 g2 即意指图形语法(the Gramma of Graphics)，同时也致敬了 ggplot2。

--- a/examples/line/basic/index.en.md
+++ b/examples/line/basic/index.en.md
@@ -1,6 +1,8 @@
 ---
 title: Line Chart
 order: 0
+redirect_from:
+  - /en/examples
 ---
 
 Description about this component.

--- a/examples/line/basic/index.zh.md
+++ b/examples/line/basic/index.zh.md
@@ -1,6 +1,8 @@
 ---
 title: 某某折线图
 order: 0
+redirect_from:
+  - /zh/examples
 ---
 
 图表的基本描述。

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,7 +22,6 @@ module.exports = {
           zh: '使用文档',
           en: 'docs',
         },
-        redirect: 'introduction',
       },
       {
         slug: 'examples',
@@ -30,7 +29,6 @@ module.exports = {
           zh: '图表演示',
           en: 'Examples',
         },
-        redirect: 'line/basic',
       },
     ],
     docs: [
@@ -40,6 +38,7 @@ module.exports = {
           zh: '图表',
           en: 'Charts',
         },
+        order: 3,
       },
       {
         slug: 'manual/advanced',
@@ -47,6 +46,7 @@ module.exports = {
           zh: '进阶',
           en: 'Advanced',
         },
+        order: 4,
       },
     ],
     examples: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,31 +15,14 @@ module.exports = {
     title: 'G2Plot',
     description: 'A collection of charts made with the Grammar of Graphics',
     githubUrl: repository.url,
-    docs: [
+    navs: [
       {
-        slug: 'manual',
+        slug: 'docs/manual',
         title: {
           zh: '使用文档',
           en: 'docs',
         },
         redirect: 'introduction',
-        order: 0,
-      },
-      {
-        slug: 'manual/plots',
-        title: {
-          zh: '图表',
-          en: 'Charts',
-        },
-        order: 3,
-      },
-      {
-        slug: 'manual/advanced',
-        title: {
-          zh: '进阶',
-          en: 'Advanced',
-        },
-        order: 4,
       },
       {
         slug: 'examples',
@@ -47,13 +30,28 @@ module.exports = {
           zh: '图表演示',
           en: 'Examples',
         },
-        order: 100,
         redirect: 'line/basic',
+      },
+    ],
+    docs: [
+      {
+        slug: 'manual/plots',
+        title: {
+          zh: '图表',
+          en: 'Charts',
+        },
+      },
+      {
+        slug: 'manual/advanced',
+        title: {
+          zh: '进阶',
+          en: 'Advanced',
+        },
       },
     ],
     examples: [
       {
-        slug: 'examples/line',
+        slug: 'line',
         icon: 'line', // 图标名可以去 https://antv.alipay.com/zh-cn/g2/3.x/demo/index.html 打开控制台查看图标类名
         title: {
           zh: '折线图',
@@ -61,8 +59,8 @@ module.exports = {
         },
       },
       {
-        slug: 'examples/pie',
-        icon: 'pie', // 图标名可以去 https://antv.alipay.com/zh-cn/g2/3.x/demo/index.html 打开控制台查看图标类名
+        slug: 'pie',
+        icon: 'pie',
         title: {
           zh: '饼图',
           en: 'Pie Charts',

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@antv/gatsby-theme-antv": "^0.8.2",
+    "@antv/gatsby-theme-antv": "^0.9.2",
     "@antv/torch": "~1.0.5",
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@antv/gatsby-theme-antv": "^0.9.2",
+    "@antv/gatsby-theme-antv": "^0.9.4",
     "@antv/torch": "~1.0.5",
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",


### PR DESCRIPTION
- https://github.com/antvis/g2plot/pull/174
- https://github.com/antvis/g/pull/251

重新定义了一下 gatsby-config.js 的配置，有一些不兼容。

- [x] 新增了 `navs` 用于定义顶部菜单。
- [x] `examples` 里的 `slug` 统一移除掉 `examples` 前缀。
- [x] `docs` 里的一级目录移到 `navs` 上。
- [x] 干掉 `redirect`，在 md 里直接定义 `redirect_from`。