### PR TITLE
fix: 修复 dark 下图表 label 问题 issue #489

### DIFF
--- a/demos/radar-series.ts
+++ b/demos/radar-series.ts
@@ -107,6 +107,7 @@ const radarPlot = new g2plot.Radar(document.getElementById('canvas'), {
   angleField: 'item',
   radiusField: 'score',
   seriesField: 'user',
+  theme: 'dark',
 });
 radarPlot.render();
 

--- a/src/plots/bar/component/label/bar-label.ts
+++ b/src/plots/bar/component/label/bar-label.ts
@@ -136,7 +136,9 @@ export class BarLabels extends ElementLabels {
         label.attr('lineWidth', 2);
       }
     } else if (labelRange.maxY < shapeRange.minY) {
-      label.attr('fill', 'black');
+      const theme = this.get('theme');
+      const labelTextColor = _.get(theme, 'label.textStyle.fill', 'black');
+      label.attr('fill', labelTextColor);
     }
   }
 

--- a/src/plots/column/component/label/column-label.ts
+++ b/src/plots/column/component/label/column-label.ts
@@ -134,7 +134,10 @@ export class ColumnLabels extends ElementLabels {
         label.attr('lineWidth', 2);
       }
     } else if (labelRange.maxY < shapeRange.minY) {
-      label.attr('fill', 'black');
+      // 非 shape 范围内的 label 需要考虑主题背景
+      const theme = this.get('theme');
+      const labelTextColor = _.get(theme, 'label.textStyle.fill', 'black');
+      label.attr('fill', labelTextColor);
     }
   }
 

--- a/src/plots/radar/layer.ts
+++ b/src/plots/radar/layer.ts
@@ -114,10 +114,6 @@ export default class RadarLayer extends ViewLayer<RadarLayerConfig> {
         label: {
           visible: true,
           offset: 8,
-          textStyle: {
-            fill: '#000',
-            opacity: 0.65,
-          },
         },
         title: {
           visible: false,

--- a/src/plots/scatter/components/label/scatter-label.ts
+++ b/src/plots/scatter/components/label/scatter-label.ts
@@ -109,7 +109,9 @@ export class ScatterLabels extends ElementLabels {
       const reflect = this._mappingColor(colorBand, gray);
       label.attr('fill', reflect);
     } else if (labelRange.maxY < shapeRange.minY) {
-      label.attr('fill', 'black');
+      const theme = this.get('theme');
+      const labelTextColor = _.get(theme, 'label.textStyle.fill', 'black');
+      label.attr('fill', labelTextColor);
     }
   }
 

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -65,7 +65,7 @@ export const DEFAULT_DARK_THEME = {
       label: {
         visible: true,
         offset: 8,
-        style: {
+        textStyle: {
           fill: 'rgba(255, 255, 255, 0.45)',
           fontSize: 12,
         },
@@ -110,7 +110,7 @@ export const DEFAULT_DARK_THEME = {
       },
       label: {
         visible: true,
-        style: {
+        textStyle: {
           fill: 'rgba(255, 255, 255, 0.65)',
           fontSize: 12,
         },
@@ -153,7 +153,7 @@ export const DEFAULT_DARK_THEME = {
       },
       label: {
         offset: 16,
-        style: {
+        textStyle: {
           fill: '#a0a4aa',
           fontSize: 12,
         },
@@ -161,6 +161,15 @@ export const DEFAULT_DARK_THEME = {
       title: {
         offset: 12,
         style: { fill: '#767b84', fontSize: 12 },
+      },
+    },
+    radius: {
+      label: {
+        offset: 12,
+        textStyle: {
+          fill: '#a0a4aa',
+          fontSize: 12,
+        },
       },
     },
   },
@@ -172,6 +181,9 @@ export const DEFAULT_DARK_THEME = {
   },
   label: {
     offset: 12,
+    textStyle: {
+      fill: 'rgba(255, 255, 255, 0.65)',
+    },
     style: {
       fill: 'rgba(255, 255, 255, 0.65)',
       lineWidth: 1,

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -130,7 +130,7 @@ export const DEFAULT_GLOBAL_THEME = {
       label: {
         visible: true,
         offset: 8,
-        style: {
+        textStyle: {
           fill: 'rgba(0,0,0,0.45)',
           fontSize: 12,
         },
@@ -176,7 +176,7 @@ export const DEFAULT_GLOBAL_THEME = {
       },
       label: {
         visible: true,
-        style: {
+        textStyle: {
           fill: 'rgba(0,0,0,0.45)',
           fontSize: 12,
         },
@@ -216,7 +216,7 @@ export const DEFAULT_GLOBAL_THEME = {
       },
       label: {
         offset: 16,
-        style: {
+        textStyle: {
           fill: 'rgba(0,0,0,0.45)',
           fontSize: 12,
         },
@@ -224,6 +224,14 @@ export const DEFAULT_GLOBAL_THEME = {
       title: {
         offset: 12,
         style: { fill: 'rgba(0, 0, 0, 0.65)', fontSize: 12 },
+      },
+    },
+    radius: {
+      label: {
+        textStyle: {
+          fill: 'rgba(0,0,0,0.45)',
+          fontSize: 12,
+        },
       },
     },
   },
@@ -236,6 +244,9 @@ export const DEFAULT_GLOBAL_THEME = {
   },
   label: {
     offset: 12,
+    textStyle: {
+      fill: 'rgba(0, 0, 0, 0.65)',
+    },
     style: {
       fill: 'rgba(0, 0, 0, 0.65)',
       stroke: '#ffffff',


### PR DESCRIPTION
1. 雷达图去除默认配置中的 label 配置，使用全局主题配置。另外：G2DefaultTheme 结构与 plotG2Theme 结构不一致，是否会存在问题？ @zqlu 需要关注一下

2. label 使用 adjustColor 时，当 label 处于 shape 外，需要考虑全局背景的影响，使用主题中的 label 颜色

![image](https://user-images.githubusercontent.com/9314735/72131189-83694480-33b6-11ea-84d2-c21625369c73.png)
![image](https://user-images.githubusercontent.com/9314735/72131145-63398580-33b6-11ea-89e3-214bdf6d879f.png)

