### PR TITLE
refactor: pie  outer label

### DIFF
--- a/__tests__/bugs/issue-485-spec.ts
+++ b/__tests__/bugs/issue-485-spec.ts
@@ -1,0 +1,80 @@
+import * as _ from '@antv/util';
+import { Shape } from '@antv/g';
+import { Pie } from '../../src';
+import { createDiv } from '../utils/dom';
+import { getOverlapArea } from '../../src/plots/pie/component/label/utils';
+
+describe('#485 饼图 outer-label 绘制错误', () => {
+  const data = [
+    {
+      type: '分类一',
+      value: 27,
+    },
+    {
+      type: '分类二',
+      value: 25,
+    },
+    {
+      type: '分类三',
+      value: 12232328,
+    },
+    {
+      type: '分类四',
+      value: 12222225,
+    },
+    {
+      type: '分类五',
+      value: 12222220,
+    },
+    {
+      type: '其它',
+      value: 50000024,
+    },
+  ];
+  const div = createDiv('pie-cantainer');
+  div.style.width = '719px';
+  div.style.height = '400px';
+  const piePlot = new Pie(div, {
+    forceFit: true,
+    title: {
+      visible: true,
+      text: '多色饼图',
+    },
+    description: {
+      visible: true,
+      text:
+        '指定颜色映射字段(colorField)，饼图切片将根据该字段数据显示为不同的颜色。指定颜色需要将color配置为一个数组。\n当把饼图label的类型设置为inner时，标签会显示在切片内部。设置offset控制标签的偏移值。',
+    },
+    padding: 'auto',
+    radius: 1,
+    data,
+    angleField: 'value',
+    colorField: 'type',
+    label: {
+      visible: true,
+      type: 'outer',
+    },
+  });
+  piePlot.render();
+
+  it('分类一和分类二 的 label 和饼图区域不重叠', () => {
+    const labels = piePlot
+      .getLayer()
+      .view.get('elements')[0]
+      .get('labels');
+    /** 求两点间距离 */
+    function distanceOfPoints(point1, point2): number {
+      const delta_x = point1.x - point2.x;
+      const delta_y = point1.y - point2.y;
+      return Math.sqrt(delta_x * delta_x + delta_y * delta_y);
+    }
+
+    const center = piePlot.getLayer().view.get('coord').getCenter();
+    const radius = piePlot.getLayer().view.get('coord').getRadius();
+    expect(_.every(labels, (label: Shape) => {
+      const box = label.getBBox();
+      const labelCenter = { x: box.x + box.width / 2, y: box.y + box.height / 2};
+      return distanceOfPoints(center, labelCenter) > radius; 
+    })).toBe(true);
+  });
+});

--- a/__tests__/bugs/issue-485-spec.ts
+++ b/__tests__/bugs/issue-485-spec.ts
@@ -69,12 +69,20 @@ describe('#485 饼图 outer-label 绘制错误', () => {
       return Math.sqrt(delta_x * delta_x + delta_y * delta_y);
     }
 
-    const center = piePlot.getLayer().view.get('coord').getCenter();
-    const radius = piePlot.getLayer().view.get('coord').getRadius();
-    expect(_.every(labels, (label: Shape) => {
-      const box = label.getBBox();
-      const labelCenter = { x: box.x + box.width / 2, y: box.y + box.height / 2};
-      return distanceOfPoints(center, labelCenter) > radius; 
-    })).toBe(true);
+    const center = piePlot
+      .getLayer()
+      .view.get('coord')
+      .getCenter();
+    const radius = piePlot
+      .getLayer()
+      .view.get('coord')
+      .getRadius();
+    expect(
+      _.every(labels, (label: Shape) => {
+        const box = label.getBBox();
+        const labelCenter = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+        return distanceOfPoints(center, labelCenter) > radius;
+      })
+    ).toBe(true);
   });
 });

--- a/__tests__/unit/pie-outerLabel-spec.ts
+++ b/__tests__/unit/pie-outerLabel-spec.ts
@@ -70,23 +70,6 @@ describe('pie outer label', () => {
     /** 三角形，两边之和 大于 第三边 */
     expect(dist).toBeLessThan(radius + labelOffset + MARGIN);
 
-    // @ts-ignore
-    const renderer = pieElement.get('labelController').labelsContainer.get('labelsRenderer');
-    const labelLines = renderer.get('lineGroup').get('children') || [];
-    const lastLine: Shape = _.last(labelLines);
-    expect(lastLine.attr('path')).toEqual(
-      [
-        'M',
-        203.64745084375787,
-        157.34152255572698,
-        'Q',
-        201.79334887750818,
-        151.63518345795606,
-        197.79334887750818,
-        151.63518345795606,
-      ].join(',')
-    );
-
     piePlot.destroy();
     document.body.removeChild(div);
   });
