### PR TITLE
fix: export mini chart config

### DIFF
--- a/examples/bubble/basic/demo/trendline.js
+++ b/examples/bubble/basic/demo/trendline.js
@@ -27,6 +27,7 @@ fetch('../data/revenue.json')
         nice: false,
       },
       trendline: {
+        visible: true,
         type: 'log',
       },
     });

--- a/examples/scatter/basic/demo/color-mapping.js
+++ b/examples/scatter/basic/demo/color-mapping.js
@@ -1,6 +1,6 @@
 import { Scatter } from '@antv/g2plot';
 
-fetch('../data/IMDB.json')
+fetch('https://gw.alipayobjects.com/os/basement_prod/7a78a36d-c97c-459d-9090-9e664cd17167.json')
   .then((res) => res.json())
   .then((data) => {
     const scatterPlot = new Scatter(document.getElementById('container'), {

--- a/examples/scatter/basic/demo/trendline.js
+++ b/examples/scatter/basic/demo/trendline.js
@@ -53,6 +53,7 @@ const scatterPlot = new Scatter(document.getElementById('container'), {
     lineWidth: 1,
   },
   trendline: {
+    visible: true,
     type: 'quad', // linear, exp, loess, log, poly, pow, quad
     showConfidence: true,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,10 @@ export * from './plots/index';
 // MINI 图形
 export { TinyLayerConfig } from './sparkline/tiny-layer';
 export { default as Progress, ProgressConfig } from './sparkline/progress';
-export { default as RingProgress } from './sparkline/ring-progress';
-export { default as TinyColumn } from './sparkline/tiny-column';
-export { default as TinyArea } from './sparkline/tiny-area';
-export { default as TinyLine } from './sparkline/tiny-line';
+export { default as RingProgress, RingProgressConfig } from './sparkline/ring-progress';
+export { default as TinyColumn, TinyColumnConfig } from './sparkline/tiny-column';
+export { default as TinyArea, TinyAreaConfig } from './sparkline/tiny-area';
+export { default as TinyLine, TinyLineConfig } from './sparkline/tiny-line';
 
 // 主题
 export { registerTheme, registerGlobalTheme } from './theme';

--- a/src/plots/bubble/layer.ts
+++ b/src/plots/bubble/layer.ts
@@ -146,6 +146,16 @@ export default class BubbleLayer<T extends BubbleLayerConfig = BubbleLayerConfig
 
   protected coord() {}
 
+  protected legend() {
+    super.legend();
+    /** 取消气泡大小图例 */
+    this.setConfig('legends', {
+      fields: {
+        [this.options.sizeField]: false,
+      },
+    });
+  }
+
   protected addGeometry() {
     const props = this.options;
 
@@ -156,13 +166,6 @@ export default class BubbleLayer<T extends BubbleLayerConfig = BubbleLayerConfig
     if (props.label && props.label.visible) {
       bubbles.label = this.extractLabel();
     }
-
-    /** 取消气泡大小图例 */
-    this.setConfig('legends', {
-      fields: {
-        [props.sizeField]: false,
-      },
-    });
 
     this.bubbles = bubbles;
     this.setConfig('element', bubbles);

--- a/src/plots/scatter/components/quadrant.ts
+++ b/src/plots/scatter/components/quadrant.ts
@@ -10,6 +10,7 @@ interface ILabel {
 }
 
 export interface QuadrantConfig {
+  visible?: boolean;
   xBaseline?: number;
   yBaseline?: number;
   regionStyle: any[] | any;

--- a/src/plots/scatter/components/trendline.ts
+++ b/src/plots/scatter/components/trendline.ts
@@ -25,6 +25,7 @@ const REGRESSION_MAP = {
 };
 
 export interface TrendlineConfig {
+  visible?: boolean;
   type?: string;
   style?: any;
   showConfidence?: boolean;

--- a/src/plots/scatter/layer.ts
+++ b/src/plots/scatter/layer.ts
@@ -94,7 +94,10 @@ export default class ScatterLayer<T extends ScatterLayerConfig = ScatterLayerCon
 
   public afterRender() {
     super.afterRender();
-    if (this.options.quadrant && !this.quadrant) {
+    if (this.options.quadrant && this.options.quadrant.visible && !this.quadrant) {
+      if (this.quadrant) {
+        this.quadrant.destroy();
+      }
       this.quadrant = new Quadrant({
         view: this.view,
         plotOptions: this.options,
@@ -102,7 +105,7 @@ export default class ScatterLayer<T extends ScatterLayerConfig = ScatterLayerCon
       });
       this.quadrant.render();
     }
-    if (this.options.trendline) {
+    if (this.options.trendline && this.options.trendline.visible) {
       this.trendline = new Trendline({
         view: this.view,
         plotOptions: this.options,


### PR DESCRIPTION
- [x] 导出 mini chart 类型定义

- [x] 散点图四象限 & trendline 添加 `visible` 属性

- [x]  气泡图legend设visible为false时报错