### PR TITLE
fix: 修复Layer/Plot相关的TS定义

### DIFF
--- a/__tests__/unit/area-spec.js
+++ b/__tests__/unit/area-spec.js
@@ -310,16 +310,16 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const plot = areaPlot.getLayer().plot;
-    const positionField = plot.get('elements')[0].get('position').fields;
-    const axes = areaPlot.plot.get('axisController').axes;
+    const view = areaPlot.getLayer().view;
+    const positionField = view.get('elements')[0].get('position').fields;
+    const axes = view.get('axisController').axes;
 
     expect(areaPlot).to.be.instanceOf(Area);
     expect(positionField[0]).to.be.equal('year');
     expect(positionField[1]).to.be.equal('value');
     expect(axes.length).to.be.equal(2);
     areaPlot.destroy();
-    expect(plot.destroyed).to.be.true;
+    expect(view.destroyed).to.be.true;
   });
 
   it('area style', () => {
@@ -362,12 +362,12 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const plot = areaPlot.getLayer().view;
-    const elements = plot.get('elements');
+    const view = areaPlot.getLayer().view;
+    const elements = view.get('elements');
     expect(elements[0].get('type')).to.be.equal('area');
     expect(elements[0].get('style').cfg.strokeStyle).to.be.equal('black');
     areaPlot.destroy();
-    expect(plot.destroyed).to.be.true;
+    expect(view.destroyed).to.be.true;
   });
 
   it('line shape attr map', () => {
@@ -397,13 +397,13 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const plot = areaPlot.getLayer().view;
-    const elements = plot.get('elements');
+    const view = areaPlot.getLayer().view;
+    const elements = view.get('elements');
     expect(elements[1].get('type')).to.be.equal('line');
     expect(elements[1].get('size').values[0]).to.be.equal(6);
     expect(elements[1].get('color').values[0]).to.be.equal('pink');
     areaPlot.destroy();
-    expect(plot.destroyed).to.be.true;
+    expect(view.destroyed).to.be.true;
   });
 
   it('line style obj', () => {
@@ -446,13 +446,13 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const plot = areaPlot.getLayer().view;
-    const elements = plot.get('elements');
+    const view = areaPlot.getLayer().view;
+    const elements = view.get('elements');
     expect(elements[1].get('type')).to.be.equal('line');
     expect(elements[1].get('size').values[0]).to.be.equal(6);
     expect(elements[1].get('style').cfg.color).to.be.equal('blue');
     areaPlot.destroy();
-    expect(plot.destroyed).to.be.true;
+    expect(view.destroyed).to.be.true;
   });
 
   // it('line style func', () => {
@@ -541,8 +541,8 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const plot = areaPlot.getLayer().view;
-    const elements = plot.get('elements');
+    const view = areaPlot.getLayer().view;
+    const elements = view.get('elements');
     expect(elements[1].get('type')).to.be.equal('line');
     expect(elements[1].get('size').values[0]).to.be.equal(6);
     expect(elements[1].get('style').cfg.strokeStyle).to.be.equal('blue');
@@ -550,7 +550,7 @@ describe('Area plot', () => {
     expect(elements[2].get('size').values[0]).to.be.equal(8);
     expect(elements[2].get('color').values[0]).to.be.equal('yellow');
     areaPlot.destroy();
-    expect(plot.destroyed).to.be.true;
+    expect(view.destroyed).to.be.true;
   });
 
   it.skip('point style obj', () => {
@@ -595,7 +595,7 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const elements = areaPlot.plot.get('elements');
+    const elements = areaPlot.getLayer().view.get('elements');
     expect(elements[1].get('type')).to.be.equal('line');
     expect(elements[1].get('size').values[0]).to.be.equal(6);
     expect(elements[1].get('style').cfg.strokeStyle).to.be.equal('blue');
@@ -649,12 +649,12 @@ describe('Area plot', () => {
       responsive: true,
     });
     areaPlot.render();
-    const plot = areaPlot.getLayer().view;
-    const elements = plot.get('elements');
+    const view = areaPlot.getLayer().view;
+    const elements = view.get('elements');
     expect(elements[0].get('type')).to.be.equal('area');
     expect(elements[0].get('color').values[0]).to.be.equal('green');
     expect(elements[0].get('color').fields[0]).to.be.equal('type');
     areaPlot.destroy();
-    expect(plot.destroyed).to.be.true;
+    expect(view.destroyed).to.be.true;
   });
 });

--- a/src/base/controller/theme.ts
+++ b/src/base/controller/theme.ts
@@ -1,10 +1,10 @@
 import * as G2 from '@antv/g2';
 import * as _ from '@antv/util';
-import BaseConfig from '../../interface/config';
 // import Theme from '../../theme';
 import { convertToG2Theme, getGlobalTheme, getTheme } from '../../theme';
 import { processAxisVisible } from '../../util/axis';
 import { getResponsiveTheme } from '../../util/responsive/theme';
+import { ViewConfig } from '../view-layer';
 
 /**
  * 负责图表theme的管理
@@ -12,7 +12,7 @@ import { getResponsiveTheme } from '../../util/responsive/theme';
 
 const G2DefaultTheme = G2.Global.theme;
 
-export default class ThemeController<T extends BaseConfig = BaseConfig> {
+export default class ThemeController<T extends ViewConfig = ViewConfig> {
   /**
    * 通过 theme 和图表类型，获取当前 plot 对应的主题
    * @param props

--- a/src/base/layer.ts
+++ b/src/base/layer.ts
@@ -3,12 +3,12 @@ import * as G from '@antv/g';
 import * as _ from '@antv/util';
 import { Point } from '../interface/config';
 
-export interface LayerCfg {
+export interface LayerConfig {
   id?: string;
   /** the top-left-x of layer, local position relative to the parent layer */
-  x: number;
-  /** the top-left-y of layer, local position telative to the parent layer */
-  y: number;
+  x?: number;
+  /** the top-left-y of layer, local position relative to the parent layer */
+  y?: number;
   /** layer width */
   width?: number;
   /** layer height */
@@ -32,7 +32,7 @@ export interface Range {
   height: number;
 }
 