@@ -131,7 +114,8 @@ describe('pie outer label', () => {
     expect(center).toEqual({ x: 250, y: 300 });
     expect(radius).toBe((500 * Radius) / 2);
     const labelShapes: Shape[] = pieElement.get('labels');
-    expect(_.some(labelShapes, (l) => !l.get('visible'))).toBe(true);
+    // 算法增强后 所有label可见
+    expect(_.every(labelShapes, (l) => l.get('visible'))).toBe(true);
     // label fontsize: 12px, label margin: 2px, buffer: 4
     expect(_.filter(labelShapes, (l) => l.get('visible')).length).toBeGreaterThanOrEqual(
       Math.floor(Height / 14) * 2 - 4

--- a/__tests__/unit/pie-utils-spec.ts
+++ b/__tests__/unit/pie-utils-spec.ts
@@ -1,4 +1,4 @@
-import { getEndPoint, getCenter, getOverlapArea, getQuadrantByAngle } from '../../src/plots/pie/component/label/utils';
+import { getEndPoint, getCenter, getOverlapArea } from '../../src/plots/pie/component/label/utils';
 
 describe('test utils of pie label', () => {
   it('getEndPoint', () => {
@@ -20,13 +20,5 @@ describe('test utils of pie label', () => {
     expect(getOverlapArea(box1, box3)).toBe(0);
     expect(getOverlapArea(box2, box3)).toBe(0);
     expect(getOverlapArea(box2, box4)).toBe(200);
-  });
-
-  it('getQuadrantByAngle', () => {
-    expect(getQuadrantByAngle(Math.PI / 4)).toBe(1);
-    expect(getQuadrantByAngle((Math.PI / 4) * 3)).toBe(2);
-    expect(getQuadrantByAngle(-Math.PI / 4)).toBe(0);
-    expect(getQuadrantByAngle((-Math.PI / 4) * 3)).toBe(3);
-    expect(getQuadrantByAngle(3.5)).toBe(3);
   });
 });

--- a/src/plots/pie/component/label/outer-label.ts
+++ b/src/plots/pie/component/label/outer-label.ts
@@ -1,10 +1,10 @@
 import Polar from '@antv/coord/lib/coord/polar';
 import { BBox, Shape } from '@antv/g';
 import { registerElementLabels } from '@antv/g2';
+import { LabelItem } from '@antv/component/lib/interface';
 import * as _ from '@antv/util';
 import { getEndPoint } from './utils';
-import BasePieLabel from './base-label';
-import { LabelItem } from '@antv/component/lib/interface';
+import BaseLabel from './base-label';
 
 // 默认label和element的偏移 16px
 const DEFAULT_OFFSET = 16;
@@ -12,356 +12,251 @@ const DEFAULT_OFFSET = 16;
 const CROOK_DISTANCE = 4;
 
 /**
- * @desc 环绕型 顺时针躲避 label 布局(溢出隐藏)
+ * @desc 环绕型 躲避 label 布局(类椭圆 - 优先顺时针偏移)
  */
-class OuterPieLabel extends BasePieLabel {
+class OuterPieLabel extends BaseLabel {
   public adjustPosition(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
-    this._adjustLabelPosition(labels, items, coord, panel);
-    this._antiCollision(labels, items, coord, panel);
+    this._adjustLabelPosition(labels, coord, panel);
+    const leftHalf = _.filter(labels, (l) => _.find(this.anchors, (a) => a.id === l.id).textAlign === 'right');
+    const rightHalf = _.filter(labels, (l) => _.find(this.anchors, (a) => a.id === l.id).textAlign === 'left');
+    [rightHalf, leftHalf].forEach((half, isLeft) => {
+      this._antiCollision(half, coord, panel, !isLeft);
+    });
   }
 
   /** @override */
   public adjustLines(labels: Shape[], labelItems: LabelItem[], labelLines: any, coord: Polar, panel: BBox) {
     _.each(labels, (label, idx: number) => {
       const labelLine = labelLines[idx];
-      const labelItem = labelItems[idx];
       // 由于布局调整，修改的只是shape 所以取用使用shape(labelItem is read-only)
-      const path = this._getLinePath(label, labelItem, coord, panel);
+      const path = this._getLinePath(label, coord, panel);
       labelLine.attr('path', path);
       labelLine.set('visible', label.get('visible'));
     });
   }
 
-  // label shape position
-  private _adjustLabelPosition(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
+  /** override */
+  protected getOffsetOfLabel(): number {
+    const labelOptions = this.getLabelOptions();
+    const offset = labelOptions.offset;
+    return offset === undefined ? DEFAULT_OFFSET : offset < CROOK_DISTANCE * 2 ? offset / 2 : offset - CROOK_DISTANCE;
+  }
+
+  /** labels 碰撞处理（重点算法） */
+  private _antiCollision(labels: Shape[], coord: Polar, plotRange: BBox, isRight: boolean) {
+    const labelHeight = this.getLabelHeight();
+    const totalR = this.anchorRadius;
     const center = coord.getCenter();
-    const r = coord.getRadius();
-    const distance = this.getCrookDistance();
-    labels.forEach((l, idx) => {
-      const item = items[idx];
+    const totalHeight = Math.min(plotRange.height, Math.max(totalR * 2 + labelHeight * 2, labels.length * labelHeight));
+    const maxLabelsCount = Math.floor(totalHeight / labelHeight);
+    // fix-bug, maxLabelsCount 之后的labels 在非 allowOverlap 不显示（避免出现尾部label展示，而前置label不展示）
+    if (!this.get('labelOptions').allowOverlap) {
+      labels.slice(maxLabelsCount).forEach((label) => {
+        label.set('visible', false);
+      });
+    }
+    labels.splice(maxLabelsCount, labels.length - maxLabelsCount);
+
+    // sort by y DESC
+    labels.sort((a, b) => a.getBBox().y - b.getBBox().y);
+    // adjust y position of labels to avoid overlapping
+    let overlapping = true;
+    let i;
+    let maxY = center.y + totalHeight / 2;
+    let minY = center.y - totalHeight / 2;
+    const boxes = labels.map((label) => {
+      const labelBox = label.getBBox();
+      if (labelBox.maxY > maxY) {
+        maxY = Math.min(plotRange.maxY, labelBox.maxY);
+      }
+      if (labelBox.minY < minY) {
+        minY = Math.max(plotRange.minY, labelBox.minY);
+      }
+      return {
+        text: label.attr('text'),
+        size: labelHeight,
+        pos: labelBox.y,
+        targets: [],
+      };
+    });
+    let j = 0;
+    while (j < boxes.length) {
+      if (j === boxes.length - 1) {
+        boxes[j].targets[0] = maxY;
+      } else {
+        boxes[j].targets[0] = boxes[j + 1].pos - boxes[j + 1].size / 2;
+      }
+      j++;
+    }
+    while (overlapping) {
+      boxes.forEach((box) => {
+        const target = _.last(box.targets);
+        box.pos = Math.max(minY, Math.min(box.pos, target - box.size));
+      });
+      // detect overlapping and join boxes
+      overlapping = false;
+      i = boxes.length;
+      while (i--) {
+        if (i > 0) {
+          const previousBox = boxes[i - 1];
+          const box = boxes[i];
+          if (previousBox.pos + previousBox.size > box.pos) {
+            // overlapping
+            previousBox.size += box.size;
+            previousBox.targets = previousBox.targets.concat(box.targets);
+            // overflow, shift up
+            const target = _.last(previousBox.targets);
+            if (previousBox.pos + previousBox.size > target) {
+              previousBox.pos = target - previousBox.size;
+            }
+            boxes.splice(i, 1); // removing box
+            overlapping = true;
+          } else {
+            // 换掉最后一个
+            previousBox.targets.splice(-1, 1, box.pos);
+          }
+        }
+      }
+    }
+
+    i = 0;
+    // step 4: normalize y and adjust x
+    boxes.forEach((b) => {
+      let posInCompositeBox = labelHeight / 2; // middle of the label
+      b.targets.forEach(() => {
+        labels[i].attr('y', b.pos + posInCompositeBox);
+        posInCompositeBox += labelHeight;
+        i++;
+      });
+    });
+
+    // 调整 x 位置在椭圆轨道上
+    const topLabels = [];
+    const bottomLabels = [];
+    labels.forEach((label) => {
+      const anchor = this.anchors.find((a) => a.id === label.id);
+      if (anchor.angle >= 0 && anchor.angle <= Math.PI) {
+        bottomLabels.push(label);
+      } else {
+        topLabels.push(label);
+      }
+    });
+    [topLabels, bottomLabels].forEach((adjustLabels, isBottom) => {
+      if (!adjustLabels.length) {
+        return;
+      }
+      let ry = isBottom
+        ? _.last(adjustLabels).getBBox().maxY - center.y
+        : center.y - _.head(adjustLabels).getBBox().minY;
+      ry = Math.max(totalR, ry);
       const offset = this.getOffsetOfLabel();
-      const pos = getEndPoint(center, item.angle, r + offset);
-      const isRight = item.textAlign === 'left';
-      l.attr('x', pos.x + (isRight ? distance * 2 : -distance * 2));
-      l.attr('y', pos.y);
+      const distance = this.getCrookDistance();
+      const maxLabelWidth =
+        Math.max.apply(
+          0,
+          _.map(labels, (label) => label.getBBox().width)
+        ) +
+        offset +
+        distance;
+      const rx = Math.max(totalR, Math.min((ry + totalR) / 2, center.x - (plotRange.minX + maxLabelWidth)));
+      const rxPow2 = rx * rx;
+      const ryPow2 = ry * ry;
+      adjustLabels.forEach((label) => {
+        const box = label.getBBox();
+        const boxCenter = { x: box.minX + box.width / 2, y: box.minY + box.height / 2 };
+        const dyPow2 = Math.pow(boxCenter.y - center.y, 2);
+        const anchor = this.anchors.find((a) => a.id === label.id);
+        const endPoint = getEndPoint(center, anchor.angle, coord.getRadius());
+        const distance_offset = (isRight ? 1 : -1) * distance * 2;
+        if (dyPow2 > ryPow2) {
+          console.warn('异常(一般不会出现)', label.attr('text'));
+          label.attr('x', endPoint.x + distance_offset);
+        } else {
+          // (x - cx)^2 / rx ^ 2 + (y - cy)^2 / ry ^ 2 = 1
+          // 避免 label的 拉线 在 element 上
+          let xPos = center.x + (isRight ? 1 : -1) * Math.sqrt((1 - dyPow2 / ryPow2) * rxPow2);
+          if (
+            (center.x === endPoint.x && boxCenter.y === endPoint.y) ||
+            (center.y === endPoint.y && xPos === endPoint.x)
+          ) {
+            xPos = endPoint.x;
+          } else {
+            const k1 = (center.y - endPoint.y) / (center.x - endPoint.x);
+            const k2 = (boxCenter.y - endPoint.y) / (xPos - endPoint.x);
+            const theta = Math.atan((k1 - k2) / (1 + k1 * k2));
+            if (Math.cos(theta) > 0 && (!isRight ? xPos > endPoint.x : xPos < endPoint.x)) {
+              xPos = endPoint.x;
+            }
+          }
+          label.attr('x', xPos + distance_offset);
+        }
+      });
+    });
+  }
+
+  // label shape position
+  private _adjustLabelPosition(labels: Shape[], coord: Polar, panel: BBox) {
+    const distance = this.getCrookDistance();
+    labels.forEach((l) => {
+      const anchor = this.anchors.find((a) => a.id === l.id);
+      const isRight = anchor.textAlign === 'left';
+      l.attr('x', anchor.x + (isRight ? distance * 2 : -distance * 2));
+      l.attr('y', anchor.y);
       // 统一垂直居中
       l.attr('textBaseline', 'middle');
     });
-    // OPTIMIZE start
-    /** all labels move into panel */
-    labels.forEach((l) => this.moveYIntoPanel(l, panel));
-    // OPTIMIZE end
   }
 
-  /** 防止label溢出  */
-  private moveYIntoPanel(label: Shape, panel: BBox): void {
-    const box = label.getBBox();
-    if (box.y < panel.y) {
-      label.attr('y', panel.y + box.height / 2);
-    } else if (box.maxY > panel.maxY) {
-      label.attr('y', panel.maxY - box.height / 2);
-    }
-  }
-
-  private _antiCollision(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
-    this._adjustRigthTopLabels(labels, items, coord, panel);
-    this._adjustRigthBottomLabels(labels, items, coord, panel);
-    this._adjustLeftBottomLabels(labels, items, coord, panel);
-    this._adjustLeftTopLabels(labels, items, coord, panel);
-  }
-
-  /** 调整右上角labels */
-  private _adjustRigthTopLabels(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
-    const margin = 2;
+  /** 获取label leader-line, 默认 not smooth */
+  private _getLinePath(label: Shape, coord: Polar, panel: BBox): string {
+    const labelOptions = this.getLabelOptions();
+    const smooth = labelOptions.line ? labelOptions.line.smooth : false;
+    const anchor = this.anchors.find((a) => a.id === label.id);
+    const angle = anchor.angle;
     const center = coord.getCenter();
-    const r = coord.getRadius();
-    const filterLabels = labels.filter((l, idx) => l.attr('textAlign') === 'left' && items[idx].angle < 0);
-    if (!filterLabels.length) return;
-    const labelHeight = _.head(filterLabels).getBBox().height + margin;
-    const offset = this.getOffsetOfLabel();
-    const rx = r + offset;
-    /** usableLabels box  */
-    const groupBox = {
-      minX: center.x,
-      maxX: panel.maxX,
-      minY: panel.minY,
-      maxY: center.y,
-    };
-    // 计算可用高度
-    const usableHeight = groupBox.maxY - groupBox.minY;
-    const usableCount = Math.min(filterLabels.length, usableHeight / labelHeight);
-    if (!usableCount) return;
-    const usableLabels = filterLabels.slice(0, usableCount);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      const box = label.getBBox();
-      let moved = false;
-      // 剩余空间不足,或 overlaped with previous label
-      if (idx === 0 && box.minY < groupBox.minY) {
-        label.attr('y', groupBox.minY + labelHeight / 2);
-        moved = true;
-      } else if (idx > 0 && box.minY < usableLabels[idx - 1].getBBox().maxY) {
-        const yPos = usableLabels[idx - 1].getBBox().maxY + labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      } else if (groupBox.maxY - box.maxY < (usableCount - (idx + 1)) * labelHeight) {
-        const yPos = groupBox.maxY - (usableCount - (idx + 1)) * labelHeight - labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      }
-      label.attr('moved', moved);
-    }
-
-    const ry = Math.max(center.y - _.head(usableLabels).getBBox().minY, usableCount * labelHeight);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      if (label.attr('moved')) {
-        const box = label.getBBox();
-        const ryPow2 = ry * ry;
-        const rxPow2 = rx * rx;
-        const dyPow2 = Math.pow(Math.abs(box.y - center.y), 2);
-        // (x - cx)^2 / rx ^ 2 + (y - cy)^2 / ry ^ 2 = 1
-        let xPos = center.x + Math.sqrt((1 - dyPow2 / ryPow2) * rxPow2);
-        const itemIdx = _.findIndex(items, (item) => item.id === label.id);
-        const dAngle = (items[itemIdx + 1] ? items[itemIdx + 1].angle : -Math.PI / 2) - items[itemIdx].angle;
-        // L=n× π× r/180
-        xPos = Math.max(xPos, center.x + dAngle * r);
-        label.attr('x', xPos);
-      }
-    }
-  }
-
-  /** 调整右下角labels */
-  private _adjustRigthBottomLabels(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
-    const margin = 2;
-    const filterLabels = labels.filter((l, idx) => l.attr('textAlign') === 'left' && items[idx].angle >= 0);
-    if (!filterLabels.length) return;
-    const center = coord.getCenter();
-    const r = coord.getRadius();
-    const offset = this.getOffsetOfLabel();
-    const labelHeight = _.head(filterLabels).getBBox().height + margin;
-    const originIdx = _.findIndex(labels, (l) => l.id === _.head(filterLabels).id);
-    const rx = r + offset;
-    /** usableLabels box  */
-    const groupBox = {
-      minX: center.x,
-      maxX: panel.maxX,
-      minY: Math.min(center.y, labels[originIdx - 1] ? labels[originIdx - 1].getBBox().maxY : Infinity),
-      maxY: panel.maxY,
-    };
-    // 计算可用高度
-    const usableHeight = groupBox.maxY - groupBox.minY;
-    const usableCount = Math.min(filterLabels.length, usableHeight / labelHeight);
-    if (!usableCount) return;
-    const usableLabels = filterLabels.slice(0, usableCount);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      const box = label.getBBox();
-      let moved = false;
-      // 剩余空间不足,或 overlaped with previous label
-      if (idx === 0 && box.minY < groupBox.minY) {
-        label.attr('y', groupBox.minY + labelHeight / 2);
-        moved = true;
-      } else if (idx > 0 && box.minY < usableLabels[idx - 1].getBBox().maxY) {
-        // could not overlaped with previous label
-        const yPos = usableLabels[idx - 1].getBBox().maxY + labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      } else if (groupBox.maxY - box.maxY < (usableCount - (idx + 1)) * labelHeight) {
-        const yPos = groupBox.maxY - (usableCount - (idx + 1)) * labelHeight - labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      }
-      label.attr('moved', moved);
-    }
-
-    const ry = Math.max(_.last(usableLabels).getBBox().maxY - center.y, usableCount * labelHeight);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      if (label.attr('moved')) {
-        const box = label.getBBox();
-        const ryPow2 = ry * ry;
-        const rxPow2 = rx * rx;
-        const dyPow2 = Math.pow(Math.abs(box.y - center.y), 2);
-        // (x - cx)^2 / rx ^ 2 + (y - cy)^2 / ry ^ 2 = 1
-        let xPos = center.x + Math.sqrt((1 - dyPow2 / ryPow2) * rxPow2);
-        const itemIdx = _.findIndex(items, (item) => item.id === label.id);
-        const dAngle = (items[itemIdx + 1] ? items[itemIdx + 1].angle : -Math.PI / 2) - items[itemIdx].angle;
-        // L=n× π× r/180
-        xPos = Math.max(xPos, center.x + dAngle * r);
-        label.attr('x', xPos);
-      }
-    }
-  }
-
-  /** 调整左下角labels */
-  private _adjustLeftBottomLabels(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
-    const margin = 2;
-    const center = coord.getCenter();
-    const r = coord.getRadius();
-    const filterLabels = labels.filter(
-      (l, idx) => l.attr('textAlign') === 'right' && items[idx].angle >= 0 && items[idx].angle <= Math.PI
-    );
-    if (!filterLabels.length) return;
-    const offset = this.getOffsetOfLabel();
-    const labelHeight = _.head(filterLabels).getBBox().height + margin;
-    const rx = r + offset;
-    /** usableLabels box  */
-    const groupBox = {
-      minX: panel.minX,
-      maxX: center.x,
-      minY: center.y,
-      maxY: panel.maxY,
-    };
-    // 计算可用高度
-    const usableHeight = groupBox.maxY - groupBox.minY;
-    const usableCount = Math.min(filterLabels.length, usableHeight / labelHeight);
-    if (!usableCount) return;
-    const usableLabels = filterLabels.slice(0, usableCount);
-    usableLabels.forEach((label, idx) => {
-      const box = label.getBBox();
-      let moved = false;
-      // 剩余空间不足,或 overlaped with previous label
-      if (idx > 0 && box.maxY > usableLabels[idx - 1].getBBox().minY) {
-        const yPos = usableLabels[idx - 1].getBBox().minY - labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      } else if (box.minY - groupBox.minY < (usableCount - (idx + 1)) * labelHeight) {
-        // enough space for remained labels
-        const newMinY = groupBox.minY + (usableCount - (idx + 1)) * labelHeight;
-        label.attr('y', newMinY + labelHeight / 2);
-        moved = true;
-      }
-      label.attr('moved', moved);
-    });
-    const ry = Math.max(_.head(usableLabels).getBBox().maxY - center.y, usableCount * labelHeight);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      if (label.attr('moved')) {
-        const box = label.getBBox();
-        const ryPow2 = ry * ry;
-        const rxPow2 = rx * rx;
-        const dyPow2 = Math.pow(Math.abs(box.y - center.y), 2);
-        // (x - cx)^2 / rx ^ 2 + (y - cy)^2 / ry ^ 2 = 1
-        let xPos = center.x - Math.sqrt((1 - dyPow2 / ryPow2) * rxPow2);
-        const itemIdx = _.findIndex(items, (item) => item.id === label.id);
-        const dAngle = (items[itemIdx + 1] ? items[itemIdx + 1].angle : -Math.PI / 2) - items[itemIdx].angle;
-        // L=n× π× r/180
-        xPos = Math.min(xPos, center.x - dAngle * r);
-        label.attr('x', xPos);
-      }
-    }
-  }
-
-  /** 调整左上角labels */
-  private _adjustLeftTopLabels(labels: Shape[], items: LabelItem[], coord: Polar, panel: BBox) {
-    const margin = 2;
-    const center = coord.getCenter();
-    const r = coord.getRadius();
-    // fix, angle maybe larger than Math.PI
-    const filterLabels = labels.filter(
-      (l, idx) => l.attr('textAlign') === 'right' && (items[idx].angle < 0 || items[idx].angle > Math.PI)
-    );
-    if (!filterLabels.length) return;
-    const labelHeight = _.head(filterLabels).getBBox().height + margin;
-    const offset = this.getOffsetOfLabel();
-    const originIdx = _.findIndex(labels, (l) => l.id === _.head(filterLabels).id);
-    const rx = r + offset;
-    /** usableLabels box  */
-    const groupBox = {
-      minX: panel.minX,
-      maxX: center.x,
-      minY: panel.minY,
-      maxY: Math.min(center.y, labels[originIdx - 1] ? labels[originIdx - 1].getBBox().minY : Infinity),
-    };
-    // 计算可用高度
-    const usableHeight = groupBox.maxY - groupBox.minY;
-    const usableCount = Math.min(filterLabels.length, usableHeight / labelHeight);
-    if (!usableCount) return;
-    const usableLabels = filterLabels.slice(0, usableCount);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      const box = label.getBBox();
-      let moved = false;
-      // 剩余空间不足,或 overlaped with previous label
-      if (idx === 0 && box.maxY > groupBox.maxY) {
-        // could not outof groupBox
-        const yPos = groupBox.maxY - labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      } else if (idx > 0 && box.maxY > usableLabels[idx - 1].getBBox().minY) {
-        // overlap with prev
-        const yPos = usableLabels[idx - 1].getBBox().minY - labelHeight / 2;
-        label.attr('y', yPos);
-        moved = true;
-      } else if (box.minY - groupBox.minY < (usableCount - (idx + 1)) * labelHeight) {
-        // enough space for remained labels
-        const newMinY = groupBox.minY + (usableCount - (idx + 1)) * labelHeight;
-        label.attr('y', newMinY + labelHeight / 2);
-        moved = true;
-      }
-      label.attr('moved', moved);
-    }
-
-    const ry = Math.max(rx, center.y - _.last(usableLabels).getBBox().minY);
-    for (let idx = 0; idx < usableLabels.length; idx += 1) {
-      const label = usableLabels[idx];
-      if (label.attr('moved')) {
-        const box = label.getBBox();
-        const ryPow2 = ry * ry;
-        const rxPow2 = rx * rx;
-        const dyPow2 = Math.pow(Math.abs(box.y - center.y), 2);
-        // (x - cx)^2 / rx ^ 2 + (y - cy)^2 / ry ^ 2 = 1
-        let xPos = center.x - Math.sqrt((1 - dyPow2 / ryPow2) * rxPow2);
-        const itemIdx = _.findIndex(items, (item) => item.id === label.id);
-        const dAngle = (items[itemIdx + 1] ? items[itemIdx + 1].angle : -Math.PI / 2) - items[itemIdx].angle;
-        // L=n× π× r/180
-        xPos = Math.min(xPos, center.x - dAngle * r);
-        label.attr('x', xPos);
-      }
-    }
-  }
-
-  // 获取label leader-line
-  private _getLinePath(label: Shape, item: LabelItem, coord: Polar, panel: BBox): string {
-    const smooth = true;
-    const angle = item.angle;
-    const center = coord.getCenter();
-    const r = coord.getRadius();
-    const offset = this.getOffsetOfLabel();
     const distance = this.getCrookDistance();
-    const start = getEndPoint(center, angle, r);
-    const isRight = item.textAlign === 'left';
-    const breakAt = getEndPoint(center, angle, r + offset);
+    const start = getEndPoint(center, angle, coord.getRadius());
+    const isRight = anchor.textAlign === 'left';
+    let breakAt = anchor;
     const end = { x: label.attr('x') + (isRight ? -distance : distance), y: label.attr('y') };
-    const theta = (angle / 180) * Math.PI;
     let smoothPath = [];
-    if (theta) {
-      smoothPath = ['Q', /** soft break */ breakAt.x, breakAt.y].concat([end.x, end.y]);
-    } else {
-      smoothPath = ['L', end.x, end.y];
+    if (end.y < anchor.y) {
+      breakAt = {
+        ...breakAt,
+        id: breakAt.id,
+        y: end.y,
+        x: end.x + (start.x - breakAt.x),
+      };
     }
-    const linePath = smooth ? smoothPath : ['L', /** pointy break */ breakAt.x, breakAt.y].concat(['L', end.x, end.y]);
-
+    smoothPath = smoothPath.concat(['Q', breakAt.x, breakAt.y]).concat([end.x, end.y]);
+    const straightPath = ['L', /** pointy break */ breakAt.x, breakAt.y].concat(['L', end.x, end.y]);
+    const linePath = smooth ? smoothPath : straightPath;
     const path = ['M', start.x, start.y].concat(linePath);
+
     return path.join(',');
   }
 
-  /** 获取label offset, 默认 16px 不允许 <= 0 */
-  private getOffsetOfLabel(): number {
+  private getCrookDistance(): number {
     const labelOptions = this.get('labelOptions');
     const offset = labelOptions.offset;
-    return offset === undefined ? DEFAULT_OFFSET : offset <= CROOK_DISTANCE ? 1 : offset - CROOK_DISTANCE;
+    return offset < CROOK_DISTANCE * 2 ? offset / 2 : CROOK_DISTANCE;
   }
 
+  /** 获取label height */
+  private getLabelHeight(): number {
+    const labelOptions = this.get('labelOptions');
+    if (!labelOptions.labelHeight) {
+      const renderer = this.get('labelsRenderer');
+      const labels: Shape[] = renderer.get('group').get('children');
+      return _.head(labels) ? _.head(labels).getBBox().height : 14;
+    }
+    return labelOptions.labelHeight;
+  }
+
+  // tslint:disable
   public getDefaultOffset(point) {
     const offset = super.getDefaultOffset(point);
     return offset === undefined ? DEFAULT_OFFSET : offset <= CROOK_DISTANCE ? 1 : offset - CROOK_DISTANCE;
-  }
-
-  private getCrookDistance(): number {
-    const offset = this.getOffsetOfLabel();
-    return offset > CROOK_DISTANCE ? CROOK_DISTANCE : 0;
   }
 }
 

--- a/src/plots/pie/component/label/utils/index.ts
+++ b/src/plots/pie/component/label/utils/index.ts
@@ -38,41 +38,37 @@ export function getOverlapArea(a: Box, b: Box, margin = 0): number {
 }
 
 /**
- * Determine the index of quadrants which point placed by angle of point.
- * -------------
- * |  3  |  0  |
- * -------------
- * |  2  |  1  |
- * -------------
- *
- * @param {number} angle
- * @return {number} the index of quadrants, always in range `<0, 3>`
+ * 计算两个矩形之间的堆叠情况
+ * @return xOverlap x方向重叠大小
+ * @return yOverlap y方向重叠大小
  */
-export function getQuadrantByAngle(angle: number): number {
-  const left = angle > Math.PI / 2 || angle < -Math.PI / 2;
-  // fix angle > Math.PI
-  const top = angle < 0 || angle > Math.PI;
-  let index: number;
+export function getOverlapInfo(a: Box, b: Box, margin = 0): { xOverlap: number; yOverlap: number } {
+  let xOverlap = Math.max(
+    0,
+    Math.min(a.x + a.width + margin, b.x + b.width + margin) - Math.max(a.x - margin, b.x - margin)
+  );
+  let yOverlap = Math.max(
+    0,
+    Math.min(a.y + a.height + margin, b.y + b.height + margin) - Math.max(a.y - margin, b.y - margin)
+  );
 
-  if (left) {
-    if (top) {
-      // Top left
-      index = 3;
-    } else {
-      // Bottom left
-      index = 2;
-    }
-  } else {
-    if (top) {
-      // Top right
-      index = 0;
-    } else {
-      // Bottom right
-      index = 1;
-    }
+  // 添加 sign
+  if (xOverlap && a.x < b.x) {
+    xOverlap = -xOverlap;
+  }
+  if (yOverlap && a.y < b.y) {
+    yOverlap = -yOverlap;
   }
 
-  return index;
+  // 重叠
+  if (a.x === b.x && a.width === b.width) {
+    xOverlap = b.width;
+  }
+  if (a.y === b.y && a.height === b.height) {
+    yOverlap = b.height;
+  }
+
+  return { xOverlap, yOverlap };
 }
 
 /**
@@ -88,3 +84,10 @@ export function inPanel(panel: Box, shape: Box) {
     panel.y + panel.height > shape.y + shape.height
   );
 }
+
+/**
+ * 判断两个数值 是否接近
+ * - 解决精度问题（由于无法确定精度上限，根据具体场景可传入 精度 参数）
+ */
+export const near = (x: number, y: number, e: number = Number.EPSILON ** 0.5): boolean =>
+  [x, y].includes(Infinity) ? Math.abs(x) === Math.abs(y) : Math.abs(x - y) < e;

--- a/src/plots/pie/component/label/utils/text.ts
+++ b/src/plots/pie/component/label/utils/text.ts
@@ -30,8 +30,9 @@ export const measureTextWidth = _.memoize(
  * @param text 需要计算的文本, 由于历史原因 除了支持string，还支持空值,number和数组等
  * @param maxWidth
  * @param font
+ * TODO 后续更新省略算法
  */
-export const getEllipsisText = (text: any, maxWidth: number, font?: Font) => {
+export const getEllipsisText = (text: any, maxWidth: number, font: Font, priority?: string[]) => {
   const STEP = 16; // 每次 16，调参工程师
   const DOT_WIDTH = measureTextWidth('...', font);
 

--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -6,7 +6,6 @@ import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { getComponent } from '../../components/factory';
 import { getGeom } from '../../geoms/factory';
 import { Label, DataItem } from '../../interface/config';
-import { extractScale } from '../../util/scale';
 import SpiderLabel from './component/label/spider-label';
 import './component/label/outer-label';
 import * as EventParser from './event';
@@ -23,7 +22,18 @@ export interface PieViewConfig extends ViewConfig {
   colorField?: string;
   radius?: number;
   pieStyle?: PieStyle | ((...args: any[]) => PieStyle);
+  label?: PieLabel;
 }
+
+type PieLabel = ViewConfig['label'] & {
+  /** label leader-line */
+  line?: {
+    smooth?: boolean;
+  };
+  /** allow label overlap */
+  allowOverlap?: boolean;
+  readonly fields?: string[];
+};
 
 export interface PieLayerConfig extends PieViewConfig, LayerConfig {}
 
@@ -53,6 +63,10 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
         visible: true,
         type: 'inner',
         autoRotate: false,
+        allowOverlap: false,
+        line: {
+          smooth: true,
+        },
       },
       legend: {
         visible: true,


### PR DESCRIPTION
详细见 commit 记录

> 备注：此版 是 目前DI上线的label, todo 部分在 DI 先上线，年前再下沉至 G2Plot

其他后续处理
- [ ] 新增的配置项，更新至文档
- [ ] outer-label 根据占比权重作为显示的优先级（由于单纯处理labels的排序不足，还需要对labelLine进行排序，放到下次再处理）
- [ ] 按照优先级(数值 > 占比  > 分类名称)显示label省略文本

close #485 

![image](https://user-images.githubusercontent.com/15646325/72035325-85f26e00-32d2-11ea-8b34-dd615019897a.png)
