### PR TITLE
docs: update G2Plot/docs/manual/introduction.zh.md

### DIFF
--- a/docs/manual/introduction.zh.md
+++ b/docs/manual/introduction.zh.md
@@ -34,7 +34,7 @@ $ npm install @antv/g2plot
 ```
 
 ```js
-import g2plot from '@antv/g2plot';
+import { Bar } from '@antv/g2plot';
 
 const data = [
   { year: '1951 年', sales: 38 },
@@ -44,7 +44,7 @@ const data = [
   { year: '1958 年', sales: 48 },
 ];
 
-const barPlot = new g2plot.Bar('c1', {
+const barPlot = new Bar('c1', {
   data,
   xField: 'sales',
   yField: 'year',


### PR DESCRIPTION
使用的版本为: antv/g2plot 0.11.4
按照文档中的使用实例使用时提示:
```shell
Attempted import error: '@antv/g2plot' does not contain a default export (imported as 'g2plot').
```
在react项目中按照官方文档这样提示没有默认导出语句,需要解构导入.
如果是我操作不当,请指出 :smile: