### PR TITLE
chore: use ACCESS_TOKEN for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run site:build
       - uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: public
           CLEAN: true

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "site:build": "npm run site:clean && gatsby build --prefix-paths",
     "site:clean": "gatsby clean",
     "site:deploy": "npm run site:build && gh-pages -d public",
-    "publish": "npm publish",
     "build": "run-s clean lib dist",
     "clean": "rimraf lib esm dist",
     "lib": "run-p lib:*",


### PR DESCRIPTION
* 目前使用GITHUB_TOKEN来push gh-pages不能触发github pages rebuid, 需要使用ACCESS_TOKEN
* 移除 package.json 中的publish script，避免npm publish时执行两次