### PR TITLE
fix: 修复百分比堆积图形在某些数据下出现120%的问题

### DIFF
--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -4,7 +4,17 @@ import * as _ from '@antv/util';
 import TextDescription from '../components/description';
 import { getComponent } from '../components/factory';
 import BaseInteraction, { InteractionCtor } from '../interaction/index';
-import { Axis, IDescription, IInteractions, ITitle, Label, Legend, StateConfig, Tooltip } from '../interface/config';
+import {
+  Axis,
+  IDescription,
+  IInteractions,
+  ITitle,
+  Label,
+  Legend,
+  StateConfig,
+  Tooltip,
+  DataItem,
+} from '../interface/config';
 import { G2Config } from '../interface/config';
 import { EVENT_MAP, onEvent } from '../util/event';
 import PaddingController from './controller/padding';
@@ -14,7 +24,7 @@ import Layer, { LayerConfig, Region } from './layer';
 import { isTextUsable } from '../util/common';
 
 export interface ViewConfig {
-  data: object[];
+  data: DataItem[];
   meta?: { [fieldId: string]: any & { type?: any } };
   padding?: number | number[] | string;
   xField?: string;
@@ -268,7 +278,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
     this.processOptions(this.options);
   }
 
-  public changeData(data: object[]): void {
+  public changeData(data: DataItem[]): void {
     this.view.changeData(this.processData(data));
   }
 
@@ -318,7 +328,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
     return this.processData((this.options.data || []).slice(start, end));
   }
 
-  protected processData(data?: object[]): object[] | undefined {
+  protected processData(data?: DataItem[]): DataItem[] | undefined {
     return data;
   }
 

--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -277,3 +277,7 @@ export interface Point {
   readonly x: number;
   readonly y: number;
 }
+
+export interface DataItem {
+  [field: string]: string | number | null | undefined;
+}

--- a/src/plots/bar/layer.ts
+++ b/src/plots/bar/layer.ts
@@ -5,7 +5,7 @@ import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
-import { ElementOption, ICatAxis, ITimeAxis, IValueAxis, Label } from '../../interface/config';
+import { ElementOption, ICatAxis, ITimeAxis, IValueAxis, Label, DataItem } from '../../interface/config';
 import { extractScale } from '../../util/scale';
 import responsiveMethods from './apply-responsive';
 import './component/label/bar-label';
@@ -130,7 +130,7 @@ export default class BaseBarLayer<T extends BarLayerConfig = BarLayerConfig> ext
     return PLOT_GEOM_MAP[type];
   }
 