-export default class Layer<T = void> extends EventEmitter {
+export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmitter {
   public id: string;
   public x: number;
   public y: number;
@@ -51,7 +51,7 @@ export default class Layer<T = void> extends EventEmitter {
   /**
    * layer base for g2plot
    */
-  constructor(props: LayerCfg) {
+  constructor(props: T) {
     super();
     const options = this.getOptions(props);
     this.id = options.id;
@@ -108,14 +108,14 @@ export default class Layer<T = void> extends EventEmitter {
    */
   public clear() {
     this.eachLayer((layer) => {
-      layer.destory();
+      layer.destroy();
     });
     this.layers = [];
     this.container.clear();
   }
 
   /**
-   * destory layer recursively, remove the container of layer
+   * destroy layer recursively, remove the container of layer
    */
   public destroy() {
     this.eachLayer((layer) => {
@@ -145,7 +145,7 @@ export default class Layer<T = void> extends EventEmitter {
    * add children layer
    * @param layer
    */
-  public addLayer(layer: Layer) {
+  public addLayer(layer: Layer<any>) {
     const idx = _.findIndex(this.layers, (item) => item === layer);
     if (idx < 0) {
       if (layer.parent !== this) {
@@ -160,7 +160,7 @@ export default class Layer<T = void> extends EventEmitter {
    * remove children layer
    * @param layer
    */
-  public removeLayer(layer: Layer) {
+  public removeLayer(layer: Layer<any>) {
     const idx = _.findIndex(this.layers, (item) => item === layer);
     if (idx >= 0) {
       this.layers.splice(idx, 1);
@@ -209,7 +209,7 @@ export default class Layer<T = void> extends EventEmitter {
   }
 
   /**
-   * get global postion of layer
+   * get global position of layer
    */
   public getGlobalPosition() {
     let globalX = this.x;
@@ -223,7 +223,7 @@ export default class Layer<T = void> extends EventEmitter {
     return { x: globalX, y: globalY };
   }
 
-  public getOptions(props: LayerCfg) {
+  public getOptions(props: T): T {
     let parentWidth = 0;
     let parentHeight = 0;
     if (props.parent) {
@@ -240,7 +240,7 @@ export default class Layer<T = void> extends EventEmitter {
     return _.deepMix({}, defaultOptions, props);
   }
 
-  public eachLayer(cb: (layer) => void) {
+  public eachLayer(cb: (layer: Layer<any>) => void) {
     _.each(this.layers, cb);
   }
 

--- a/src/base/layer.ts
+++ b/src/base/layer.ts
@@ -26,10 +26,10 @@ export interface Region {
 }
 
 export interface Range {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
 }
 
 export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmitter {

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -10,9 +10,9 @@ import { EVENT_MAP, onEvent } from '../util/event';
 import PaddingController from './controller/padding';
 import StateController from './controller/state';
 import ThemeController from './controller/theme';
-import Layer, { LayerCfg } from './layer';
+import Layer, { LayerConfig } from './layer';
 
-export interface ViewLayerCfg extends LayerCfg {
+export interface ViewConfig {
   data: object[];
   meta?: { [fieldId: string]: any & { type?: any } };
   padding?: number | number[] | string;
@@ -31,6 +31,17 @@ export interface ViewLayerCfg extends LayerCfg {
   responsiveTheme?: {} | string;
   interactions?: IInteractions[];
   responsive?: boolean;
+  forceFit?: boolean;
+  title?: {
+    visible: boolean;
+    text: string;
+    style?: any;
+  };
+  description?: {
+    visible: boolean;
+    text: string;
+    style?: any;
+  };
   events?: {
     [k: string]: ((...args: any[]) => any) | boolean;
   };
@@ -40,15 +51,13 @@ export interface ViewLayerCfg extends LayerCfg {
     selected?: StateConfig;
     disabled?: StateConfig;
   };
-  // fixme: any
-  [k: string]: any;
 }
 
-export default abstract class ViewLayer<T extends ViewLayerCfg = ViewLayerCfg> extends Layer {
-  public static getDefaultOptions(): any {
+export interface ViewLayerConfig extends ViewConfig, LayerConfig {}
+
+export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerConfig> extends Layer<T> {
+  public static getDefaultOptions(): Partial<ViewConfig> {
     return {
-      width: 400,
-      height: 400,
       title: {
         visible: false,
         text: '',
@@ -132,7 +141,7 @@ export default abstract class ViewLayer<T extends ViewLayerCfg = ViewLayerCfg> e
   protected description: TextDescription;
   private interactions: BaseInteraction[] = [];
 
-  constructor(props: ViewLayerCfg) {
+  constructor(props: T) {
     super(props);
     this.options = this.getOptions(props);
     this.initialOptions = _.deepMix({}, this.options);
@@ -145,7 +154,7 @@ export default abstract class ViewLayer<T extends ViewLayerCfg = ViewLayerCfg> e
     this.themeController = new ThemeController();
   }
 
-  public getOptions(props: ViewLayerCfg) {
+  public getOptions(props: T): T {
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -4,7 +4,7 @@ import * as _ from '@antv/util';
 import TextDescription from '../components/description';
 import { getComponent } from '../components/factory';
 import BaseInteraction, { InteractionCtor } from '../interaction/index';
-import { Axis, IInteractions, Label, Legend, StateConfig, Tooltip } from '../interface/config';
+import { Axis, IDescription, IInteractions, ITitle, Label, Legend, StateConfig, Tooltip } from '../interface/config';
 import { G2Config } from '../interface/config';
 import { EVENT_MAP, onEvent } from '../util/event';
 import PaddingController from './controller/padding';
@@ -32,16 +32,8 @@ export interface ViewConfig {
   interactions?: IInteractions[];
   responsive?: boolean;
   forceFit?: boolean;
-  title?: {
-    visible: boolean;
-    text: string;
-    style?: any;
-  };
-  description?: {
-    visible: boolean;
-    text: string;
-    style?: any;
-  };
+  title?: ITitle;
+  description?: IDescription;
   events?: {
     [k: string]: ((...args: any[]) => any) | boolean;
   };

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -31,7 +31,6 @@ export interface ViewConfig {
   responsiveTheme?: {} | string;
   interactions?: IInteractions[];
   responsive?: boolean;
-  forceFit?: boolean;
   title?: ITitle;
   description?: IDescription;
   events?: {
@@ -58,7 +57,6 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
         visible: false,
         text: '',
       },
-      forceFit: true,
       padding: 'auto',
       legend: {
         visible: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 // 通用配置
-export { default as Config } from './interface/config';
 export * from './interface/config';
 
 // 图形
-export { default as Layer } from './base/layer';
-export { default as ViewLayer } from './base/view-layer';
-export { default as Base } from './base/plot';
+export { default as Layer, LayerConfig } from './base/layer';
+export { default as ViewLayer, ViewConfig } from './base/view-layer';
+export { default as Base, PlotConfig } from './base/plot';
 export { default as Line, LineConfig } from './plots/line';
 export { default as Density, DensityConfig } from './plots/density';
 export { default as Column, ColumnConfig } from './plots/column';

--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -101,16 +101,17 @@ interface IBaseAxis {
   position?: 'default' | 'opposite';
   line?: {
     visible?: boolean;
-    style: {};
+    style?: {};
   };
   grid?:
     | {
         visible?: boolean;
-        style: {};
+        style?: {};
       }
     | ((text: string, idx: number, count: number) => any);
   autoRotateLabel?: boolean; // 当 label 过长发生遮挡时是否自动旋转坐标轴文本，默认为 true
   autoHideLabel?: boolean; // 当 label 存在遮挡时，是否自动隐藏被遮挡的坐标轴文本，默认为 false
+  autoRotateTitle?: boolean;
   label?:
     | {
         visible?: boolean;
@@ -139,7 +140,7 @@ interface IBaseAxis {
 }
 /** Linear型 */
 export interface IValueAxis extends IBaseAxis {
-  type: 'linear';
+  type?: 'linear';
   /** tick相关配置 */
   min?: number;
   max?: number;
@@ -150,7 +151,7 @@ export interface IValueAxis extends IBaseAxis {
 }
 /** 时间型 */
 export interface ITimeAxis extends IBaseAxis {
-  type: 'time';
+  type?: 'time';
   /** tick相关配置 */
   tickInterval?: string;
   tickCount?: number;
@@ -158,7 +159,7 @@ export interface ITimeAxis extends IBaseAxis {
 }
 /** 离散类目型 */
 export interface ICatAxis extends IBaseAxis {
-  type: 'category';
+  type?: 'category';
   /** tick相关配置 */
   tickInterval?: number;
   tickCount?: number;
@@ -203,6 +204,7 @@ export interface Tooltip {
   itemTpl?: string;
   /** 辅助线 */
   crosshair?: 'x' | 'y' | 'cross' | boolean;
+  crosshairs?: { type: string }; // FIXME:
   style?: {};
 }
 

--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -9,79 +9,14 @@ import { Option } from '@antv/g2';
 import { AttributeCfg, LabelOptions } from '@antv/g2/lib/element/base';
 import { AdjustCfg } from '@antv/g2/lib/interface';
 
-export default interface Config {
-  /** 数据，对象数组 */
-  data: object[];
-  width?: number;
-  height?: number;
-  /** 自适应父容器宽度和高度 */
-  forceFit?: boolean;
-  /** 渲染引擎 */
-  renderer?: string;
-  /** 字段描述信息，G2用于设置Tooltip、Scale等配置 */
-  // meta?: { [fieldId: string]: ScaleConfig & { type?: Scale['type'] } };
-  meta?: { [fieldId: string]: any & { type?: any } };
-  /** 图表标题 */
-  title?: ITitle;
-  /** 图表描述 */
-  description?: IDescription;
-  /** padding */
-  padding?: number | number[] | string;
-  /** x、y轴字段 */
-  xField?: string;
-  yField?: string;
-  /** 颜色映射 */
-  color?: string | string[] | {};
-  /** 大小映射 */
-  size?: number | number[] | {};
-  /** 形状映射 */
-  shape?: string | string[] | {};
-  /** 轴 */
-  xAxis?: Axis;
-  yAxis?: Axis;
-  /** 数据标签 */
-  label?: Label;
-  /** Tooltip */
-  tooltip?: Tooltip;
-  /** 图例 */
-  legend?: Legend;
-  /** 动画 */
-  animation?: any | boolean;
-  /** 标注 */
-  annotation?: any[];
-  /** 样式 */
-  theme?: Theme | string;
-  /** 响应式规则 */
-  responsiveTheme?: {} | string;
-  /** 交互，待定 */
-  interactions?: IInteractions[];
-  /** 是否响应式 */
-  responsive?: boolean;
-  /** 图表层级的事件 */
-  events?: {
-    [k: string]: ((...args: any[]) => any) | boolean;
-  };
-  /** 图表初始状态 */
-  defaultState?: {
-    active?: StateConfig;
-    inActive?: StateConfig;
-    selected?: StateConfig;
-    disabled?: StateConfig;
-  };
-  // fixme: any
-  [k: string]: any;
-}
-
-type Formatter = (value: any, index?: number, ...args: any[]) => string;
-
-interface ITitle {
+export interface ITitle {
   visible: boolean;
   text: string;
   style?: {};
   alignWithAxis?: boolean;
 }
 
-interface IDescription {
+export interface IDescription {
   visible: boolean;
   text: string;
   style?: {};
@@ -178,6 +113,7 @@ export interface Label {
   offsetY?: number;
   events?: IEvents;
   position?: string;
+  adjustColor?: boolean;
   /** 展示优化策略 */
 }
 
@@ -324,12 +260,7 @@ export interface IScrollBarInteractionConfig {
   categorySize?: number;
 }
 
-// TODO: to remove
-export interface IAnyInteractionConfig {
-  [key: string]: any;
-}
-
-export type IInteractionConfig = IAnyInteractionConfig | IScrollBarInteractionConfig | ISliderInteractionConfig;
+export type IInteractionConfig = IScrollBarInteractionConfig | ISliderInteractionConfig;
 
 export interface IInteractions {
   type: string;

--- a/src/plots/area/index.ts
+++ b/src/plots/area/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import AreaLayer, { AreaLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import AreaLayer, { AreaViewConfig } from './layer';
 
-export interface AreaConfig extends AreaLayerConfig, PlotCfg {}
+export interface AreaConfig extends AreaViewConfig, PlotConfig {}
 
 export default class Area<T extends AreaConfig = AreaConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof AreaLayer.getDefaultOptions = AreaLayer.getDefaultOptions;

--- a/src/plots/area/layer.ts
+++ b/src/plots/area/layer.ts
@@ -1,7 +1,8 @@
 import { DataPointType } from '@antv/g2/lib/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import { ElementOption, ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
@@ -34,7 +35,7 @@ const GEOM_MAP = {
   point: 'point',
 };
 
-export interface AreaLayerConfig extends ViewLayerCfg {
+export interface AreaViewConfig extends ViewConfig {
   areaStyle?: AreaStyle | ((...args: any) => AreaStyle);
   seriesField?: string;
   xAxis?: ICatAxis | ITimeAxis;
@@ -56,6 +57,8 @@ export interface AreaLayerConfig extends ViewLayerCfg {
   };
   smooth?: boolean;
 }
+
+export interface AreaLayerConfig extends AreaViewConfig, LayerConfig {}
 
 export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {

--- a/src/plots/bar/index.ts
+++ b/src/plots/bar/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import BarLayer, { BarLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import BarLayer, { BarViewConfig } from './layer';
 
-export interface BarConfig extends BarLayerConfig, PlotCfg {}
+export interface BarConfig extends BarViewConfig, PlotConfig {}
 
 export default class Bar<T extends BarConfig = BarConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof BarLayer.getDefaultOptions = BarLayer.getDefaultOptions;

--- a/src/plots/bar/layer.ts
+++ b/src/plots/bar/layer.ts
@@ -1,10 +1,11 @@
 import { DataPointType } from '@antv/g2/lib/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
-import BaseConfig, { ElementOption, ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
+import { ElementOption, ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
 import { extractAxis } from '../../util/axis';
 import { extractScale } from '../../util/scale';
 import responsiveMethods from './apply-responsive';
@@ -25,7 +26,7 @@ const PLOT_GEOM_MAP = {
   interval: 'bar',
 };
 
-export interface BarLayerConfig extends ViewLayerCfg {
+export interface BarViewConfig extends ViewConfig {
   // 图形
   type?: 'rect'; // todo | 'triangle' | 'round';
   // 百分比, 数值, 最小最大宽度
@@ -37,9 +38,11 @@ export interface BarLayerConfig extends ViewLayerCfg {
   yAxis?: IValueAxis;
 }
 
+export interface BarLayerConfig extends BarViewConfig, LayerConfig {}
+
 export default class BaseBarLayer<T extends BarLayerConfig = BarLayerConfig> extends ViewLayer<T> {
-  public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+  public static getDefaultOptions(): Partial<BarViewConfig> {
+    const cfg: Partial<BarViewConfig> = {
       xAxis: {
         visible: false,
       },
@@ -82,7 +85,8 @@ export default class BaseBarLayer<T extends BarLayerConfig = BarLayerConfig> ext
         visible: true,
         position: 'top-left',
       },
-    });
+    };
+    return _.deepMix({}, super.getDefaultOptions(), cfg);
   }
 
   public bar: any;

--- a/src/plots/bubble/index.ts
+++ b/src/plots/bubble/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import BubbleLayer, { BubbleLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import BubbleLayer, { BubbleViewConfig } from './layer';
 
-export interface BubbleConfig extends BubbleLayerConfig, PlotCfg {}
+export interface BubbleConfig extends BubbleViewConfig, PlotConfig {}
 
 export default class Bubble<T extends BubbleConfig = BubbleConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof BubbleLayer.getDefaultOptions = BubbleLayer.getDefaultOptions;

--- a/src/plots/bubble/layer.ts
+++ b/src/plots/bubble/layer.ts
@@ -1,6 +1,7 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import { ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
@@ -21,7 +22,7 @@ const PLOT_GEOM_MAP = {
   point: 'bubble',
 };
 
-export interface BubbleLayerConfig extends ViewLayerCfg {
+export interface BubbleViewConfig extends ViewConfig {
   /** TODO 待补充 */
   bubbleStyle?: BubbleStyle | ((...args: any[]) => BubbleStyle);
   /** 气泡大小字段 */
@@ -31,6 +32,8 @@ export interface BubbleLayerConfig extends ViewLayerCfg {
   xAxis?: ICatAxis | ITimeAxis;
   yAxis?: IValueAxis;
 }
+
+export interface BubbleLayerConfig extends BubbleViewConfig, LayerConfig {}
 
 export default class BaseBubbleLayer<T extends BubbleLayerConfig = BubbleLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {

--- a/src/plots/column/index.ts
+++ b/src/plots/column/index.ts
@@ -1,13 +1,13 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import ColumnLayer, { ColumnLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import ColumnLayer, { ColumnViewConfig } from './layer';
 
-export interface ColumnConfig extends ColumnLayerConfig, PlotCfg {}
+export interface ColumnConfig extends ColumnViewConfig, PlotConfig {}
 
 export default class Column<T extends ColumnConfig = ColumnConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof ColumnLayer.getDefaultOptions = ColumnLayer.getDefaultOptions;
 
-  public createLayers(props) {
+  public createLayers(props: T) {
     const layerProps = _.deepMix({}, props);
     layerProps.type = 'column';
     super.createLayers(layerProps);

--- a/src/plots/column/layer.ts
+++ b/src/plots/column/layer.ts
@@ -1,7 +1,8 @@
 import { DataPointType } from '@antv/g2/lib/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import { ElementOption, ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
@@ -25,7 +26,7 @@ const PLOT_GEOM_MAP = {
   interval: 'column',
 };
 
-export interface ColumnLayerConfig extends ViewLayerCfg {
+export interface ColumnViewConfig extends ViewConfig {
   // 图形
   type?: 'rect' | 'triangle' | 'round';
   // 百分比, 数值, 最小最大宽度
@@ -36,6 +37,8 @@ export interface ColumnLayerConfig extends ViewLayerCfg {
   xAxis?: ICatAxis | ITimeAxis;
   yAxis?: IValueAxis;
 }
+
+export interface ColumnLayerConfig extends ColumnViewConfig, LayerConfig {}
 
 export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
@@ -67,7 +70,7 @@ export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerCo
   public column: any;
   public type: string = 'column';
 
-  public getOptions(props: ViewLayerCfg) {
+  public getOptions(props: T) {
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();

--- a/src/plots/density/index.ts
+++ b/src/plots/density/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import DensityLayer, { DensityLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import DensityLayer, { DensityViewConfig } from './layer';
 
-export interface DensityConfig extends DensityLayerConfig, PlotCfg {}
+export interface DensityConfig extends DensityViewConfig, PlotConfig {}
 
 export default class Density<T extends DensityConfig = DensityConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof DensityLayer.getDefaultOptions = DensityLayer.getDefaultOptions;

--- a/src/plots/density/layer.ts
+++ b/src/plots/density/layer.ts
@@ -2,15 +2,18 @@ import { DataPointType } from '@antv/g2/lib/interface';
 import { getScale } from '@antv/scale';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { sturges } from '../../util/math';
-import Area, { AreaLayerConfig } from '../area/layer';
+import Area, { AreaViewConfig } from '../area/layer';
 
-export interface DensityLayerConfig extends AreaLayerConfig {
+export interface DensityViewConfig extends AreaViewConfig {
   binField: string;
   binWidth?: number;
   binNumber?: number;
   kernel?: 'uniform' | 'triangle' | 'epanechnikov' | 'quartic' | 'triweight' | 'gaussian' | 'cosinus';
 }
+
+export interface DensityLayerConfig extends DensityViewConfig, LayerConfig {}
 
 const kernels = {
   epanechnikov: (dist: number) => {

--- a/src/plots/gauge/index.ts
+++ b/src/plots/gauge/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import GaugeLayer, { GaugeLayerConfig } from './layer';
 
-export interface GaugeConfig extends GaugeLayerConfig, PlotCfg {}
+export interface GaugeConfig extends GaugeLayerConfig, PlotConfig {}
 
 export default class Gauge<T extends GaugeConfig = GaugeConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof GaugeLayer.getDefaultOptions = GaugeLayer.getDefaultOptions;

--- a/src/plots/gauge/layer.ts
+++ b/src/plots/gauge/layer.ts
@@ -1,7 +1,8 @@
 import { CoordinateType } from '@antv/g2/lib/plot/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { ElementOption } from '../../interface/config';
 import { extractScale } from '../../util/scale';
 import './geometry/shape/pointer';
@@ -16,14 +17,19 @@ interface GaugeStyle {
   size?: number;
 }
 
-export interface GaugeLayerConfig extends ViewLayerCfg {
+export interface GaugeViewConfig extends ViewConfig {
   min?: number;
   max?: number;
   value?: number;
   showValue?: boolean;
   format?: (...args: any[]) => string;
   gaugeStyle?: GaugeStyle;
+  range: number[];
+  styleMix?: any;
+  valueText?: string;
 }
+
+export interface GaugeLayerConfig extends GaugeViewConfig, LayerConfig {}
 
 export default class GaugeLayer extends ViewLayer<GaugeLayerConfig> {
   public type: string = 'gauge';

--- a/src/plots/group-bar/index.ts
+++ b/src/plots/group-bar/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import GroupBarLayer, { GroupBarLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import GroupBarLayer, { GroupBarViewConfig } from './layer';
 
-export interface GroupBarConfig extends GroupBarLayerConfig, PlotCfg {}
+export interface GroupBarConfig extends GroupBarViewConfig, PlotConfig {}
 
 export default class GroupBar<T extends GroupBarConfig = GroupBarConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof GroupBarLayer.getDefaultOptions = GroupBarLayer.getDefaultOptions;

--- a/src/plots/group-bar/layer.ts
+++ b/src/plots/group-bar/layer.ts
@@ -1,11 +1,14 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { ElementOption } from '../../interface/config';
-import BaseBarLayer, { BarLayerConfig } from '../bar/layer';
+import BaseBarLayer, { BarViewConfig } from '../bar/layer';
 
-export interface GroupBarLayerConfig extends BarLayerConfig {
+export interface GroupBarViewConfig extends BarViewConfig {
   groupField: string;
 }
+
+export interface GroupBarLayerConfig extends GroupBarViewConfig, LayerConfig {}
 
 export default class GroupBarLayer extends BaseBarLayer<GroupBarLayerConfig> {
   public static getDefaultOptions(): any {

--- a/src/plots/group-column/index.ts
+++ b/src/plots/group-column/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import GroupColumnLayer, { GroupColumnLayerConfig } from './layer';
 
-export interface GroupColumnConfig extends GroupColumnLayerConfig, PlotCfg {}
+export interface GroupColumnConfig extends GroupColumnLayerConfig, PlotConfig {}
 
 export default class GroupColumn<T extends GroupColumnConfig = GroupColumnConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof GroupColumnLayer.getDefaultOptions = GroupColumnLayer.getDefaultOptions;

--- a/src/plots/group-column/layer.ts
+++ b/src/plots/group-column/layer.ts
@@ -1,10 +1,13 @@
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { ElementOption } from '../../interface/config';
-import BaseColumnLayer, { ColumnLayerConfig } from '../column/layer';
+import BaseColumnLayer, { ColumnViewConfig } from '../column/layer';
 
-export interface GroupColumnLayerConfig extends ColumnLayerConfig {
+export interface GroupColumnViewConfig extends ColumnViewConfig {
   groupField: string;
 }
+
+export interface GroupColumnLayerConfig extends GroupColumnViewConfig, LayerConfig {}
 
 export default class GroupColumnLayer extends BaseColumnLayer<GroupColumnLayerConfig> {
   public type: string = 'groupColumn';

--- a/src/plots/histogram/index.ts
+++ b/src/plots/histogram/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import HistogramLayer, { HistogramLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import HistogramLayer, { HistogramViewConfig } from './layer';
 
-export interface HistogramConfig extends HistogramLayerConfig, PlotCfg {}
+export interface HistogramConfig extends HistogramViewConfig, PlotConfig {}
 
 export default class Histogram<T extends HistogramConfig = HistogramConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof HistogramLayer.getDefaultOptions = HistogramLayer.getDefaultOptions;

--- a/src/plots/histogram/layer.ts
+++ b/src/plots/histogram/layer.ts
@@ -1,13 +1,16 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { sturges } from '../../util/math';
-import Column, { ColumnLayerConfig } from '../column/layer';
+import Column, { ColumnViewConfig } from '../column/layer';
 
-export interface HistogramLayerConfig extends ColumnLayerConfig {
+export interface HistogramViewConfig extends ColumnViewConfig {
   binField: string;
   binWidth?: number;
   binNumber?: number;
 }
+
+export interface HistogramLayerConfig extends HistogramViewConfig, LayerConfig {}
 
 export default class HistogramLayer extends Column<HistogramLayerConfig> {
   public type: string = 'histogram';

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import LineLayer, { LineLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import LineLayer, { LineViewConfig } from './layer';
 
-export interface LineConfig extends LineLayerConfig, PlotCfg {}
+export interface LineConfig extends LineViewConfig, PlotConfig {}
 
 export default class Line<T extends LineConfig = LineConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof LineLayer.getDefaultOptions = LineLayer.getDefaultOptions;

--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -1,6 +1,7 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import BaseConfig, { ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
@@ -36,7 +37,7 @@ const GEOM_MAP = {
   point: 'point',
 };
 
-export interface LineLayerConfig extends ViewLayerCfg {
+export interface LineViewConfig extends ViewConfig {
   /** 分组字段 */
   seriesField?: string;
   /** 是否平滑 */
@@ -53,6 +54,8 @@ export interface LineLayerConfig extends ViewLayerCfg {
   xAxis?: IValueAxis | ICatAxis | ITimeAxis;
   yAxis?: IValueAxis;
 }
+
+export interface LineLayerConfig extends LineViewConfig, LayerConfig {}
 
 export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
@@ -76,7 +79,7 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
   public point: any;
   public type: string = 'line';
 
-  public getOptions(props: ViewLayerCfg) {
+  public getOptions(props: T) {
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();

--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -4,7 +4,7 @@ import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
-import BaseConfig, { ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
+import { ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
 import { extractScale } from '../../util/scale';
 import './animation/clipIn-with-data';
 import responsiveMethods from './apply-responsive';
@@ -199,7 +199,6 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
 
   protected applyInteractions() {
     super.applyInteractions();
-    const props = this.options;
     // 加入默认交互
     const interactions = this.view.get('interactions');
     const lineActive = new LineActive({ view: this.view });

--- a/src/plots/liquid/index.ts
+++ b/src/plots/liquid/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import LiquidLayer, { LiquidLayerConfig } from './layer';
 
-export interface LiquidConfig extends LiquidLayerConfig, PlotCfg {}
+export interface LiquidConfig extends LiquidLayerConfig, PlotConfig {}
 
 export default class Liquid<T extends LiquidConfig = LiquidConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof LiquidLayer.getDefaultOptions = LiquidLayer.getDefaultOptions;

--- a/src/plots/liquid/layer.ts
+++ b/src/plots/liquid/layer.ts
@@ -1,9 +1,10 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { ElementOption } from '../../interface/config';
 import { extractScale } from '../../util/scale';
 
+import { LayerConfig } from '../../base/layer';
 import './geometry/shape/liquid';
 import './theme';
 
@@ -25,7 +26,7 @@ const PLOT_GEOM_MAP = {
   interval: 'liquid',
 };
 
-export interface LiquidLayerConfig extends ViewLayerCfg {
+export interface LiquidViewConfig extends ViewConfig {
   type?: 'normal' | 'percent';
   min?: number;
   max?: number;
@@ -33,7 +34,11 @@ export interface LiquidLayerConfig extends ViewLayerCfg {
   showValue?: boolean;
   format?: (...args: any[]) => string;
   liquidStyle?: LiquidStyle;
+  styleMix?: any;
+  valueText?: string;
 }
+
+export interface LiquidLayerConfig extends LiquidViewConfig, LayerConfig {}
 
 export default class LiquidLayer extends ViewLayer<LiquidLayerConfig> {
   public type: string = 'liquid';

--- a/src/plots/percentage-stack-area/index.ts
+++ b/src/plots/percentage-stack-area/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import PercentageStackAreaLayer, { PercentageStackAreaLayerConfig } from './layer';
 
-export interface PercentageStackAreaConfig extends PercentageStackAreaLayerConfig, PlotCfg {}
+export interface PercentageStackAreaConfig extends PercentageStackAreaLayerConfig, PlotConfig {}
 
 export default class PercentageStackArea<
   T extends PercentageStackAreaConfig = PercentageStackAreaConfig

--- a/src/plots/percentage-stack-area/layer.ts
+++ b/src/plots/percentage-stack-area/layer.ts
@@ -1,10 +1,12 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import StackArea, { StackAreaLayerConfig } from '../stack-area/layer';
+import { LayerConfig } from '../../base/layer';
+import StackArea, { StackAreaViewConfig } from '../stack-area/layer';
 
-export interface PercentageStackAreaLayerConfig extends StackAreaLayerConfig {}
+export interface PercentageStackAreaViewConfig extends StackAreaViewConfig {}
+export interface PercentageStackAreaLayerConfig extends PercentageStackAreaViewConfig, LayerConfig {}
 
-export default class PercentageStackAreaLayer extends StackArea {
+export default class PercentageStackAreaLayer extends StackArea<PercentageStackAreaLayerConfig> {
   public static getDefaultOptions(): any {
     return _.deepMix({}, super.getDefaultOptions(), {
       yAxis: {
@@ -19,7 +21,6 @@ export default class PercentageStackAreaLayer extends StackArea {
       },
     });
   }
-
   public type: string = 'percentageStackArea';
 
   protected processData(originData?: object[]) {

--- a/src/plots/percentage-stack-bar/index.ts
+++ b/src/plots/percentage-stack-bar/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import PercentageStackBarLayer, { PercentageStackBarLayerConfig } from './layer';
 
-export interface PercentageStackBarConfig extends PercentageStackBarLayerConfig, PlotCfg {}
+export interface PercentageStackBarConfig extends PercentageStackBarLayerConfig, PlotConfig {}
 
 export default class PercentageStackBar<T extends PercentageStackBarConfig = PercentageStackBarConfig> extends BasePlot<
   T

--- a/src/plots/percentage-stack-bar/layer.ts
+++ b/src/plots/percentage-stack-bar/layer.ts
@@ -1,10 +1,12 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import StackBar, { StackBarLayerConfig } from '../stack-bar/layer';
+import { LayerConfig } from '../../base/layer';
+import StackBar, { StackBarViewConfig } from '../stack-bar/layer';
 
-export interface PercentageStackBarLayerConfig extends StackBarLayerConfig {}
+export interface PercentageStackBarViewConfig extends StackBarViewConfig {}
+export interface PercentageStackBarLayerConfig extends PercentageStackBarViewConfig, LayerConfig {}
 
-export default class PercentageStackBarLayer extends StackBar {
+export default class PercentageStackBarLayer extends StackBar<PercentageStackBarLayerConfig> {
   public static getDefaultOptions(): any {
     return _.deepMix({}, super.getDefaultOptions(), {
       xAxis: {
@@ -19,7 +21,6 @@ export default class PercentageStackBarLayer extends StackBar {
       },
     });
   }
-
   public type: string = 'percentageStackBar';
 
   protected processData(originData?: object[]) {

--- a/src/plots/percentage-stack-column/index.ts
+++ b/src/plots/percentage-stack-column/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import PercentageStackColumnLayer, { PercentageStackColumnLayerConfig } from './layer';
 
-export interface PercentageStackColumnConfig extends PercentageStackColumnLayerConfig, PlotCfg {}
+export interface PercentageStackColumnConfig extends PercentageStackColumnLayerConfig, PlotConfig {}
 
 export default class PercentageStackColumn<
   T extends PercentageStackColumnConfig = PercentageStackColumnConfig

--- a/src/plots/percentage-stack-column/layer.ts
+++ b/src/plots/percentage-stack-column/layer.ts
@@ -1,10 +1,12 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import StackColumn, { StackColumnLayerConfig } from '../stack-column/layer';
+import { LayerConfig } from '../../base/layer';
+import StackColumn, { StackColumnViewConfig } from '../stack-column/layer';
 
-export interface PercentageStackColumnLayerConfig extends StackColumnLayerConfig {}
+export interface PercentageStackColumnViewConfig extends StackColumnViewConfig {}
+export interface PercentageStackColumnLayerConfig extends PercentageStackColumnViewConfig, LayerConfig {}
 
-export default class PercentageStackColumnLayer extends StackColumn {
+export default class PercentageStackColumnLayer extends StackColumn<PercentageStackColumnLayerConfig> {
   public static getDefaultOptions(): any {
     return _.deepMix({}, super.getDefaultOptions(), {
       yAxis: {
@@ -19,7 +21,6 @@ export default class PercentageStackColumnLayer extends StackColumn {
       },
     });
   }
-
   public type: string = 'percentageStackColumn';
 
   protected processData(originData?: object[]) {

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import PieLayer, { PieLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import PieLayer, { PieViewConfig } from './layer';
 
-export interface PieConfig extends PieLayerConfig, PlotCfg {}
+export interface PieConfig extends PieViewConfig, PlotConfig {}
 
 export default class Pie<T extends PieConfig = PieConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof PieLayer.getDefaultOptions = PieLayer.getDefaultOptions;

--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -1,7 +1,8 @@
 import { CoordinateType } from '@antv/g2/lib/plot/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import BaseConfig, { Label } from '../../interface/config';
@@ -10,12 +11,14 @@ import SpiderLabel from './component/label/spider-label';
 import * as EventParser from './event';
 import './theme';
 
-export interface PieLayerConfig extends ViewLayerCfg {
+export interface PieViewConfig extends ViewConfig {
   angleField: string;
   colorField?: string;
   radius?: number;
   pieStyle?: {};
 }
+
+export interface PieLayerConfig extends PieViewConfig, LayerConfig {}
 
 const G2_GEOM_MAP = {
   pie: 'interval',
@@ -63,7 +66,7 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
   public spiderLabel: any;
   public type: string = 'pie';
 
-  public getOptions(props: ViewLayerCfg) {
+  public getOptions(props: T) {
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();

--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -5,7 +5,7 @@ import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
-import BaseConfig, { Label } from '../../interface/config';
+import { Label } from '../../interface/config';
 import { extractScale } from '../../util/scale';
 import SpiderLabel from './component/label/spider-label';
 import * as EventParser from './event';
@@ -150,17 +150,6 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
 
   protected parserEvents(eventParser) {
     super.parserEvents(EventParser);
-  }
-
-  private adjustPieStyle() {
-    const props = this.options;
-    if (!props.colorField) {
-      const defaultStyle = { stroke: 'white', lineWidth: 1 };
-      if (!props.pieStyle) {
-        props.pieStyle = {};
-      }
-      props.pieStyle = _.deepMix(props.pieStyle, defaultStyle);
-    }
   }
 
   private label() {

--- a/src/plots/radar/index.ts
+++ b/src/plots/radar/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import RadarLayer, { RadarLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import RadarLayer, { RadarViewConfig } from './layer';
 
-export interface RadarConfig extends RadarLayerConfig, PlotCfg {}
+export interface RadarConfig extends RadarViewConfig, PlotConfig {}
 
 export default class Radar<T extends RadarConfig = RadarConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof RadarLayer.getDefaultOptions = RadarLayer.getDefaultOptions;

--- a/src/plots/radar/layer.ts
+++ b/src/plots/radar/layer.ts
@@ -1,7 +1,8 @@
 import { CoordinateType } from '@antv/g2/lib/plot/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import ViewLayer, { ViewLayerCfg } from '../../base/view-layer';
+import { LayerConfig } from '../../base/layer';
+import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import { extractScale } from '../../util/scale';
@@ -30,7 +31,7 @@ interface Point {
   [k: string]: any;
 }
 
-export interface RadarLayerConfig extends ViewLayerCfg {
+export interface RadarViewConfig extends ViewConfig {
   /** 分组字段 */
   seriesField?: string;
   /** 是否平滑 */
@@ -58,6 +59,8 @@ export interface RadarLayerConfig extends ViewLayerCfg {
   // fixme: any
   [attr: string]: any;
 }
+
+export interface RadarLayerConfig extends RadarViewConfig, LayerConfig {}
 
 const GEOM_MAP = {
   area: 'area',
@@ -180,7 +183,7 @@ export default class RadarLayer extends ViewLayer<RadarLayerConfig> {
     super.init();
   }
 
-  public getOptions(props: ViewLayerCfg) {
+  public getOptions(props: RadarLayerConfig) {
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();
@@ -259,7 +262,7 @@ export default class RadarLayer extends ViewLayer<RadarLayerConfig> {
           };
         }
       }
-  
+
       if (props.radiusAxis.visible === false) {
         axesConfig.fields[props.radiusField] = false;
       } else {

--- a/src/plots/ring/index.ts
+++ b/src/plots/ring/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import RingLayer, { RingLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import RingLayer, { RingViewConfig } from './layer';
 
-export interface RingConfig extends RingLayerConfig, PlotCfg {}
+export interface RingConfig extends RingViewConfig, PlotConfig {}
 
 export default class Ring<T extends RingConfig = RingConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof RingLayer.getDefaultOptions = RingLayer.getDefaultOptions;

--- a/src/plots/ring/layer.ts
+++ b/src/plots/ring/layer.ts
@@ -1,15 +1,19 @@
 import { CoordinateType } from '@antv/g2/lib/plot/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
-import PieLayer, { PieLayerConfig } from '../pie/layer';
+import { LayerConfig } from '../../base/layer';
+import PieLayer, { PieViewConfig } from '../pie/layer';
 import responsiveMethods from './apply-responsive';
 import './apply-responsive/theme';
 import * as centralTextTemplate from './component/annotation/central-text-template';
 import * as EventParser from './event';
 
-export interface RingLayerConfig extends PieLayerConfig {
+export interface RingViewConfig extends PieViewConfig {
   innerRadius?: number;
+  annotation?: any; // FIXME:
 }
+
+export interface RingLayerConfig extends RingViewConfig, LayerConfig {}
 
 interface IAttrs {
   [key: string]: any;

--- a/src/plots/stack-area/index.ts
+++ b/src/plots/stack-area/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import StackAreaLayer, { StackAreaLayerConfig } from './layer';
 
-export interface StackAreaConfig extends StackAreaLayerConfig, PlotCfg {}
+export interface StackAreaConfig extends StackAreaLayerConfig, PlotConfig {}
 
 export default class StackArea<T extends StackAreaConfig = StackAreaConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof StackAreaLayer.getDefaultOptions = StackAreaLayer.getDefaultOptions;

--- a/src/plots/stack-area/layer.ts
+++ b/src/plots/stack-area/layer.ts
@@ -1,16 +1,19 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getComponent } from '../../components/factory';
 import { ElementOption, Label } from '../../interface/config';
-import BaseArea, { AreaLayerConfig } from '../area/layer';
+import BaseArea, { AreaViewConfig } from '../area/layer';
 import './component/label/area-label';
 import './component/label/line-label';
 
-export interface StackAreaLayerConfig extends AreaLayerConfig {
+export interface StackAreaViewConfig extends AreaViewConfig {
   stackField: string;
 }
 
-export default class StackAreaLayer extends BaseArea<StackAreaLayerConfig> {
+export interface StackAreaLayerConfig extends StackAreaViewConfig, LayerConfig {}
+
+export default class StackAreaLayer<T extends StackAreaLayerConfig = StackAreaLayerConfig> extends BaseArea<T> {
   public static getDefaultOptions(): any {
     return _.deepMix({}, super.getDefaultOptions(), {
       label: {

--- a/src/plots/stack-bar/index.ts
+++ b/src/plots/stack-bar/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import StackBarLayer, { StackBarLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import StackBarLayer, { StackBarViewConfig } from './layer';
 
-export interface StackBarConfig extends StackBarLayerConfig, PlotCfg {}
+export interface StackBarConfig extends StackBarViewConfig, PlotConfig {}
 
 export default class StackBar<T extends StackBarConfig = StackBarConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof StackBarLayer.getDefaultOptions = StackBarLayer.getDefaultOptions;

--- a/src/plots/stack-bar/layer.ts
+++ b/src/plots/stack-bar/layer.ts
@@ -1,15 +1,18 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getComponent } from '../../components/factory';
 import { ElementOption, Label } from '../../interface/config';
-import BaseBarLayer, { BarLayerConfig } from '../bar/layer';
+import BaseBarLayer, { BarViewConfig } from '../bar/layer';
 import './component/label/stack-bar-label';
 
-export interface StackBarLayerConfig extends BarLayerConfig {
+export interface StackBarViewConfig extends BarViewConfig {
   stackField: string;
 }
 
-export default class StackBarLayer extends BaseBarLayer<StackBarLayerConfig> {
+export interface StackBarLayerConfig extends StackBarViewConfig, LayerConfig {}
+
+export default class StackBarLayer<T extends StackBarLayerConfig = StackBarLayerConfig> extends BaseBarLayer<T> {
   public static getDefaultOptions() {
     return _.deepMix({}, super.getDefaultOptions(), {
       xAxis: {

--- a/src/plots/stack-column/index.ts
+++ b/src/plots/stack-column/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import StackColumnLayer, { StackColumnLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import StackColumnLayer, { StackColumnViewConfig } from './layer';
 
-export interface StackColumnConfig extends StackColumnLayerConfig, PlotCfg {}
+export interface StackColumnConfig extends StackColumnViewConfig, PlotConfig {}
 
 export default class StackColumn<T extends StackColumnConfig = StackColumnConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof StackColumnLayer.getDefaultOptions = StackColumnLayer.getDefaultOptions;

--- a/src/plots/stack-column/layer.ts
+++ b/src/plots/stack-column/layer.ts
@@ -1,17 +1,22 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import ConnectedArea from '../../components/connected-area';
 import { getComponent } from '../../components/factory';
 import { ElementOption, Label } from '../../interface/config';
-import BaseColumnLayer, { ColumnLayerConfig } from '../column/layer';
+import BaseColumnLayer, { ColumnViewConfig } from '../column/layer';
 import './component/label/stack-column-label';
 
-export interface StackColumnLayerConfig extends ColumnLayerConfig {
+export interface StackColumnViewConfig extends ColumnViewConfig {
   stackField: string;
   connectedArea?: any;
 }
 
-export default class StackColumnLayer extends BaseColumnLayer<StackColumnLayerConfig> {
+export interface StackColumnLayerConfig extends StackColumnViewConfig, LayerConfig {}
+
+export default class StackColumnLayer<
+  T extends StackColumnLayerConfig = StackColumnLayerConfig
+> extends BaseColumnLayer<T> {
   public static getDefaultOptions() {
     return _.deepMix({}, super.getDefaultOptions(), {
       legend: {

--- a/src/tiny-plots/progress/index.ts
+++ b/src/tiny-plots/progress/index.ts
@@ -1,9 +1,9 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyPlot from '../tiny-plot';
-import ProgressLayer, { ProgressLayerConfig } from './layer';
+import ProgressLayer, { ProgressViewConfig } from './layer';
 
-export interface ProgressConfig extends ProgressLayerConfig, PlotCfg {}
+export interface ProgressConfig extends ProgressViewConfig, PlotConfig {}
 
 export default class Progress<T extends ProgressConfig = ProgressConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof ProgressLayer.getDefaultOptions = ProgressLayer.getDefaultOptions;

--- a/src/tiny-plots/progress/layer.ts
+++ b/src/tiny-plots/progress/layer.ts
@@ -1,12 +1,17 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
-import TinyLayer, { TinyLayerConfig } from '../tiny-layer';
+import TinyLayer, { TinyViewConfig } from '../tiny-layer';
 import * as EventParser from './event';
 
-export interface ProgressLayerConfig extends TinyLayerConfig {
+export interface ProgressViewConfig extends TinyViewConfig {
   stackField?: number;
+  progressStyle?: any; // FIXME:
+  percent?: number; // FIXME:
 }
+
+export interface ProgressLayerConfig extends ProgressViewConfig, LayerConfig {}
 
 const G2_GEOM_MAP = {
   progress: 'interval',
@@ -18,7 +23,7 @@ const PLOT_GEOM_MAP = {
 
 const DEFAULT_COLOR = ['#55A6F3', '#E8EDF3'];
 
-export default class ProgressLayer extends TinyLayer<ProgressLayerConfig> {
+export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayerConfig> extends TinyLayer<T> {
   /**
    * 将进度条配置项转为堆叠条形图配置项
    */

--- a/src/tiny-plots/ring-progress/index.ts
+++ b/src/tiny-plots/ring-progress/index.ts
@@ -1,9 +1,9 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyPlot from '../tiny-plot';
-import RingProgressLayer, { RingProgressLayerConfig } from './layer';
+import RingProgressLayer, { RingProgressViewConfig } from './layer';
 
-export interface RingProgressConfig extends RingProgressLayerConfig, PlotCfg {}
+export interface RingProgressConfig extends RingProgressViewConfig, PlotConfig {}
 
 export default class RingProgress<T extends RingProgressConfig = RingProgressConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof RingProgressLayer.getDefaultOptions = RingProgressLayer.getDefaultOptions;

--- a/src/tiny-plots/ring-progress/layer.ts
+++ b/src/tiny-plots/ring-progress/layer.ts
@@ -1,16 +1,18 @@
 import { CoordinateType } from '@antv/g2/lib/plot/interface';
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
-import ProgressLayer, { ProgressLayerConfig } from '../progress/layer';
+import ProgressLayer, { ProgressViewConfig } from '../progress/layer';
 import { getAngle, setShapeInfo } from './animation/index';
 import * as EventParser from './event';
 
 const DEFAULT_COLOR = ['#55A6F3', '#E8EDF3'];
 
-export interface RingProgressLayerConfig extends ProgressLayerConfig {}
+export interface RingProgressViewConfig extends ProgressViewConfig {}
+export interface RingProgressLayerConfig extends RingProgressViewConfig, LayerConfig {}
 
-export default class RingProgressLayer extends ProgressLayer {
+export default class RingProgressLayer extends ProgressLayer<RingProgressLayerConfig> {
   public ring: any;
   public type: string = 'ringProgrsss';
 

--- a/src/tiny-plots/tiny-area/index.ts
+++ b/src/tiny-plots/tiny-area/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import TinyAreaLayer, { TinyAreaLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import TinyAreaLayer, { TinyAreaViewConfig } from './layer';
 
-export interface TinyAreaConfig extends TinyAreaLayerConfig, PlotCfg {}
+export interface TinyAreaConfig extends TinyAreaViewConfig, PlotConfig {}
 
 export default class TinyArea<T extends TinyAreaConfig = TinyAreaConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof TinyAreaLayer.getDefaultOptions = TinyAreaLayer.getDefaultOptions;

--- a/src/tiny-plots/tiny-area/layer.ts
+++ b/src/tiny-plots/tiny-area/layer.ts
@@ -1,7 +1,8 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
-import TinyLayer, { TinyLayerConfig } from '../tiny-layer';
+import TinyLayer, { TinyViewConfig } from '../tiny-layer';
 import * as EventParser from './event';
 
 const GEOM_MAP = {
@@ -9,9 +10,10 @@ const GEOM_MAP = {
   line: 'line',
 };
 
-export interface TinyAreaLayerConfig extends TinyLayerConfig {}
+export interface TinyAreaViewConfig extends TinyViewConfig {}
+export interface TinyAreaLayerConfig extends TinyAreaViewConfig, LayerConfig {}
 
-export default class TinyAreaLayer extends TinyLayer {
+export default class TinyAreaLayer extends TinyLayer<TinyAreaLayerConfig> {
   public line: any;
   public area: any;
   public type: string = 'tinyArea';

--- a/src/tiny-plots/tiny-column/index.ts
+++ b/src/tiny-plots/tiny-column/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
+import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyColumnLayer, { TinyColumnLayerConfig } from './layer';
 
-export interface TinyColumnConfig extends TinyColumnLayerConfig, PlotCfg {}
+export interface TinyColumnConfig extends TinyColumnLayerConfig, PlotConfig {}
 
 export default class TinyColumn<T extends TinyColumnConfig = TinyColumnConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof TinyColumnLayer.getDefaultOptions = TinyColumnLayer.getDefaultOptions;

--- a/src/tiny-plots/tiny-column/layer.ts
+++ b/src/tiny-plots/tiny-column/layer.ts
@@ -1,7 +1,8 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
-import TinyLayer, { TinyLayerConfig } from '../tiny-layer';
+import TinyLayer, { TinyLayerConfig, TinyViewConfig } from '../tiny-layer';
 import * as EventParser from './event';
 
 const WIDTH_RATIO = 0.6;
@@ -14,9 +15,10 @@ const PLOT_GEOM_MAP = {
   interval: 'column',
 };
 
-export interface TinyColumnLayerConfig extends TinyLayerConfig {}
+export interface TinyColumnViewConfig extends TinyViewConfig {}
+export interface TinyColumnLayerConfig extends TinyColumnViewConfig, LayerConfig {}
 
-export default class TinyColumnLayer extends TinyLayer {
+export default class TinyColumnLayer extends TinyLayer<TinyColumnLayerConfig> {
   public line: any;
   public area: any;
   public type: string = 'tinyColumn';

--- a/src/tiny-plots/tiny-layer.ts
+++ b/src/tiny-plots/tiny-layer.ts
@@ -1,12 +1,15 @@
 import * as _ from '@antv/util';
-import ViewLayer, { ViewLayerCfg } from '../base/view-layer';
+import { LayerConfig } from '../base/layer';
+import ViewLayer, { ViewConfig } from '../base/view-layer';
 import { getComponent } from '../components/factory';
 import '../geoms/line/mini';
-import BaseConfig from '../interface/config';
 
-export interface TinyLayerConfig extends ViewLayerCfg {
+export interface TinyViewConfig extends ViewConfig {
   indicator?: any;
+  guideLine?: any; // FIXME:
 }
+
+export interface TinyLayerConfig extends TinyViewConfig, LayerConfig {}
 
 export default abstract class TinyLayer<T extends TinyLayerConfig = TinyLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {

--- a/src/tiny-plots/tiny-line/index.ts
+++ b/src/tiny-plots/tiny-line/index.ts
@@ -1,8 +1,8 @@
 import * as _ from '@antv/util';
-import BasePlot, { PlotCfg } from '../../base/plot';
-import TinyLineLayer, { TinyLineLayerConfig } from './layer';
+import BasePlot, { PlotConfig } from '../../base/plot';
+import TinyLineLayer, { TinyLineViewConfig } from './layer';
 
-export interface TinyLineConfig extends TinyLineLayerConfig, PlotCfg {}
+export interface TinyLineConfig extends TinyLineViewConfig, PlotConfig {}
 
 export default class TinyLine<T extends TinyLineConfig = TinyLineConfig> extends BasePlot<T> {
   public static getDefaultOptions: typeof TinyLineLayer.getDefaultOptions = TinyLineLayer.getDefaultOptions;

--- a/src/tiny-plots/tiny-line/layer.ts
+++ b/src/tiny-plots/tiny-line/layer.ts
@@ -1,16 +1,18 @@
 import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
+import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
-import TinyLayer, { TinyLayerConfig } from '../tiny-layer';
+import TinyLayer, { TinyViewConfig } from '../tiny-layer';
 import * as EventParser from './event';
 
 const GEOM_MAP = {
   line: 'line',
 };
 
-export interface TinyLineLayerConfig extends TinyLayerConfig {}
+export interface TinyLineViewConfig extends TinyViewConfig {}
+export interface TinyLineLayerConfig extends TinyLineViewConfig, LayerConfig {}
 
-export default class TinyLineLayer extends TinyLayer {
+export default class TinyLineLayer extends TinyLayer<TinyLineLayerConfig> {
   public line: any;
   public type: string = 'tinyLine';
 

--- a/src/tiny-plots/tiny-plot.ts
+++ b/src/tiny-plots/tiny-plot.ts
@@ -1,7 +1,7 @@
-import BasePlot, { PlotCfg } from '../base/plot';
-import { TinyLayerConfig } from './tiny-layer';
+import BasePlot, { PlotConfig } from '../base/plot';
+import { TinyViewConfig } from './tiny-layer';
 
-export interface TinyPlotConfig extends TinyLayerConfig, PlotCfg {}
+export interface TinyPlotConfig extends TinyViewConfig, PlotConfig {}
 
 export default abstract class TinyPlot<T extends TinyPlotConfig = TinyPlotConfig> extends BasePlot<T> {
   //


### PR DESCRIPTION
#184 
- [X] TS定义修复：LayerConfig为内部使用不暴露出来，具体每个图形会有对应的`XXViewConfig`，和`XXLayerConfig`
- [X] `BasePlot`和`Layer`继承关系断开
- [ ] 各个图形的`getDefaultOptions`按文档补充：`getDefaultOptions`类型定义可以参照`bar/layer.ts`