### PR TITLE
test(pie-coverage): 增加pie-label测试断言

### DIFF
--- a/__tests__/unit/pie-label-spec.ts
+++ b/__tests__/unit/pie-label-spec.ts
@@ -163,6 +163,34 @@ describe('Pie plot with outer-label', () => {
     }
   });
 
+  it('when label offset < 0, all labels still outside element', () => {
+    const canvasDiv = createDiv('canvas-2');
+    const piePlot1 = new Pie(canvasDiv, {
+      ...pieConfig,
+      data,
+      radius: 0.5,
+      label: {
+        visible: true,
+        type: 'outer',
+        offset: -1,
+        formatter: (text, item) => {
+          return `${item._origin['type']} (${item._origin['value'].toFixed(2)})`;
+        },
+      },
+    });
+    piePlot1.render();
+    const plot = piePlot1.getLayer().view;
+    const element = plot.get('elements')[0];
+    const labelShapes: Shape[] = element.get('labels');
+    const coord = plot.get('coord');
+    labelShapes.forEach((label) => {
+      const distX = Math.abs(coord.getCenter().x - label.attr('x'));
+      const distY = Math.abs(coord.getCenter().y - label.attr('y'));
+      const dist = Math.sqrt(distX * distX + distY * distY);
+      expect(dist > coord.getRadius()).toBe(true);
+    });
+  });
+
   afterAll(() => {
     // piePlot.destroy();
   });

--- a/src/plots/pie/component/label/outer-label.ts
+++ b/src/plots/pie/component/label/outer-label.ts
@@ -36,7 +36,7 @@ class OuterPieLabel extends BasePieLabel {
     const r = coord.getRadius();
     labels.forEach((l, idx) => {
       const item = items[idx];
-      const offset = this.getOffsetOfLabel(item);
+      const offset = this.getOffsetOfLabel();
       const pos = getEndPoint(center, item.angle, r + offset);
       l.attr('x', pos.x + (item.textAlign === 'left' ? 12 : -12));
       l.attr('y', pos.y);
@@ -57,7 +57,7 @@ class OuterPieLabel extends BasePieLabel {
     const center = coord.getCenter();
     const filterLabels = labels.filter((l, idx) => l.attr('textAlign') === 'left' && items[idx].angle < 0);
     const labelHeight = _.head(filterLabels).getBBox().height;
-    const offset = this.getOffsetOfLabel(_.head(filterLabels));
+    const offset = this.getOffsetOfLabel();
     for (let idx = 0; idx < filterLabels.length; idx += 1) {
       const l = filterLabels[idx];
       const box = l.getBBox();
@@ -111,7 +111,7 @@ class OuterPieLabel extends BasePieLabel {
   private _adjustRigthBottomLabels(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
     const filterLabels = labels.filter((l, idx) => l.attr('textAlign') === 'left' && items[idx].angle >= 0);
     const labelHeight = _.head(filterLabels).getBBox().height;
-    const offset = this.getOffsetOfLabel(_.head(filterLabels));
+    const offset = this.getOffsetOfLabel();
     const center = coord.getCenter();
     const lastRightTopLabel = _.last(labels.filter((l, idx) => l.attr('textAlign') === 'left' && items[idx].angle < 0));
     filterLabels.forEach((l, idx) => {
@@ -171,7 +171,7 @@ class OuterPieLabel extends BasePieLabel {
     const filterLabels = labels.filter(
       (l, idx) => l.attr('textAlign') === 'right' && items[idx].angle >= 0 && items[idx].angle <= Math.PI
     );
-    const offset = this.getOffsetOfLabel(_.head(filterLabels));
+    const offset = this.getOffsetOfLabel();
     const labelHeight = _.head(filterLabels).getBBox().height;
     // filterLabels.forEach((l, idx) => {
     for (let idx = 0; idx < filterLabels.length; idx += 1) {
@@ -235,7 +235,7 @@ class OuterPieLabel extends BasePieLabel {
       (l, idx) => l.attr('textAlign') === 'right' && (items[idx].angle < 0 || items[idx].angle > Math.PI)
     );
     const labelHeight = _.head(filterLabels).getBBox().height;
-    const offset = this.getOffsetOfLabel(_.head(filterLabels));
+    const offset = this.getOffsetOfLabel();
     const lastLeftBottomLabel = _.last(
       labels.filter((l, idx) => l.attr('textAlign') === 'right' && items[idx].angle >= 0 && items[idx].angle <= Math.PI)
     );
@@ -294,7 +294,7 @@ class OuterPieLabel extends BasePieLabel {
     const r = coord.getRadius();
     const start = getEndPoint(center, angle, r);
     const end = { x: label.attr('x') - (item.textAlign === 'left' ? 4 : -4), y: label.attr('y') };
-    const offset = this.getOffsetOfLabel(item);
+    const offset = this.getOffsetOfLabel();
     const alignment = item.textAlign;
     const breakAt = getEndPoint(center, angle, r + offset);
     breakAt.x = alignment === 'left' ? Math.min(breakAt.x, end.x) : Math.max(breakAt.x, end.x);
@@ -303,10 +303,15 @@ class OuterPieLabel extends BasePieLabel {
   }
 
   /** 获取label offset, 默认 16px 不允许 <= 0 */
-  private getOffsetOfLabel(labelItem: LabelItem): number {
-    // @ts-ignore
-    const offset = (labelItem && labelItem.offset) || DEFAULT_OFFSET;
-    return offset > 0 ? offset : 1;
+  private getOffsetOfLabel(): number {
+    const labelOptions = this.get('labelOptions');
+    const offset = labelOptions.offset;
+    return offset === undefined ? DEFAULT_OFFSET : offset > 0 ? offset : 1;
+  }
+
+  public getDefaultOffset(point) {
+    const offset = super.getDefaultOffset(point);
+    return offset === undefined ? DEFAULT_OFFSET : offset > 0 ? offset : 1;
   }
 }
 


### PR DESCRIPTION
1. 复写pie outer-label  `getDefaultOffset`的方法 (强制offset > 0)
2. 当label offset 无配置（重置为16px）或小于等于0（重置为1px）时，自动重置
3. 提高测试覆盖率