### PR TITLE
add percentage data formatter for percentage-stack plots

### DIFF
--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -197,6 +197,7 @@ export interface Tooltip {
   shared: boolean;
   /** html */
   html?: HTMLDivElement;
+  formatter?: (...args: any) => string;
   htmlContent?: (title: string, items: any[]) => string;
   containerTpl?: string;
   itemTpl?: string;

--- a/src/plots/percentage-stack-area/layer.ts
+++ b/src/plots/percentage-stack-area/layer.ts
@@ -5,6 +5,21 @@ import StackArea, { StackAreaLayerConfig } from '../stack-area/layer';
 export interface PercentageStackAreaLayerConfig extends StackAreaLayerConfig {}
 
 export default class PercentageStackAreaLayer extends StackArea {
+  public static getDefaultOptions(): any {
+    return _.deepMix({}, super.getDefaultOptions(), {
+      yAxis: {
+        visible: true,
+        label: {
+          visible: true,
+          formatter: (v) => {
+            const reg = /%/gi;
+            return v.replace(reg, '');
+          },
+        },
+      },
+    });
+  }
+
   public type: string = 'percentageStackArea';
 
   protected processData(originData?: object[]) {
@@ -32,6 +47,18 @@ export default class PercentageStackAreaLayer extends StackArea {
     });
 
     return plotData;
+  }
+
+  protected scale() {
+    const metaConfig = {};
+    metaConfig[this.options.yField] = {
+      formatter: (v) => {
+        const formattedValue = (v * 100).toFixed(1);
+        return `${formattedValue}%`;
+      },
+    };
+    this.options.meta = metaConfig;
+    super.scale();
   }
 }
 

--- a/src/plots/percentage-stack-bar/layer.ts
+++ b/src/plots/percentage-stack-bar/layer.ts
@@ -5,6 +5,21 @@ import StackBar, { StackBarLayerConfig } from '../stack-bar/layer';
 export interface PercentageStackBarLayerConfig extends StackBarLayerConfig {}
 
 export default class PercentageStackBarLayer extends StackBar {
+  public static getDefaultOptions(): any {
+    return _.deepMix({}, super.getDefaultOptions(), {
+      xAxis: {
+        visible: true,
+        label: {
+          visible: true,
+          formatter: (v) => {
+            const reg = /%/gi;
+            return v.replace(reg, '');
+          },
+        },
+      },
+    });
+  }
+
   public type: string = 'percentageStackBar';
 
   protected processData(originData?: object[]) {
@@ -32,6 +47,18 @@ export default class PercentageStackBarLayer extends StackBar {
     });
 
     return plotData;
+  }
+
+  protected scale() {
+    const metaConfig = {};
+    metaConfig[this.options.xField] = {
+      formatter: (v) => {
+        const formattedValue = (v * 100).toFixed(1);
+        return `${formattedValue}%`;
+      },
+    };
+    this.options.meta = metaConfig;
+    super.scale();
   }
 }
 

--- a/src/plots/percentage-stack-column/layer.ts
+++ b/src/plots/percentage-stack-column/layer.ts
@@ -5,6 +5,21 @@ import StackColumn, { StackColumnLayerConfig } from '../stack-column/layer';
 export interface PercentageStackColumnLayerConfig extends StackColumnLayerConfig {}
 
 export default class PercentageStackColumnLayer extends StackColumn {
+  public static getDefaultOptions(): any {
+    return _.deepMix({}, super.getDefaultOptions(), {
+      yAxis: {
+        visible: true,
+        label: {
+          visible: true,
+          formatter: (v) => {
+            const reg = /%/gi;
+            return v.replace(reg, '');
+          },
+        },
+      },
+    });
+  }
+
   public type: string = 'percentageStackColumn';
 
   protected processData(originData?: object[]) {
@@ -32,6 +47,18 @@ export default class PercentageStackColumnLayer extends StackColumn {
     });
 
     return plotData;
+  }
+
+  protected scale() {
+    const metaConfig = {};
+    metaConfig[this.options.yField] = {
+      formatter: (v) => {
+        const formattedValue = (v * 100).toFixed(1);
+        return `${formattedValue}%`;
+      },
+    };
+    this.options.meta = metaConfig;
+    super.scale();
   }
 }
 


### PR DESCRIPTION
* 为百分比堆叠柱、条、面积图加入formatter

- [x]  label

- [x]  axis

- [x]  连续轴标签

<img width="711" alt="屏幕快照 2019-11-08 下午2 59 18" src="https://user-images.githubusercontent.com/5888974/68456287-6094a580-0238-11ea-8d04-d480218c2382.png">

* 柱状图条形图系列加入默认配置