-  protected processData(data?: object[]): object[] {
+  protected processData(data?: DataItem[]): DataItem[] {
     return data ? data.slice().reverse() : data;
   }
 

--- a/src/plots/density/layer.ts
+++ b/src/plots/density/layer.ts
@@ -5,6 +5,7 @@ import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { sturges } from '../../util/math';
 import Area, { AreaViewConfig } from '../area/layer';
+import { DataItem } from '../../interface/config';
 
 export interface DensityViewConfig extends AreaViewConfig {
   binField: string;
@@ -54,7 +55,7 @@ export default class DensityLayer<T extends DensityLayerConfig = DensityLayerCon
     super.init();
   }
 
-  protected processData(originData?: object[]) {
+  protected processData(originData?: DataItem[]) {
     const { binField, binWidth, binNumber, kernel } = this.options;
     const _kernel = kernel ? kernel : 'epanechnikov';
     const kernelFunc = kernels[_kernel];

--- a/src/plots/histogram/layer.ts
+++ b/src/plots/histogram/layer.ts
@@ -3,6 +3,7 @@ import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { sturges } from '../../util/math';
 import Column, { ColumnViewConfig } from '../column/layer';
+import { DataItem } from '../../interface/config';
 
 export interface HistogramViewConfig extends ColumnViewConfig {
   binField: string;
@@ -21,7 +22,7 @@ export default class HistogramLayer extends Column<HistogramLayerConfig> {
     super.init();
   }
 
-  protected processData(originData?: object[]) {
+  protected processData(originData?: DataItem[]) {
     const { binField, binWidth, binNumber } = this.options;
     const originData_copy = _.clone(originData);
     // 根据binField value对源数据进行排序

--- a/src/plots/percentage-stack-area/layer.ts
+++ b/src/plots/percentage-stack-area/layer.ts
@@ -2,6 +2,8 @@ import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import StackArea, { StackAreaViewConfig } from '../stack-area/layer';
+import { DataItem } from '../../interface/config';
+import { transformDataPercentage } from '../../util/data';
 
 export interface PercentageStackAreaViewConfig extends StackAreaViewConfig {}
 export interface PercentageStackAreaLayerConfig extends PercentageStackAreaViewConfig, LayerConfig {}
@@ -23,31 +25,10 @@ export default class PercentageStackAreaLayer extends StackArea<PercentageStackA
   }
   public type: string = 'percentageStackArea';
 
-  protected processData(originData?: object[]) {
-    const props = this.options;
-    const { xField, yField } = props;
-    // 百分比堆叠面积图需要对原始数据进行预处理
-    // step1: 以xField为单位，对yField做聚合
-    const plotData = [];
-    const sum = {};
-    _.each(originData, (d) => {
-      const sumField = d[xField];
-      if (!_.has(sum, sumField)) {
-        sum[sumField] = 0;
-      }
-      sum[sumField] += Number.parseFloat(d[yField]);
-    });
-    // step2: 获取每一条数据stackField的值在对应xField数值总和的占比
-    _.each(originData, (d) => {
-      const total = sum[d[xField]];
-      const d_copy = _.clone(d);
-      d_copy[yField] = d[yField] / total;
-      d_copy._origin = d;
-      d_copy.total = total;
-      plotData.push(d_copy);
-    });
+  protected processData(originData?: DataItem[]) {
+    const { xField, yField } = this.options;
 
-    return plotData;
+    return transformDataPercentage(originData, xField, [yField]);
   }
 
   protected scale() {
@@ -56,6 +37,8 @@ export default class PercentageStackAreaLayer extends StackArea<PercentageStackA
     metaConfig[this.options.yField] = {
       tickCount: 6,
       alias: `${yField} (%)`,
+      minLimit: 0,
+      maxLimit: 1,
       formatter: (v) => {
         const formattedValue = (v * 100).toFixed(1);
         return `${formattedValue}%`;

--- a/src/plots/percentage-stack-column/layer.ts
+++ b/src/plots/percentage-stack-column/layer.ts
@@ -2,6 +2,8 @@ import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import StackColumn, { StackColumnViewConfig } from '../stack-column/layer';
+import { transformDataPercentage } from '../../util/data';
+import { DataItem } from '../../interface/config';
 
 export interface PercentageStackColumnViewConfig extends StackColumnViewConfig {}
 export interface PercentageStackColumnLayerConfig extends PercentageStackColumnViewConfig, LayerConfig {}
@@ -33,31 +35,9 @@ export default class PercentageStackColumnLayer extends StackColumn<PercentageSt
   }
   public type: string = 'percentageStackColumn';
 
-  protected processData(originData?: object[]) {
-    const props = this.options;
-    const { xField, yField } = props;
-    // 百分比堆叠面积图需要对原始数据进行预处理
-    // step1: 以xField为单位，对yField做聚合
-    const plotData = [];
-    const sum = {};
-    _.each(originData, (d) => {
-      const sumField = d[xField];
-      if (!_.has(sum, sumField)) {
-        sum[sumField] = 0;
-      }
-      sum[sumField] += Number.parseFloat(d[yField]);
-    });
-    // step2: 获取每一条数据yField的值在对应xField数值总和的占比
-    _.each(originData, (d) => {
-      const total = sum[d[xField]];
-      const d_copy = _.clone(d);
-      d_copy[yField] = d[yField] / total;
-      d_copy._origin = d;
-      d_copy.total = total;
-      plotData.push(d_copy);
-    });
-
-    return plotData;
+  protected processData(originData?: DataItem[]) {
+    const { xField, yField } = this.options;
+    return transformDataPercentage(originData || [], xField, [yField]);
   }
 
   protected scale() {
@@ -66,6 +46,8 @@ export default class PercentageStackColumnLayer extends StackColumn<PercentageSt
     metaConfig[yField] = {
       tickCount: 6,
       alias: `${yField} (%)`,
+      minLimit: 0,
+      maxLimit: 1,
       formatter: (v) => {
         const formattedValue = (v * 100).toFixed(1);
         return `${formattedValue}%`;

--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -5,7 +5,7 @@ import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
-import { Label } from '../../interface/config';
+import { Label, DataItem } from '../../interface/config';
 import { extractScale } from '../../util/scale';
 import SpiderLabel from './component/label/spider-label';
 import * as EventParser from './event';
@@ -118,9 +118,12 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
     super.scale();
   }
 
-  protected processData(data?: object[]): object[] | undefined {
+  protected processData(data?: DataItem[]): DataItem[] | undefined {
     const key = this.options.angleField;
-    return data.map((item) => ({ ...item, [key]: Number.parseFloat(item[key]) }));
+    return data.map((item) => ({
+      ...item,
+      [key]: typeof item[key] === 'string' ? Number.parseFloat(item[key] as 'string') : item[key],
+    }));
   }
 
   protected axis() {}

--- a/src/plots/ring/layer.ts
+++ b/src/plots/ring/layer.ts
@@ -162,7 +162,11 @@ export default class RingLayer<T extends RingLayerConfig = RingLayerConfig> exte
   private getTotalValue(): object {
     const props = this.options;
     let total = 0;
-    props.data.forEach((item) => (total += item[props.angleField]));
+    _.each(props.data, (item) => {
+      if (typeof item[props.angleField] === 'number') {
+        total += item[props.angleField];
+      }
+    });
     const data = {
       [props.angleField]: total,
       [props.colorField]: '总计',

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -1,0 +1,49 @@
+import { groupBy, mapValues, map, flatten, isNumber, reduce, each } from '@antv/util';
+import { DataItem } from '../interface/config';
+
+export const transformDataPercentage = (data: DataItem[], groupField: string, measures: string[]): DataItem[] => {
+  // 按照groupBy字段计算各个group的总和
+  let chain = groupBy(data, groupField);
+  chain = mapValues(chain, (items) => map(items, (item) => map(measures, (field) => item[field])));
+  chain = mapValues(chain, flatten);
+  chain = mapValues(chain, (vals) =>
+    map(vals, (val) => {
+      // @ts-ignore
+      const v = Number.parseFloat(val);
+      if (!isNumber(v) || isNaN(v)) {
+        return 0;
+      }
+      return v;
+    })
+  );
+  // @ts-ignore
+  const groupTotals = mapValues(chain, (vals: number[]) => reduce(vals, (sum, val) => sum + val, 0));
+
+  // 覆盖measures字段的值为对于的百分比
+  const newData = map(data, (item) => {
+    const rst = { ...item, _origin: item, total: groupTotals[item[groupField]] };
+    each(measures, (field) => {
+      // @ts-ignore
+      rst[field] = item[field] / groupTotals[item[groupField]];
+    });
+    return rst;
+  });
+
+  // 检查精度，确保总和为1
+  each(groupBy(newData, groupField), (items: DataItem[]) => {
+    let sum = 0;
+    each(items, (item: DataItem, itemIdx: number) => {
+      each(measures, (field: string, fieldIdx: number) => {
+        // @ts-ignore
+        if (sum + item[field] >= 1 || (itemIdx === items.length - 1 && fieldIdx === measures.length - 1)) {
+          item[field] = 1 - sum;
+        }
+        // @ts-ignore
+        sum += item[field];
+      });
+    });
+  });
+
+  // @ts-ignore
+  return newData;
+};


### PR DESCRIPTION
问题可在[DEMO](https://codesandbox.io/s/gracious-spence-uwxki?fontsize=14&hidenavigation=1&theme=dark)中复现

- 在 processData 中保证处理后的数据加起来恒为1
- scale中设置 minLimit/maxLimit 为0/1