### PR TITLE
chore: correct site-publish token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           git commit -m "update by release action"
       - uses: ad-m/github-push-action@master
         with:
-          github_token: ${{secrets.ACCESS_TOKEN}}
+          github_token: ${{secrets.PERSONAL_ACCESS_TOKEN}}
           directory: public
           branch: gh-pages
           force: true


### PR DESCRIPTION
setting里面写的PERSONAL_ACCESS_TOKEN