### PR TITLE
fix: 修复Pie Ring的labelLine 以及area的透明度

### DIFF
--- a/src/plots/area/layer.ts
+++ b/src/plots/area/layer.ts
@@ -54,6 +54,7 @@ export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> exte
       smooth: false,
       areaStyle: {
         opacity: 0.25,
+        fillOpacity: 1,
       },
       line: {
         visible: true,

--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -176,6 +176,11 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
     if (labelConfig.type === 'inner') {
       const offsetBase = this.getDefaultLabelInnerOffset();
       labelConfig.offset = labelConfig.offset ? labelConfig.offset : offsetBase;
+      // @ts-ignore
+      labelConfig.labelLine = false;
+    } else {
+      // @ts-ignore
+      labelConfig.labelLine = true;
     }
 
     // 此处做个 hack 操作, 防止g2 controller层找不到未注册的inner,outter,和spider Label

--- a/src/plots/radar/layer.ts
+++ b/src/plots/radar/layer.ts
@@ -87,7 +87,8 @@ export default class RadarLayer extends ViewLayer<RadarLayerConfig> {
       area: {
         visible: true,
         style: {
-          fillOpacity: 0.4,
+          opacity: 0.25,
+          fillOpacity: 1,
         },
       },
       point: {


### PR DESCRIPTION
修复饼图 环图 在label.type=inner he renderer='svg'时多余线的渲染
修复带area类图表的透明度不符合视觉要求的bug