### PR TITLE
fix: fix radar errors #436

### DIFF
--- a/demos/radar-basic.ts
+++ b/demos/radar-basic.ts
@@ -1,0 +1,55 @@
+// 雷达图
+
+const data = [
+  {
+    item: 'Design',
+    score: 70,
+  },
+  {
+    item: 'Development',
+    score: 60,
+  },
+  {
+    item: 'Marketing',
+    score: 60,
+  },
+  {
+    item: 'Users',
+    score: 40,
+  },
+  {
+    item: 'Test',
+    score: 60,
+  },
+  {
+    item: 'Language',
+    score: 70,
+  },
+  {
+    item: 'Technology',
+    score: 50,
+  },
+  {
+    item: 'Support',
+    score: 30,
+  },
+  {
+    item: 'Sales',
+    score: 60,
+  },
+  {
+    item: 'UX',
+    score: 50,
+  },
+];
+const radarPlot = new g2plot.Radar(document.getElementById('canvas'), {
+  data: [],
+  angleField: 'item',
+  radiusField: 'score',
+});
+radarPlot.render();
+
+radarPlot.changeData(data);
+
+// 作为模块 避免变量冲突
+export {};

--- a/demos/radar-series.ts
+++ b/demos/radar-series.ts
@@ -107,9 +107,6 @@ const radarPlot = new g2plot.Radar(document.getElementById('canvas'), {
   angleField: 'item',
   radiusField: 'score',
   seriesField: 'user',
-  line: {
-    visible: true,
-  },
 });
 radarPlot.render();
 

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -285,7 +285,8 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
   }
 
   public changeData(data: DataItem[]): void {
-    this.view.changeData(this.processData(data));
+    this.options.data = this.processData(data);
+    this.view.changeData(this.options.data);
   }
 
   // plot 不断销毁重建，需要一个api获取最新的plot

--- a/src/plots/radar/layer.ts
+++ b/src/plots/radar/layer.ts
@@ -24,8 +24,8 @@ export interface RadarViewConfig extends ViewConfig {
   /** 折线图形样式 */
   line?: {
     visible?: boolean;
-    size: number;
-    color: string;
+    size?: number;
+    color?: string;
     style?: LineStyle;
   };
   /** 数据点图形样式 */
@@ -42,9 +42,9 @@ export interface RadarViewConfig extends ViewConfig {
     style?: FillStyle;
   };
   // fixme: any --> IValueAxis  | ICatAxis | ITimeAxis
-  angleAxis: any;
+  angleAxis?: any;
   // fixme: any --> IValueAxis
-  radiusAxis: any;
+  radiusAxis?: any;
   radius?: number;
   // fixme: any
   [attr: string]: any;


### PR DESCRIPTION
* 修复雷达图类型定义，部分定义非必须传入
* 修复雷达图空数据问题，viewLayer changeData 后，options 中的 data 应置为最新的 data，因为 render 与 resize 的 data 均为从 options 中获取
