### PR TITLE
fix: 修改plot为非泛型

### DIFF
--- a/src/plots/area/index.ts
+++ b/src/plots/area/index.ts
@@ -4,7 +4,7 @@ import AreaLayer, { AreaViewConfig } from './layer';
 
 export interface AreaConfig extends AreaViewConfig, PlotConfig {}
 
-export default class Area<T extends AreaConfig = AreaConfig> extends BasePlot<T> {
+export default class Area extends BasePlot<AreaConfig> {
   public static getDefaultOptions: typeof AreaLayer.getDefaultOptions = AreaLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/bar/index.ts
+++ b/src/plots/bar/index.ts
@@ -4,7 +4,7 @@ import BarLayer, { BarViewConfig } from './layer';
 
 export interface BarConfig extends BarViewConfig, PlotConfig {}
 
-export default class Bar<T extends BarConfig = BarConfig> extends BasePlot<T> {
+export default class Bar extends BasePlot<BarConfig> {
   public static getDefaultOptions: typeof BarLayer.getDefaultOptions = BarLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/bubble/index.ts
+++ b/src/plots/bubble/index.ts
@@ -4,7 +4,7 @@ import BubbleLayer, { BubbleViewConfig } from './layer';
 
 export interface BubbleConfig extends BubbleViewConfig, PlotConfig {}
 
-export default class Bubble<T extends BubbleConfig = BubbleConfig> extends BasePlot<T> {
+export default class Bubble extends BasePlot<BubbleConfig> {
   public static getDefaultOptions: typeof BubbleLayer.getDefaultOptions = BubbleLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/column/index.ts
+++ b/src/plots/column/index.ts
@@ -4,10 +4,10 @@ import ColumnLayer, { ColumnViewConfig } from './layer';
 
 export interface ColumnConfig extends ColumnViewConfig, PlotConfig {}
 
-export default class Column<T extends ColumnConfig = ColumnConfig> extends BasePlot<T> {
+export default class Column extends BasePlot<ColumnConfig> {
   public static getDefaultOptions: typeof ColumnLayer.getDefaultOptions = ColumnLayer.getDefaultOptions;
 
-  public createLayers(props: T) {
+  public createLayers(props: ColumnConfig) {
     const layerProps = _.deepMix({}, props);
     layerProps.type = 'column';
     super.createLayers(layerProps);

--- a/src/plots/column/layer.ts
+++ b/src/plots/column/layer.ts
@@ -29,6 +29,7 @@ const PLOT_GEOM_MAP = {
 export interface ColumnViewConfig extends ViewConfig {
   // 图形
   type?: 'rect' | 'triangle' | 'round';
+  colorField?: string;
   // 百分比, 数值, 最小最大宽度
   columnSize?: number;
   maxWidth?: number;

--- a/src/plots/density/index.ts
+++ b/src/plots/density/index.ts
@@ -4,7 +4,7 @@ import DensityLayer, { DensityViewConfig } from './layer';
 
 export interface DensityConfig extends DensityViewConfig, PlotConfig {}
 
-export default class Density<T extends DensityConfig = DensityConfig> extends BasePlot<T> {
+export default class Density extends BasePlot<DensityConfig> {
   public static getDefaultOptions: typeof DensityLayer.getDefaultOptions = DensityLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/gauge/index.ts
+++ b/src/plots/gauge/index.ts
@@ -4,7 +4,7 @@ import GaugeLayer, { GaugeLayerConfig } from './layer';
 
 export interface GaugeConfig extends GaugeLayerConfig, PlotConfig {}
 
-export default class Gauge<T extends GaugeConfig = GaugeConfig> extends BasePlot<T> {
+export default class Gauge extends BasePlot<GaugeConfig> {
   public static getDefaultOptions: typeof GaugeLayer.getDefaultOptions = GaugeLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/group-bar/index.ts
+++ b/src/plots/group-bar/index.ts
@@ -4,7 +4,7 @@ import GroupBarLayer, { GroupBarViewConfig } from './layer';
 
 export interface GroupBarConfig extends GroupBarViewConfig, PlotConfig {}
 
-export default class GroupBar<T extends GroupBarConfig = GroupBarConfig> extends BasePlot<T> {
+export default class GroupBar extends BasePlot<GroupBarConfig> {
   public static getDefaultOptions: typeof GroupBarLayer.getDefaultOptions = GroupBarLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/group-column/index.ts
+++ b/src/plots/group-column/index.ts
@@ -1,10 +1,10 @@
 import * as _ from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
-import GroupColumnLayer, { GroupColumnLayerConfig } from './layer';
+import GroupColumnLayer, { GroupColumnViewConfig } from './layer';
 
-export interface GroupColumnConfig extends GroupColumnLayerConfig, PlotConfig {}
+export interface GroupColumnConfig extends GroupColumnViewConfig, PlotConfig {}
 
-export default class GroupColumn<T extends GroupColumnConfig = GroupColumnConfig> extends BasePlot<T> {
+export default class GroupColumn extends BasePlot<GroupColumnConfig> {
   public static getDefaultOptions: typeof GroupColumnLayer.getDefaultOptions = GroupColumnLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/histogram/index.ts
+++ b/src/plots/histogram/index.ts
@@ -4,7 +4,7 @@ import HistogramLayer, { HistogramViewConfig } from './layer';
 
 export interface HistogramConfig extends HistogramViewConfig, PlotConfig {}
 
-export default class Histogram<T extends HistogramConfig = HistogramConfig> extends BasePlot<T> {
+export default class Histogram extends BasePlot<HistogramConfig> {
   public static getDefaultOptions: typeof HistogramLayer.getDefaultOptions = HistogramLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -4,7 +4,7 @@ import LineLayer, { LineViewConfig } from './layer';
 
 export interface LineConfig extends LineViewConfig, PlotConfig {}
 
-export default class Line<T extends LineConfig = LineConfig> extends BasePlot<T> {
+export default class Line extends BasePlot<LineConfig> {
   public static getDefaultOptions: typeof LineLayer.getDefaultOptions = LineLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/liquid/index.ts
+++ b/src/plots/liquid/index.ts
@@ -4,7 +4,7 @@ import LiquidLayer, { LiquidLayerConfig } from './layer';
 
 export interface LiquidConfig extends LiquidLayerConfig, PlotConfig {}
 
-export default class Liquid<T extends LiquidConfig = LiquidConfig> extends BasePlot<T> {
+export default class Liquid extends BasePlot<LiquidConfig> {
   public static getDefaultOptions: typeof LiquidLayer.getDefaultOptions = LiquidLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -4,7 +4,7 @@ import PieLayer, { PieViewConfig } from './layer';
 
 export interface PieConfig extends PieViewConfig, PlotConfig {}
 
-export default class Pie<T extends PieConfig = PieConfig> extends BasePlot<T> {
+export default class Pie extends BasePlot<PieConfig> {
   public static getDefaultOptions: typeof PieLayer.getDefaultOptions = PieLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/radar/index.ts
+++ b/src/plots/radar/index.ts
@@ -4,7 +4,7 @@ import RadarLayer, { RadarViewConfig } from './layer';
 
 export interface RadarConfig extends RadarViewConfig, PlotConfig {}
 
-export default class Radar<T extends RadarConfig = RadarConfig> extends BasePlot<T> {
+export default class Radar extends BasePlot<RadarConfig> {
   public static getDefaultOptions: typeof RadarLayer.getDefaultOptions = RadarLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/ring/index.ts
+++ b/src/plots/ring/index.ts
@@ -4,7 +4,7 @@ import RingLayer, { RingViewConfig } from './layer';
 
 export interface RingConfig extends RingViewConfig, PlotConfig {}
 
-export default class Ring<T extends RingConfig = RingConfig> extends BasePlot<T> {
+export default class Ring extends BasePlot<RingConfig> {
   public static getDefaultOptions: typeof RingLayer.getDefaultOptions = RingLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/stack-area/index.ts
+++ b/src/plots/stack-area/index.ts
@@ -4,7 +4,7 @@ import StackAreaLayer, { StackAreaLayerConfig } from './layer';
 
 export interface StackAreaConfig extends StackAreaLayerConfig, PlotConfig {}
 
-export default class StackArea<T extends StackAreaConfig = StackAreaConfig> extends BasePlot<T> {
+export default class StackArea extends BasePlot<StackAreaConfig> {
   public static getDefaultOptions: typeof StackAreaLayer.getDefaultOptions = StackAreaLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/stack-bar/index.ts
+++ b/src/plots/stack-bar/index.ts
@@ -4,7 +4,7 @@ import StackBarLayer, { StackBarViewConfig } from './layer';
 
 export interface StackBarConfig extends StackBarViewConfig, PlotConfig {}
 
-export default class StackBar<T extends StackBarConfig = StackBarConfig> extends BasePlot<T> {
+export default class StackBar extends BasePlot<StackBarConfig> {
   public static getDefaultOptions: typeof StackBarLayer.getDefaultOptions = StackBarLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/plots/stack-column/index.ts
+++ b/src/plots/stack-column/index.ts
@@ -4,7 +4,7 @@ import StackColumnLayer, { StackColumnViewConfig } from './layer';
 
 export interface StackColumnConfig extends StackColumnViewConfig, PlotConfig {}
 
-export default class StackColumn<T extends StackColumnConfig = StackColumnConfig> extends BasePlot<T> {
+export default class StackColumn extends BasePlot<StackColumnConfig> {
   public static getDefaultOptions: typeof StackColumnLayer.getDefaultOptions = StackColumnLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -170,11 +170,11 @@ export const DEFAULT_GLOBAL_THEME = {
     // 距离panelRange的距离
     innerPadding: [16, 16, 16, 16],
   },
-  label:{
+  label: {
     offset: 12,
-    style:{
-      stroke:'#ffffff',
-      lineWidth:2
-    }
-  }
+    style: {
+      stroke: '#ffffff',
+      lineWidth: 2,
+    },
+  },
 };

--- a/src/tiny-plots/progress/index.ts
+++ b/src/tiny-plots/progress/index.ts
@@ -5,7 +5,7 @@ import ProgressLayer, { ProgressViewConfig } from './layer';
 
 export interface ProgressConfig extends ProgressViewConfig, PlotConfig {}
 
-export default class Progress<T extends ProgressConfig = ProgressConfig> extends BasePlot<T> {
+export default class Progress extends BasePlot<ProgressConfig> {
   public static getDefaultOptions: typeof ProgressLayer.getDefaultOptions = ProgressLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/tiny-plots/ring-progress/index.ts
+++ b/src/tiny-plots/ring-progress/index.ts
@@ -5,7 +5,7 @@ import RingProgressLayer, { RingProgressViewConfig } from './layer';
 
 export interface RingProgressConfig extends RingProgressViewConfig, PlotConfig {}
 
-export default class RingProgress<T extends RingProgressConfig = RingProgressConfig> extends BasePlot<T> {
+export default class RingProgress extends BasePlot<RingProgressConfig> {
   public static getDefaultOptions: typeof RingProgressLayer.getDefaultOptions = RingProgressLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/tiny-plots/tiny-area/index.ts
+++ b/src/tiny-plots/tiny-area/index.ts
@@ -4,7 +4,7 @@ import TinyAreaLayer, { TinyAreaViewConfig } from './layer';
 
 export interface TinyAreaConfig extends TinyAreaViewConfig, PlotConfig {}
 
-export default class TinyArea<T extends TinyAreaConfig = TinyAreaConfig> extends BasePlot<T> {
+export default class TinyArea extends BasePlot<TinyAreaConfig> {
   public static getDefaultOptions: typeof TinyAreaLayer.getDefaultOptions = TinyAreaLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/tiny-plots/tiny-column/index.ts
+++ b/src/tiny-plots/tiny-column/index.ts
@@ -4,7 +4,7 @@ import TinyColumnLayer, { TinyColumnLayerConfig } from './layer';
 
 export interface TinyColumnConfig extends TinyColumnLayerConfig, PlotConfig {}
 
-export default class TinyColumn<T extends TinyColumnConfig = TinyColumnConfig> extends BasePlot<T> {
+export default class TinyColumn extends BasePlot<TinyColumnConfig> {
   public static getDefaultOptions: typeof TinyColumnLayer.getDefaultOptions = TinyColumnLayer.getDefaultOptions;
 
   public createLayers(props) {

--- a/src/tiny-plots/tiny-line/index.ts
+++ b/src/tiny-plots/tiny-line/index.ts
@@ -4,7 +4,7 @@ import TinyLineLayer, { TinyLineViewConfig } from './layer';
 
 export interface TinyLineConfig extends TinyLineViewConfig, PlotConfig {}
 
-export default class TinyLine<T extends TinyLineConfig = TinyLineConfig> extends BasePlot<T> {
+export default class TinyLine extends BasePlot<TinyLineConfig> {
   public static getDefaultOptions: typeof TinyLineLayer.getDefaultOptions = TinyLineLayer.getDefaultOptions;
 
   public createLayers(props) {


### PR DESCRIPTION
Plot不需要为泛型

要不然用户使用的时候还需要

```
new G2Plot.Line<LineConfig>(...)
```
要不然updataConfig时 不能确定类型报错