### PR TITLE
docs(readme): optimize readme style, and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # G2Plot
 
-A charting library based on the Grammar of Graphics.
+> A charting library based on the Grammar of Graphics.
 
 English | [简体中文](./README.zh-CN.md)
 
-[![版本](https://badgen.net/npm/v/@antv/g2plot)](https://www.npmjs.com/@antv/g2plot)
+[![Version](https://badgen.net/npm/v/@antv/g2plot)](https://www.npmjs.com/@antv/g2plot)
 [![NPM downloads](http://img.shields.io/npm/dm/@antv/g2plot.svg)](http://npmjs.com/@antv/g2plot)
-![最近提交](https://badgen.net/github/last-commit/antvis/g2plot)
+![Latest commit](https://badgen.net/github/last-commit/antvis/g2plot)
 
-g2plot is an interactive and responsive charting library based on [the grammar of graphics](https://github.com/antvis/g2), which enables users to generate high quality statistical charts through a few lines of code easily.
+`G2Plot` is an interactive and responsive charting library based on [the grammar of graphics](https://github.com/antvis/g2), which enables users to generate high quality statistical charts through a few lines of code easily.
 
-Moreover, combining with AntV design principles, g2plot provides standard and elegant visual styles as well as better user experience.
+Moreover, combining with AntV design principles, G2Plot provides standard and elegant visual styles as well as better user experience.
 
 <img src="https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*MjhQQLsbWeQAAAAAAAAAAABkARQnAQ" width="200"><img src="https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*CkSoSpPfWQMAAAAAAAAAAABkARQnAQ" width="200"><img src="https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*ZYmtSqcNDtkAAAAAAAAAAABkARQnAQ" width="200"><img src="https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*gV_JQZVbDWAAAAAAAAAAAABkARQnAQ" width="200">
-<br/>
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,10 +1,18 @@
 # G2Plot
 
+> 基于图形语法（Grammar of Graphics）的图表库。
+
+[English](./README.md) | 简体中文
+
 [![版本](https://badgen.net/npm/v/@antv/g2plot)](https://www.npmjs.com/@antv/g2plot)
 [![NPM downloads](http://img.shields.io/npm/dm/@antv/g2plot.svg)](http://npmjs.com/@antv/g2plot)
 ![最近提交](https://badgen.net/github/last-commit/antvis/g2plot)
 
-一套简单、易用、并具备一定扩展能力和组合能力的统计图表库，基于图形语法理论搭建而成，『G2Plot』中的 G2 即意指图形语法 (the Grammar of Graphics)，同时也致敬了 [ggplot2](https://ggplot2.tidyverse.org/)。我们想做的事有三件：（1）使用户不用成为可视化专家也能够轻松制作出优雅美观的图表 （2）保证图表能够经受得起业务的检验，在真实的场景中易用、好用 （3）探索统计图表的更多可能性，使统计图表变得更好玩、更酷。
+一套简单、易用、并具备一定扩展能力和组合能力的统计图表库，基于图形语法理论搭建而成，『G2Plot』中的 G2 即意指图形语法 (the Grammar of Graphics)，同时也致敬了 [ggplot2](https://ggplot2.tidyverse.org/)。我们想做的事有三件：
+
+1. 使用户不用成为可视化专家也能够轻松制作出优雅美观的图表
+2. 保证图表能够经受得起业务的检验，在真实的场景中易用、好用
+3. 探索统计图表的更多可能性，使统计图表变得更好玩、更酷
 
 <img src="https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*pivcSq450scAAAAAAAAAAABkARQnAQ" width="1000">
 
@@ -77,3 +85,7 @@ $ npm run dev
 # run demos
 $ npm run demos
 ```
+
+## License
+
+MIT


### PR DESCRIPTION
preview: https://github.com/antvis/G2Plot/blob/86db2cf1f832e078b289b7a101e843ef4a3b3b19/README.md 

- [x] g2plot -> G2Plot
 - [x] license for zh_CN readme
 - [x] readme style (two blanks before h2)
 - [x] nav link for zh_CN readme