### PR TITLE
fix: 修复column/bar数据标签position配置在负数值情况的位置

### DIFF
--- a/src/plots/bar/component/label/bar-label.ts
+++ b/src/plots/bar/component/label/bar-label.ts
@@ -18,6 +18,7 @@ export class BarLabels extends ElementLabels {
     const coord = this.get('coord');
     const point0 = coord.convertPoint(originPoint.points[0]);
     const point1 = coord.convertPoint(originPoint.points[2]);
+    const negative = point0.x > point1.x;
     const width = ((point0.x - point1.x) / 2) * -1;
     const height = ((point0.y - point1.y) / 2) * -1;
 
@@ -34,21 +35,41 @@ export class BarLabels extends ElementLabels {
         break;
       case 'left':
         point.x -= width * 2;
-        point.textAlign = point.textAlign || 'left';
+        point.textAlign = point.textAlign || (negative ? 'right' : 'left');
         break;
       case 'middle':
         point.x -= width;
         point.textAlign = point.textAlign || 'center';
         break;
       case 'right':
-        point.textAlign = point.textAlign || 'left';
+        point.textAlign = point.textAlign || (negative ? 'right' : 'left');
         break;
       default:
         break;
     }
   }
+
+  // 针对负数值的label调整
+  private adjustOffset(points: any[], shapes: Shape[]) {
+    const renderer = this.get('labelsRenderer');
+    const items = renderer.get('items');
+    const labels = renderer.get('group').get('children');
+    const coord = this.get('coord');
+    _.each(items, (item, idx) => {
+      const label = labels[idx];
+      const point0 = coord.convertPoint(points[idx].points[0]);
+      const point1 = coord.convertPoint(points[idx].points[2]);
+      const negative = point0.x > point1.x;
+      if (negative && item.offset) {
+        item.x -= item.offset * 2;
+        label.attr('x', label.attr('x') - item.offset * 2);
+      }
+    });
+  }
+
   public showLabels(points: any, shapes: Shape[]) {
     super.showLabels(points, shapes);
+    this.adjustOffset(points, shapes);
     const renderer = this.get('labelsRenderer');
     const labels = renderer.get('group').get('children');
     const items = renderer.get('items');

--- a/src/plots/column/component/label/column-label.ts
+++ b/src/plots/column/component/label/column-label.ts
@@ -17,6 +17,7 @@ export class ColumnLabels extends ElementLabels {
     const coord = this.get('coord');
     const point0 = coord.convertPoint(originPoint.points[0]);
     const point1 = coord.convertPoint(originPoint.points[2]);
+    const negative = point0.y < point1.y;
     const width = (point0.x - point1.x) / 2;
     const height = (point0.y - point1.y) / 2;
 
@@ -46,8 +47,28 @@ export class ColumnLabels extends ElementLabels {
         break;
     }
   }
-  public showLabels(points: any, shapes: Shape[]) {
+
+  private adjustOffset(points: LooseMap[], shapes: Shape[]) {
+    const renderer = this.get('labelsRenderer');
+    const items = renderer.get('items');
+    const labels = renderer.get('group').get('children');
+    const coord = this.get('coord');
+    _.each(items, (item, idx) => {
+      const label = labels[idx];
+      const point0 = coord.convertPoint(points[idx].points[0]);
+      const point1 = coord.convertPoint(points[idx].points[2]);
+      const negative = point0.y < point1.y;
+      if (negative) {
+        item.y += item.offset * 2;
+        label.attr('textBaseline', 'top');
+        label.attr('y', label.attr('y') + item.offset * 2);
+      }
+    });
+  }
+
+  public showLabels(points: LooseMap[], shapes: Shape[]) {
     super.showLabels(points, shapes);
+    this.adjustOffset(points, shapes);
     const renderer = this.get('labelsRenderer');
     const labels = renderer.get('group').get('children');
     const items = renderer.get('items');

--- a/src/plots/column/layer.ts
+++ b/src/plots/column/layer.ts
@@ -206,6 +206,14 @@ export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerCo
         },
       };
     }
+    if (position === 'bottom') {
+      return {
+        offset: 4,
+        style: {
+          textBaseline: 'bottom',
+        },
+      };
+    }
     return { offset: 0 };
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1142242/71507967-361eaa80-28c1-11ea-9b22-58ee63a2fe39.png)
