### PR TITLE
fix: 直方图绘制失效

### DIFF
--- a/src/plots/histogram/layer.ts
+++ b/src/plots/histogram/layer.ts
@@ -65,6 +65,7 @@ export default class HistogramLayer extends Column<HistogramLayerConfig> {
     // fixme: 类型定义
     const range = this.config.scales.range as any;
     range.nice = false;
+    range.type = 'linear';
   }
 
   private getBin(value, binWidth) {


### PR DESCRIPTION
column将x轴scale type强制设为cat，直方图扩展自column，而x scale是linear的，造成无法绘制。