### PR TITLE
fix: support line label formatter config

### DIFF
--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -178,9 +178,10 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
     }
 
     this.line.label = getComponent('label', {
-      fields: label.type === 'line' ? [props.seriesField] : [props.yField],
-      labelType: label.type,
       plot: this,
+      labelType: label.type,
+      fields: label.type === 'line' ? [props.seriesField] : [props.yField],
+      ...label,
     });
   }
 


### PR DESCRIPTION
修复折线图上label相关的配置无效问题，如formatter