### PR TITLE
迁移 step line

### DIFF
--- a/__tests__/unit/plots/step/index-spec.ts
+++ b/__tests__/unit/plots/step/index-spec.ts
@@ -1,44 +1,16 @@
 import { StepLine } from '../../../../src';
-import ViewLayer from '../../../../src/base/view-layer';
 import { StepLineLayer } from '../../../../src/plots/step-line/layer';
 
 const data = [
-  {
-    year: '1991',
-    value: 3,
-  },
-  {
-    year: '1992',
-    value: 4,
-  },
-  {
-    year: '1993',
-    value: 3.5,
-  },
-  {
-    year: '1994',
-    value: 5,
-  },
-  {
-    year: '1995',
-    value: 4.9,
-  },
-  {
-    year: '1996',
-    value: 6,
-  },
-  {
-    year: '1997',
-    value: 7,
-  },
-  {
-    year: '1998',
-    value: 9,
-  },
-  {
-    year: '1999',
-    value: 13,
-  },
+  { year: '1991', value: 3 },
+  { year: '1992', value: 4 },
+  { year: '1993', value: 3.5 },
+  { year: '1994', value: 5 },
+  { year: '1995', value: 4.9 },
+  { year: '1996', value: 6 },
+  { year: '1997', value: 7 },
+  { year: '1998', value: 9 },
+  { year: '1999', value: 13 },
 ];
 
 describe('Step plot', () => {
@@ -50,7 +22,7 @@ describe('Step plot', () => {
   canvasDiv.id = 'canvas1';
   document.body.appendChild(canvasDiv);
 
-  it.skip('step', () => {
+  it('step', () => {
     const step = new StepLine(canvasDiv, {
       width: 600,
       height: 600,
@@ -63,7 +35,7 @@ describe('Step plot', () => {
     const layer = step.getLayer() as StepLineLayer;
     const plot = layer.getPlot();
 
-    const positionField = plot.get('elements')[0].get('position').fields;
+    const positionField = plot.geometries[0].getAttribute('position').getFields();
     expect(step).toBeInstanceOf(StepLine);
     expect(positionField[0]).toBe('year');
     expect(positionField[1]).toBe('value');

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "event-simulate": "^1.0.0",
     "gatsby": "^2.19.15",
     "gh-pages": "^2.1.1",
-    "husky": "^4.2.1",
+    "husky": "^4.2.3",
     "jest": "^24.9.0",
     "jest-electron": "^0.1.7",
     "jest-extended": "^0.11.2",

--- a/src/base/controller/canvas.ts
+++ b/src/base/controller/canvas.ts
@@ -1,6 +1,6 @@
 import { modifyCSS } from '@antv/dom-util';
 import { Canvas } from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { debounce, get } from '@antv/util';
 import ResizeObserver from 'resize-observer-polyfill';
 import { getGlobalTheme } from '../../theme/global';
 import BasePlot from '../plot';
@@ -30,7 +30,7 @@ export default class CanvasController {
   /**
    * when the container size changed, trigger it after 300ms.
    */
-  private onResize = _.debounce(() => {
+  private onResize = debounce(() => {
     if (this.plot.destroyed) {
       return;
     }
@@ -97,7 +97,7 @@ export default class CanvasController {
   public updateCanvasTheme() {
     const { theme } = this.plot;
     const globalTheme = ThemeController.getGlobalTheme(theme);
-    const fill: string = _.get(globalTheme, 'backgroundStyle.fill');
+    const fill: string = get(globalTheme, 'backgroundStyle.fill');
     if (fill) {
       this.updateCanvasStyle({
         backgroundColor: fill,

--- a/src/base/controller/event.ts
+++ b/src/base/controller/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { wrapBehavior, each, contains } from '@antv/util';
 import { IElement, ICanvas, IShape } from '@antv/g-canvas';
 import BBox from '../../util/bbox';
 import BasePlot from '../plot';
@@ -52,18 +52,18 @@ export default class EventController {
   }
 
   public bindEvents() {
-    this.addEvent(this.canvas, 'mousedown', _.wrapBehavior(this, 'onEvents'));
-    this.addEvent(this.canvas, 'mousemove', _.wrapBehavior(this, 'onMove'));
-    this.addEvent(this.canvas, 'mouseup', _.wrapBehavior(this, 'onEvents'));
-    this.addEvent(this.canvas, 'click', _.wrapBehavior(this, 'onEvents'));
-    this.addEvent(this.canvas, 'dblclick', _.wrapBehavior(this, 'onEvents'));
-    this.addEvent(this.canvas, 'contextmenu', _.wrapBehavior(this, 'onEvents'));
-    this.addEvent(this.canvas, 'wheel', _.wrapBehavior(this, 'onEvents'));
+    this.addEvent(this.canvas, 'mousedown', wrapBehavior(this, 'onEvents'));
+    this.addEvent(this.canvas, 'mousemove', wrapBehavior(this, 'onMove'));
+    this.addEvent(this.canvas, 'mouseup', wrapBehavior(this, 'onEvents'));
+    this.addEvent(this.canvas, 'click', wrapBehavior(this, 'onEvents'));
+    this.addEvent(this.canvas, 'dblclick', wrapBehavior(this, 'onEvents'));
+    this.addEvent(this.canvas, 'contextmenu', wrapBehavior(this, 'onEvents'));
+    this.addEvent(this.canvas, 'wheel', wrapBehavior(this, 'onEvents'));
   }
 
   public clearEvents() {
     const eventHandlers = this.eventHandlers;
-    _.each(eventHandlers, (eh) => {
+    each(eventHandlers, (eh) => {
       eh.target.off(eh.type, eh.handler);
     });
   }
@@ -116,7 +116,7 @@ export default class EventController {
     let parent = shape.get('parent');
     while (parent) {
       const parentName = parent.get('name');
-      if (parentName && _.contains(groupName, parentName)) {
+      if (parentName && contains(groupName, parentName)) {
         return true;
       }
       parent = parent.get('parent');
@@ -135,7 +135,7 @@ export default class EventController {
   }
 
   private onLayerEvent(layers: Layer[], eventObj: EventObj, eventName: string) {
-    _.each(layers, (layer) => {
+    each(layers, (layer) => {
       const bbox = layer.getGlobalBBox();
       if (isPointInBBox({ x: eventObj.x, y: eventObj.y }, bbox)) {
         layer.emit(`${eventName}`, eventObj);

--- a/src/base/controller/padding.ts
+++ b/src/base/controller/padding.ts
@@ -1,6 +1,6 @@
 import { IElement } from '@antv/g-canvas';
 import { View } from '@antv/g2';
-import * as _ from '@antv/util';
+import { filter, each, isArray, clone } from '@antv/util';
 import ViewLayer from '../view-layer';
 import { MarginPadding } from '../../interface/types';
 import BBox from '../../util/bbox';
@@ -52,11 +52,11 @@ export default class PaddingController {
     this.innerPaddingComponents = [];
     // 一些组件是在view渲染完成之后渲染初始化的
     // TODO: afterRender的什么时候清除
-    this.outerPaddingComponents = _.filter(this.outerPaddingComponents, (component) => component.afterRender);
+    this.outerPaddingComponents = filter(this.outerPaddingComponents, (component) => component.afterRender);
   }
 
   public clearOuterComponents() {
-    _.each(this.outerPaddingComponents, (component) => {
+    each(this.outerPaddingComponents, (component) => {
       if (component.afterRender) {
         component.destroy();
       }
@@ -87,7 +87,7 @@ export default class PaddingController {
     let viewMaxX = this.plot.layerBBox.maxX;
     let viewMinY = this.plot.layerBBox.minY;
     let viewMaxY = this.plot.layerBBox.maxY;
-    _.each(this.outerPaddingComponents, (component) => {
+    each(this.outerPaddingComponents, (component) => {
       const { position } = component;
       const { minX, maxX, minY, maxY } = component.getBBox();
       if (maxY >= viewMinY && maxY <= viewMaxY && position === 'top') {
@@ -112,15 +112,15 @@ export default class PaddingController {
     const viewRange: any = view.viewBBox;
     const { maxX, maxY } = viewRange;
     const bleeding = this.plot.config.theme.bleeding;
-    if (_.isArray(bleeding)) {
-      _.each(bleeding, (it, index) => {
+    if (isArray(bleeding)) {
+      each(bleeding, (it, index) => {
         if (typeof bleeding[index] === 'function') {
           bleeding[index] = bleeding[index](props);
         }
       });
     }
     this.plot.config.theme.legend.margin = bleeding;
-    this.bleeding = _.clone(bleeding);
+    this.bleeding = clone(bleeding);
     // 参与auto padding的components: axis legend
     const components_bbox = [view.coordinateBBox];
     this._getAxis(view, components_bbox);
@@ -129,7 +129,7 @@ export default class PaddingController {
     box = this._mergeBBox(components_bbox);
     // 参与auto padding的自定义组件
     const components = this.innerPaddingComponents;
-    _.each(components, (obj) => {
+    each(components, (obj) => {
       const component = obj;
       const bbox = component.getBBox();
       components_bbox.push(bbox);
@@ -159,7 +159,7 @@ export default class PaddingController {
   private _getAxis(view, bboxes) {
     const axesContainer = view.getController('axis').axisContainer.get('children');
     if (axesContainer.length > 0) {
-      _.each(axesContainer, (a) => {
+      each(axesContainer, (a) => {
         const bbox = a.getBBox();
         bboxes.push(bbox);
       });
@@ -170,7 +170,7 @@ export default class PaddingController {
     const viewRange = view.viewBBox;
     const legends = view.get('legendController').legends;
     if (legends.length > 0) {
-      _.each(legends, (l) => {
+      each(legends, (l) => {
         const legend = l;
         this._adjustLegend(legend, view, box);
         const legendBBox = legend.getBBox();
@@ -205,7 +205,7 @@ export default class PaddingController {
   private _getPanel(view, box) {
     const groups = [];
     const geoms = view.get('elements');
-    _.each(geoms, (geom) => {
+    each(geoms, (geom) => {
       if (geom.get('labelController')) {
         const labelContainer = geom.get('labelController').labelsContainer;
         if (labelContainer) {
@@ -217,7 +217,7 @@ export default class PaddingController {
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
-    _.each(groups, (group) => {
+    each(groups, (group) => {
       const children = group.get('children');
       children.forEach((child) => {
         if (child.type === 'group' && child.get('children').length === 0) {
@@ -273,7 +273,7 @@ export default class PaddingController {
     let minY = Infinity;
     let maxY = -Infinity;
 
-    _.each(bboxes, (bbox) => {
+    each(bboxes, (bbox) => {
       const box = bbox;
       minX = Math.min(box.minX, minX);
       maxX = Math.max(box.maxX, maxX);

--- a/src/base/controller/state.ts
+++ b/src/base/controller/state.ts
@@ -2,15 +2,15 @@
  * stateManager负责stateManager的创建/绑定，对状态量更新的响应
  */
 import { IGroup, IShape } from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { isFunction, assign, each, isArray, mix, clone } from '@antv/util';
 import { getComponentStateMethod } from '../../components/factory';
 import { onEvent } from '../../util/event';
 import StateManager from '../../util/state-manager';
 
 export function compare(origin, condition) {
-  if (!_.isFunction(condition)) {
+  if (!isFunction(condition)) {
     const { name, exp } = condition;
-    if (_.isFunction(exp)) {
+    if (isFunction(exp)) {
       return exp(origin[name]);
     }
     return origin[name] === exp;
@@ -26,7 +26,7 @@ export default class StateController {
   private shapeContainers: IGroup[] = [];
 
   constructor(cfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
   }
 
   public createStateManager(cfg) {
@@ -44,7 +44,7 @@ export default class StateController {
   }
 
   public defaultStates(states) {
-    _.each(states, (state, type) => {
+    each(states, (state, type) => {
       const { condition, style, related } = state;
       this.setState({ type, condition, related });
     });
@@ -57,18 +57,18 @@ export default class StateController {
       this.originAttrs = this._getOriginAttrs();
     }
     // this.resetZIndex();
-    _.each(this.shapes, (shape, index) => {
+    each(this.shapes, (shape, index) => {
       const shapeOrigin = shape.get('origin');
-      const origin = _.isArray(shapeOrigin) ? shapeOrigin[0]._origin : shapeOrigin._origin;
+      const origin = isArray(shapeOrigin) ? shapeOrigin[0]._origin : shapeOrigin._origin;
 
       if (compare(origin, condition)) {
         const stateStyle = cfg.style ? cfg.style : this._getDefaultStateStyle(type, shape);
         const originAttr = this.originAttrs[index];
         let attrs;
-        if (_.isFunction(stateStyle)) {
+        if (isFunction(stateStyle)) {
           attrs = stateStyle(originAttr);
         } else {
-          attrs = _.mix({}, originAttr, stateStyle);
+          attrs = mix({}, originAttr, stateStyle);
         }
         shape.attr(attrs);
         this.setZIndex(type, shape);
@@ -84,10 +84,10 @@ export default class StateController {
   }
 
   private _updateStateProcess(setStateCfg) {
-    _.each(setStateCfg, (cfg: any) => {
+    each(setStateCfg, (cfg: any) => {
       const state = cfg.state;
       let handler;
-      if (_.isFunction(state)) {
+      if (isFunction(state)) {
         handler = (e) => {
           const s = state(e);
           this.stateManager.setState(s.name, s.exp);
@@ -106,7 +106,7 @@ export default class StateController {
   }
 
   private _stateChangeProcess(onChangeCfg) {
-    _.each(onChangeCfg, (cfg: any) => {
+    each(onChangeCfg, (cfg: any) => {
       this.stateManager.on(`${cfg.name}:change`, (props) => {
         cfg.callback(props, this.plot);
       });
@@ -116,7 +116,7 @@ export default class StateController {
   private _getShapes() {
     const shapes = [];
     const geoms = this.plot.view.get('elements');
-    _.each(geoms, (geom: any) => {
+    each(geoms, (geom: any) => {
       const shapeContainer = geom.get('shapeContainer');
       this.shapeContainers.push(shapeContainer);
       if (!geom.destroyed) {
@@ -128,8 +128,8 @@ export default class StateController {
 
   private _getOriginAttrs() {
     const attrs = [];
-    _.each(this.shapes, (shape) => {
-      attrs.push(_.clone(shape.attr()));
+    each(this.shapes, (shape) => {
+      attrs.push(clone(shape.attr()));
     });
     return attrs;
   }
@@ -148,7 +148,7 @@ export default class StateController {
     const styleField = `${plotGeomType}Style`;
     if (theme[styleField]) {
       let style = theme[styleField][type];
-      if (_.isFunction(style)) {
+      if (isFunction(style)) {
         style = style(shape.attr());
       }
       return style;
@@ -157,7 +157,7 @@ export default class StateController {
   }
 
   private _parserRelated(type, related, condition) {
-    _.each(related, (r) => {
+    each(related, (r) => {
       if (this.plot[r]) {
         // fixme: 自定义组件
         // this.plot[r].setState(type, condition);
@@ -178,7 +178,7 @@ export default class StateController {
   }
 
   private resetZIndex() {
-    _.each(this.shapeContainers, (container) => {
+    each(this.shapeContainers, (container) => {
       const children = container.get('children');
       children.sort((obj1, obj2) => {
         return obj1._INDEX - obj2._INDEX;

--- a/src/base/controller/theme.ts
+++ b/src/base/controller/theme.ts
@@ -1,5 +1,5 @@
 import * as G2 from '@antv/g2';
-import * as _ from '@antv/util';
+import { isString, deepMix } from '@antv/util';
 // import Theme from '../../theme';
 import { convertToG2Theme, getGlobalTheme, getTheme } from '../../theme';
 import { processAxisVisible } from '../../util/axis';
@@ -18,10 +18,10 @@ export default class ThemeController<T extends ViewConfig = ViewConfig> {
    * @param theme
    */
   public static getGlobalTheme(theme: string | object) {
-    if (_.isString(theme)) {
+    if (isString(theme)) {
       return getGlobalTheme(theme);
     }
-    return _.deepMix({}, getGlobalTheme(), theme);
+    return deepMix({}, getGlobalTheme(), theme);
   }
 
   /**
@@ -31,10 +31,10 @@ export default class ThemeController<T extends ViewConfig = ViewConfig> {
    */
   public getPlotTheme(props: T, type: string) {
     const { theme } = props;
-    if (_.isString(theme)) {
-      return _.deepMix({}, getGlobalTheme(theme), getTheme(type));
+    if (isString(theme)) {
+      return deepMix({}, getGlobalTheme(theme), getTheme(type));
     }
-    return _.deepMix({}, getGlobalTheme(), getTheme(type), theme);
+    return deepMix({}, getGlobalTheme(), getTheme(type), theme);
   }
 
   /**
@@ -44,7 +44,7 @@ export default class ThemeController<T extends ViewConfig = ViewConfig> {
    */
   public getTheme(props: T, type: string): any {
     const plotG2Theme = convertToG2Theme(this.getPlotTheme(props, type));
-    const g2Theme = _.deepMix({}, G2DefaultTheme, plotG2Theme);
+    const g2Theme = deepMix({}, G2DefaultTheme, plotG2Theme);
     // this._processVisible(g2Theme);
     return g2Theme;
   }

--- a/src/base/layer.ts
+++ b/src/base/layer.ts
@@ -1,6 +1,6 @@
 import EventEmitter from '@antv/event-emitter';
 import * as G from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { deepMix, each, findIndex, keys, contains, isFunction } from '@antv/util';
 import { Point } from '../interface/config';
 import { LAYER_EVENT_MAP } from '../util/event';
 import BBox from '../util/bbox';
@@ -75,7 +75,7 @@ export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmi
   }
 
   public updateConfig(cfg: Partial<T>): void {
-    this.options = _.deepMix({}, this.options, cfg);
+    this.options = deepMix({}, this.options, cfg);
     this.processOptions(this.options);
   }
 
@@ -135,7 +135,7 @@ export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmi
     this.eachLayer((layer) => {
       layer.destroy();
     });
-    _.each(this.eventHandlers, (h) => {
+    each(this.eventHandlers, (h) => {
       this.off(h.eventName, h.handler);
     });
     this.container.remove(true);
@@ -163,7 +163,7 @@ export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmi
    * @param layer
    */
   public addLayer(layer: Layer<any>) {
-    const idx = _.findIndex(this.layers, (item) => item === layer);
+    const idx = findIndex(this.layers, (item) => item === layer);
     if (idx < 0) {
       if (layer.parent !== this) {
         layer.parent = this;
@@ -178,7 +178,7 @@ export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmi
    * @param layer
    */
   public removeLayer(layer: Layer<any>) {
-    const idx = _.findIndex(this.layers, (item) => item === layer);
+    const idx = findIndex(this.layers, (item) => item === layer);
     if (idx >= 0) {
       this.layers.splice(idx, 1);
     }
@@ -196,7 +196,7 @@ export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmi
       width: this.width,
       height: this.height,
     };
-    const newRange = _.deepMix({}, originRange, props);
+    const newRange = deepMix({}, originRange, props);
     this.x = newRange.x;
     this.y = newRange.y;
     this.width = newRange.width;
@@ -258,17 +258,17 @@ export default class Layer<T extends LayerConfig = LayerConfig> extends EventEmi
       width: parentWidth,
       height: parentHeight,
     };
-    return _.deepMix({}, defaultOptions, props);
+    return deepMix({}, defaultOptions, props);
   }
 
   public eachLayer(cb: (layer: Layer<any>) => void) {
-    _.each(this.layers, cb);
+    each(this.layers, cb);
   }
 
   protected parseEvents(eventParser?) {
-    const eventsName = _.keys(LAYER_EVENT_MAP);
-    _.each(eventParser, (e, k) => {
-      if (_.contains(eventsName, k) && _.isFunction(e)) {
+    const eventsName = keys(LAYER_EVENT_MAP);
+    each(eventParser, (e, k) => {
+      if (contains(eventsName, k) && isFunction(e)) {
         const eventName = LAYER_EVENT_MAP[k] || k;
         const handler = e;
         this.on(eventName, handler);

--- a/src/base/plot.ts
+++ b/src/base/plot.ts
@@ -1,6 +1,6 @@
 import EventEmitter from '@antv/event-emitter';
 import * as G from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { isNil, each, findIndex, deepMix, keys, contains, isFunction } from '@antv/util';
 import { RecursivePartial, LooseMap } from '../interface/types';
 import StateManager from '../util/state-manager';
 import CanvasController from './controller/canvas';
@@ -36,7 +36,7 @@ export default class BasePlot<T extends PlotConfig = PlotConfig> extends EventEm
   constructor(container: HTMLElement, props: T) {
     super();
     this.containerDOM = typeof container === 'string' ? document.getElementById(container) : container;
-    this.forceFit = !_.isNil(props.forceFit) ? props.forceFit : _.isNil(props.width) && _.isNil(props.height);
+    this.forceFit = !isNil(props.forceFit) ? props.forceFit : isNil(props.width) && isNil(props.height);
     this.renderer = props.renderer || 'canvas';
     this.pixelRatio = props.pixelRatio || null;
     this.width = props.width;
@@ -210,7 +210,7 @@ export default class BasePlot<T extends PlotConfig = PlotConfig> extends EventEm
   }
 
   protected eachLayer(cb: (layer: Layer<any>) => void) {
-    _.each(this.layers, cb);
+    each(this.layers, cb);
   }
 
   /**
@@ -218,7 +218,7 @@ export default class BasePlot<T extends PlotConfig = PlotConfig> extends EventEm
    * @param layer
    */
   public addLayer(layer: Layer<any>) {
-    const idx = _.findIndex(this.layers, (item) => item === layer);
+    const idx = findIndex(this.layers, (item) => item === layer);
     if (idx < 0) {
       this.layers.push(layer);
     }
@@ -229,7 +229,7 @@ export default class BasePlot<T extends PlotConfig = PlotConfig> extends EventEm
       // TODO: combo plot
     } else if (props.type) {
       const viewLayerCtr = getPlotType(props.type);
-      const viewLayerProps: T = _.deepMix({}, props, {
+      const viewLayerProps: T = deepMix({}, props, {
         canvas: this.canvasController.canvas,
         x: 0,
         y: 0,
@@ -242,10 +242,10 @@ export default class BasePlot<T extends PlotConfig = PlotConfig> extends EventEm
   }
 
   protected parseEvents(props) {
-    const eventsName = _.keys(CANVAS_EVENT_MAP);
+    const eventsName = keys(CANVAS_EVENT_MAP);
     if (props.events) {
-      _.each(props.events, (e, k) => {
-        if (_.contains(eventsName, k) && _.isFunction(e)) {
+      each(props.events, (e, k) => {
+        if (contains(eventsName, k) && isFunction(e)) {
           const eventName = CANVAS_EVENT_MAP[k] || k;
           const handler = e;
           this.on(eventName, handler);

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -1,6 +1,6 @@
 import * as G from '@antv/g-canvas';
 import * as G2 from '@antv/g2';
-import * as _ from '@antv/util';
+import { deepMix, isEmpty, mapValues, get, isUndefined, each, assign, isFunction, mix } from '@antv/util';
 import TextDescription from '../components/description';
 import { getComponent } from '../components/factory';
 import BaseInteraction, { InteractionCtor } from '../interaction/index';
@@ -149,7 +149,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
   constructor(props: T) {
     super(props);
     this.options = this.getOptions(props);
-    this.initialOptions = _.deepMix({}, this.options);
+    this.initialOptions = deepMix({}, this.options);
     this.paddingController = new PaddingController({
       plot: this,
     });
@@ -163,7 +163,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions(props);
-    return _.deepMix({}, options, defaultOptions, props);
+    return deepMix({}, options, defaultOptions, props);
   }
 
   public beforeInit() {
@@ -259,7 +259,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
   public render(): void {
     super.render();
     const { data } = this.options;
-    if (!_.isEmpty(data)) {
+    if (!isEmpty(data)) {
       this.view.render();
     }
   }
@@ -276,7 +276,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
     if (!cfg.padding && this.initialOptions.padding && this.initialOptions.padding === 'auto') {
       cfg.padding = 'auto';
     }
-    this.options = _.deepMix({}, this.options, cfg);
+    this.options = deepMix({}, this.options, cfg);
     this.processOptions(this.options);
   }
 
@@ -345,11 +345,11 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
     /** scale meta配置 */
     // 1. this.config.scales中已有子图形在处理xAxis/yAxis是写入的xField/yField对应的scale信息，这里再检查用户设置的meta，将meta信息合并到默认的scale中
     // 2. 同时xAxis/yAxis中的type优先级更高，覆盖meta中的type配置
-    const scaleTypes = _.mapValues(this.config.scales, (scaleConfig: any) => {
+    const scaleTypes = mapValues(this.config.scales, (scaleConfig: any) => {
       const type = scaleConfig.type;
       return type ? { type } : {};
     });
-    const scales = _.deepMix({}, this.config.scales, this.options.meta || {}, scaleTypes);
+    const scales = deepMix({}, this.config.scales, this.options.meta || {}, scaleTypes);
 
     this.setConfig('scales', scales);
   }
@@ -376,9 +376,9 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
       return;
     }
 
-    this.setConfig('tooltip', _.deepMix({}, _.get(this.options, 'tooltip')));
+    this.setConfig('tooltip', deepMix({}, get(this.options, 'tooltip')));
 
-    _.deepMix(this.config.theme.tooltip, this.options.tooltip.style);
+    deepMix(this.config.theme.tooltip, this.options.tooltip.style);
   }
 
   protected legend(): void {
@@ -386,15 +386,15 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
       this.setConfig('legends', false);
       return;
     }
-    const flipOption = _.get(this.options, 'legend.flipPage');
-    const clickable = _.get(this.options, 'legend.clickable');
+    const flipOption = get(this.options, 'legend.flipPage');
+    const clickable = get(this.options, 'legend.clickable');
     this.setConfig('legends', {
-      position: _.get(this.options, 'legend.position'),
-      formatter: _.get(this.options, 'legend.formatter'),
-      offsetX: _.get(this.options, 'legend.offsetX'),
-      offsetY: _.get(this.options, 'legend.offsetY'),
-      clickable: _.isUndefined(clickable) ? true : clickable,
-      // wordSpacing: _.get(this.options, 'legend.wordSpacing'),
+      position: get(this.options, 'legend.position'),
+      formatter: get(this.options, 'legend.formatter'),
+      offsetX: get(this.options, 'legend.offsetX'),
+      offsetY: get(this.options, 'legend.offsetY'),
+      clickable: isUndefined(clickable) ? true : clickable,
+      // wordSpacing: get(this.options, 'legend.wordSpacing'),
       flipPage: flipOption,
     });
   }
@@ -402,7 +402,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
   protected annotation() {
     const config = [];
     if (this.config.coordinate.type === 'cartesian' && this.options.guideLine) {
-      _.each(this.options.guideLine, (line) => {
+      each(this.options.guideLine, (line) => {
         const guideLine = getComponent('guideLine', {
           plot: this,
           cfg: line,
@@ -460,7 +460,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
       this.config[key] = false;
       return;
     }
-    _.assign(this.config[key], config);
+    assign(this.config[key], config);
   }
 
   protected parseEvents(eventParser?): void {
@@ -468,8 +468,8 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
     if (options.events) {
       super.parseEvents(options.events);
       const eventmap = eventParser ? eventParser.EVENT_MAP : EVENT_MAP;
-      _.each(options.events, (e, k) => {
-        if (_.isFunction(e)) {
+      each(options.events, (e, k) => {
+        if (isFunction(e)) {
           const eventName = eventmap[k] || k;
           const handler = e;
           onEvent(this, eventName, handler);
@@ -493,7 +493,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
         leftMargin: range.minX + theme.title.padding[3],
         topMargin: range.minY + theme.title.padding[0],
         text: props.title.text,
-        style: _.mix(theme.title, props.title.style),
+        style: mix(theme.title, props.title.style),
         wrapperWidth: width - theme.title.padding[3] - theme.title.padding[1],
         container: this.container.addGroup() as any,
         theme,
@@ -532,7 +532,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
         leftMargin: range.minX + theme.description.padding[3],
         topMargin,
         text: props.description.text,
-        style: _.mix(theme.description, props.description.style),
+        style: mix(theme.description, props.description.style),
         wrapperWidth: width - theme.description.padding[3] - theme.description.padding[1],
         container: this.container.addGroup() as any,
         theme,

--- a/src/components/axis/parser.ts
+++ b/src/components/axis/parser.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, isFunction, get } from '@antv/util';
 import { ViewLayer } from '../..';
 import { IBaseAxis } from '../../interface/config';
 import { combineFormatter, getNoopFormatter, getPrecisionFormatter, getSuffixFormatter } from '../../util/formatter';
@@ -55,7 +55,7 @@ export default class AxisParser {
     /** 如果在图表配置项里没有设置坐标轴整体的visibility则去对应的theme取 */
     const propos = this.plot.options;
     const propsConfig = propos[`${this.dim}Axis`] ? propos[`${this.dim}Axis`] : {};
-    const config = _.deepMix({}, this.themeConfig, propsConfig);
+    const config = deepMix({}, this.themeConfig, propsConfig);
     this.localProps = config;
     if (config.visible) {
       return true;
@@ -75,10 +75,10 @@ export default class AxisParser {
     const { grid: gridCfg } = this.localProps;
     const { style } = gridCfg;
 
-    if (_.isFunction(style)) {
+    if (isFunction(style)) {
       this.config.grid = (text: string, index: number, count: number) => {
         const cfg = style(text, index, count);
-        return { line: { style: _.deepMix({}, _.get(this.themeConfig, `grid.style`), cfg) } };
+        return { line: { style: deepMix({}, get(this.themeConfig, `grid.style`), cfg) } };
       };
     } else if (style) {
       this.config.grid = { line: { style } };
@@ -100,7 +100,7 @@ export default class AxisParser {
     if (style) {
       labelConfig.style = { style: this.localProps.label.style };
     }
-    labelConfig.style = _.deepMix({}, _.get(this.themeConfig, 'label.style'), labelConfig.style);
+    labelConfig.style = deepMix({}, get(this.themeConfig, 'label.style'), labelConfig.style);
     const formatter = this.parseFormatter(labelConfig);
     labelConfig.formatter = formatter;
     this.config.label = labelConfig;
@@ -116,7 +116,7 @@ export default class AxisParser {
       if (style) {
         titleConfig.style = style;
       }
-      titleConfig.style = _.deepMix({}, _.get(this.config, 'title.style'), titleConfig.textStyle);
+      titleConfig.style = deepMix({}, get(this.config, 'title.style'), titleConfig.textStyle);
 
       if (text) {
         titleConfig.text = text;
@@ -133,7 +133,7 @@ export default class AxisParser {
   }
 
   private applyThemeConfig(type: 'line' | 'grid' | 'tickLine') {
-    this.config[type] = _.deepMix({}, _.get(this.themeConfig, `${type}.style`), this.config[type]);
+    this.config[type] = deepMix({}, get(this.themeConfig, `${type}.style`), this.config[type]);
   }
 
   protected parseFormatter(labelConfig) {

--- a/src/components/axis/state.ts
+++ b/src/components/axis/state.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { each, clone, isObject, isFunction } from '@antv/util';
 // import { compare } from '../../base/controller/state';
 
 // 对axis label和label样式进行缓存
@@ -9,7 +9,7 @@ function onActive(plot, condition) {
   if (!labels) {
     getAllAxisLabels(plot);
   }
-  _.each(labels, (label, index) => {
+  each(labels, (label, index) => {
     const { labelData, con } = beforeCompare(label, condition);
     if (compare(labelData, con)) {
       const originAttr = originAttrs[index];
@@ -23,7 +23,7 @@ function onDisable(plot, condition) {
   if (!labels) {
     getAllAxisLabels(plot);
   }
-  _.each(labels, (label, index) => {
+  each(labels, (label, index) => {
     const { labelData, con } = beforeCompare(label, condition);
     if (compare(labelData, con)) {
       const originAttr = originAttrs[index];
@@ -37,14 +37,14 @@ function getAllAxisLabels(plot) {
   labels = [];
   originAttrs = [];
   const axes = plot.view.get('axisController').axes;
-  _.each(axes, (axis) => {
+  each(axes, (axis) => {
     const labelArr = [];
     const scale = getScale(plot, axis);
     const labelShapes = axis
       .get('labelRenderer')
       .get('group')
       .get('children');
-    _.each(labelShapes, (shape) => {
+    each(labelShapes, (shape) => {
       if (shape.type === 'text') {
         labelArr.push({ shape });
         originAttrs.push(shape.attr());
@@ -53,7 +53,7 @@ function getAllAxisLabels(plot) {
     if (scale) {
       // 取到scale values作为原始数据，避免被label format的影响
       const { ticks, field } = scale;
-      _.each(labelArr, (label, index) => {
+      each(labelArr, (label, index) => {
         label.value = ticks[index];
         label.scaleField = field;
         label.type = scale.type;
@@ -77,8 +77,8 @@ function getScale(plot, axis) {
 
 function beforeCompare(label, condition) {
   const labelData = { [label.scaleField]: label.value };
-  const con = _.clone(condition);
-  if (label.type === 'time' && _.isObject(condition) && !_.isFunction(con.exp)) {
+  const con = clone(condition);
+  if (label.type === 'time' && isObject(condition) && !isFunction(con.exp)) {
     con.exp = new Date(con.exp).getTime();
   }
   return { labelData, con };
@@ -94,12 +94,12 @@ function labelActiveStyle(style) {
 }
 
 function compare(origin, condition) {
-  if (!_.isFunction(condition)) {
+  if (!isFunction(condition)) {
     const { name, exp } = condition;
     if (!origin[name]) {
       return false;
     }
-    if (_.isFunction(exp)) {
+    if (isFunction(exp)) {
       return exp(origin[name]);
     }
     return origin[name] === exp;

--- a/src/components/connected-area.ts
+++ b/src/components/connected-area.ts
@@ -3,14 +3,14 @@
  */
 import { Group, Shape, Shapes } from '@antv/g-canvas';
 import { View } from '@antv/g2';
-import * as _ from '@antv/util';
+import { each, assign, mix } from '@antv/util';
 import { compare } from '../base/controller/state';
 
 function parsePoints(shape) {
   const parsedPoints = [];
   const coord = shape.get('coord');
   const points = shape.get('origin').points;
-  _.each(points, (p) => {
+  each(points, (p) => {
     parsedPoints.push(coord.convertPoint(p));
   });
   return parsedPoints;
@@ -42,13 +42,13 @@ export default class ConnectedArea {
   private animation: boolean;
 
   constructor(cfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
     this._init();
   }
 
   public draw() {
     const groupedShapes = this._getGroupedShapes();
-    _.each(groupedShapes, (shapes, name) => {
+    each(groupedShapes, (shapes, name) => {
       if (shapes.length > 0) {
         this._drawConnection(shapes, name);
       }
@@ -102,11 +102,11 @@ export default class ConnectedArea {
     const shapes = geometry.getShapes();
     // 创建分组
     const groups = {};
-    _.each(values, (v) => {
+    each(values, (v) => {
       groups[v] = [];
     });
     // 执行分组
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const origin = shape.get('origin')._origin;
       const key = origin[this.field];
       groups[key].push(shape);
@@ -122,14 +122,14 @@ export default class ConnectedArea {
     for (let i = 0; i < shapes.length - 1; i++) {
       const current = parsePoints(shapes[i]);
       const next = parsePoints(shapes[i + 1]);
-      const areaStyle = _.mix({}, this._areaStyle[name]);
-      const lineStyle = _.mix({}, this._lineStyle[name]);
+      const areaStyle = mix({}, this._areaStyle[name]);
+      const lineStyle = mix({}, this._lineStyle[name]);
       if (this.triggerOn) {
         areaStyle.opacity = 0;
         lineStyle.opacity = 0;
       }
       const area = this.container.addShape('path', {
-        attrs: _.mix({} as any, areaStyle, {
+        attrs: mix({} as any, areaStyle, {
           path: [
             ['M', current[2].x, current[2].y],
             ['L', next[1].x, next[1].y],
@@ -140,7 +140,7 @@ export default class ConnectedArea {
         name: 'connectedArea',
       });
       const line = this.container.addShape('path', {
-        attrs: _.mix({} as any, lineStyle, {
+        attrs: mix({} as any, lineStyle, {
           path: [
             ['M', current[2].x, current[2].y],
             ['L', next[1].x, next[1].y],
@@ -170,7 +170,7 @@ export default class ConnectedArea {
       mappedStyle = { stroke: originColor };
     }
 
-    return _.mix(defaultStyle, mappedStyle);
+    return mix(defaultStyle, mappedStyle);
   }
 
   private _addInteraction() {
@@ -227,7 +227,7 @@ export default class ConnectedArea {
   }
 
   private _onActive(condition) {
-    _.each(this.areas, (area) => {
+    each(this.areas, (area) => {
       const shapeData = area.get('data');
       const styleField = shapeData[this.field];
       if (compare(shapeData, condition)) {
@@ -237,7 +237,7 @@ export default class ConnectedArea {
         area.animate({ opacity }, 400, 'easeQuadOut');
       }
     });
-    _.each(this.lines, (line) => {
+    each(this.lines, (line) => {
       const shapeData = line.get('data');
       const styleField = shapeData[this.field];
       if (compare(shapeData, condition)) {
@@ -250,7 +250,7 @@ export default class ConnectedArea {
   }
 
   private _onDisabled(condition) {
-    _.each(this.areas, (area) => {
+    each(this.areas, (area) => {
       const shapeData = area.get('data');
       if (compare(shapeData, condition)) {
         // area.attr('opacity',0);
@@ -264,7 +264,7 @@ export default class ConnectedArea {
         );
       }
     });
-    _.each(this.lines, (line) => {
+    each(this.lines, (line) => {
       const shapeData = line.get('data');
       if (compare(shapeData, condition)) {
         // line.attr('opacity',0);

--- a/src/components/description.ts
+++ b/src/components/description.ts
@@ -1,5 +1,5 @@
 import { Canvas, IGroup, Shape } from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { assign, isArray, each, mix } from '@antv/util';
 import { breakText } from '../util/common';
 import ViewLayer from '../base/view-layer';
 import BBox from '../util/bbox';
@@ -38,7 +38,7 @@ export default class TextDescription {
   private plot: ViewLayer;
 
   constructor(cfg: TextConfig) {
-    _.assign(this as any, cfg);
+    assign(this as any, cfg);
     this._init();
   }
 
@@ -50,8 +50,8 @@ export default class TextDescription {
         return BBox.fromBBoxObject(bbox);
       }
       const padding = this.plot.theme.description.padding;
-      if (_.isArray(padding)) {
-        _.each(padding, (it, index) => {
+      if (isArray(padding)) {
+        each(padding, (it, index) => {
           if (typeof padding[index] === 'function') {
             padding[index] = padding[index](this.plot.options.legend.position);
           }
@@ -79,7 +79,7 @@ export default class TextDescription {
   private _init() {
     const content = this._textWrapper();
     this.shape = (this.container.addShape('text', {
-      attrs: _.mix(
+      attrs: mix(
         {
           x: this.leftMargin,
           y: this.topMargin,

--- a/src/components/guide-line.ts
+++ b/src/components/guide-line.ts
@@ -1,5 +1,5 @@
 import { getScale } from '@antv/scale';
-import * as _ from '@antv/util';
+import { assign, deepMix, mix, each } from '@antv/util';
 import { getMean, getMedian } from '../util/math';
 
 export default class GuideLine {
@@ -9,7 +9,7 @@ export default class GuideLine {
   private values: number[];
 
   constructor(cfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
     this._init();
   }
 
@@ -22,8 +22,8 @@ export default class GuideLine {
       start: this.cfg.start,
       end: this.cfg.end,
     };
-    baseConfig.line = _.deepMix({}, defaultStyle.line, { style: this.cfg.lineStyle });
-    baseConfig.text = _.deepMix({}, defaultStyle.text, this.cfg.text);
+    baseConfig.line = deepMix({}, defaultStyle.line, { style: this.cfg.lineStyle });
+    baseConfig.text = deepMix({}, defaultStyle.text, this.cfg.text);
     if (this.cfg.type) {
       const stateValue = this._getState(this.cfg.type);
       const minValue = this._getState('min');
@@ -31,7 +31,7 @@ export default class GuideLine {
       const Scale = getScale('linear');
       // 重新组织scale并使用scale的min和max来计算guide point的百分比位置，以避免受nice的影响
       const scale = new Scale(
-        _.mix(
+        mix(
           {},
           {
             min: this.plot.type === 'column' ? 0 : minValue,
@@ -45,7 +45,7 @@ export default class GuideLine {
       const percent = `${(1.0 - scale.scale(stateValue)) * 100}%`;
       const start = ['0%', percent];
       const end = ['100%', percent];
-      this.config = _.mix(
+      this.config = mix(
         {
           start,
           end,
@@ -77,7 +77,7 @@ export default class GuideLine {
     const props = this.plot.options;
     const field = props.yField;
     const values = [];
-    _.each(props.data, (d) => {
+    each(props.data, (d) => {
       values.push(d[field]);
     });
     return values;

--- a/src/components/label/parser.ts
+++ b/src/components/label/parser.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign, isFunction, deepMix, get, each, has } from '@antv/util';
 import { Label } from '../../interface/config';
 import { combineFormatter, getNoopFormatter, getPrecisionFormatter, getSuffixFormatter } from '../../util/formatter';
 import { LooseMap } from '../../interface/types';
@@ -20,7 +20,7 @@ export default class LabelParser {
   }
 
   protected init(cfg) {
-    _.assign(this.config, cfg);
+    assign(this.config, cfg);
     this.config.callback = (val, ...restArgs: any[]) => {
       return this.parseCallBack(val, ...restArgs);
     };
@@ -32,7 +32,7 @@ export default class LabelParser {
     const config: LooseMap = { ...labelProps };
     this.parseOffset(labelProps, config);
     if (labelProps.position) {
-      if (_.isFunction(labelProps.position)) {
+      if (isFunction(labelProps.position)) {
         config.position = labelProps.position(val);
       } else {
         config.position = labelProps.position;
@@ -40,13 +40,13 @@ export default class LabelParser {
     }
     this.parseFormatter(config, val, ...restArgs);
     if (labelProps.style) {
-      if (_.isFunction(labelProps.style)) {
+      if (isFunction(labelProps.style)) {
         config.textStyle = labelProps.style(val);
       } else {
         config.textStyle = labelProps.style;
       }
     }
-    config.textStyle = _.deepMix({}, _.get(theme, 'label.style'), config.textStyle);
+    config.textStyle = deepMix({}, get(theme, 'label.style'), config.textStyle);
     if (labelProps.autoRotate) {
       config.autoRotate = labelProps.autoRotate;
     }
@@ -57,14 +57,14 @@ export default class LabelParser {
   protected parseOffset(props, config) {
     const mapper = ['offset', 'offsetX', 'offsetY'];
     let count = 0;
-    _.each(mapper, (m) => {
-      if (_.has(props, m)) {
+    each(mapper, (m) => {
+      if (has(props, m)) {
         config[m] = props[m];
         count++;
       }
     });
     // 如用户没有设置offset，而label position又为middle时，则默认设置offset为0
-    if (count === 0 && _.get(props, 'position') === 'middle') {
+    if (count === 0 && get(props, 'position') === 'middle') {
       config.offset = 0;
     }
   }

--- a/src/components/label/state.ts
+++ b/src/components/label/state.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { each, mix } from '@antv/util';
 import { compare } from '../../base/controller/state';
 
 // 对label和label样式进行缓存
@@ -9,11 +9,11 @@ function onActive(plot, condition) {
   if (!labels) {
     getAllLabels(plot);
   }
-  _.each(labels, (label, index) => {
+  each(labels, (label, index) => {
     const origin = label.get('origin');
     if (compare(origin, condition)) {
       const originAttr = originAttrs[index];
-      const style = _.mix({}, originAttr, { opacity: 1 });
+      const style = mix({}, originAttr, { opacity: 1 });
       label.attr(style);
     }
   });
@@ -23,7 +23,7 @@ function onDisable(plot, condition) {
   if (!labels) {
     getAllLabels(plot);
   }
-  _.each(labels, (label, index) => {
+  each(labels, (label, index) => {
     const origin = label.get('origin');
     if (compare(origin, condition)) {
       const originAttr = originAttrs[index];
@@ -37,10 +37,10 @@ function getAllLabels(plot) {
   labels = [];
   originAttrs = [];
   const geoms = plot.view.get('elements');
-  _.each(geoms, (geom) => {
+  each(geoms, (geom) => {
     const geomLabels = geom.get('labels');
     if (geomLabels) {
-      _.each(geomLabels, (label) => {
+      each(geomLabels, (label) => {
         labels.push(label);
         originAttrs.push(label.attr());
       });

--- a/src/components/tooltip/state.ts
+++ b/src/components/tooltip/state.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { each, clone, isFunction, has } from '@antv/util';
 import { compare } from '../../base/controller/state';
 
 const POSITION_MAPPER = ['xField', 'yField', 'angleField'];
@@ -8,7 +8,7 @@ function onActive(plot, condition) {
   // 获取state condition对应在画布的位置，只有在state condition对应字段为位置映射字段时，tooltip才会对齐进行响应
   if (shouldActive(props, condition)) {
     const data = props.data;
-    _.each(data, (d) => {
+    each(data, (d) => {
       if (compare(d, condition)) {
         const point = plot.view.getXY(d);
         // 调用showTooltip方法
@@ -29,9 +29,9 @@ function onDisable(plot, condition) {
 
 function processState(condition, e, inverse) {
   const expected = inverse ? false : true;
-  const originItems = _.clone(e.items);
+  const originItems = clone(e.items);
   e.items.splice(0);
-  _.each(originItems, (item) => {
+  each(originItems, (item) => {
     const origin = item.point._origin;
     if (compare(origin, condition) === expected) {
       e.items.push(item);
@@ -41,13 +41,13 @@ function processState(condition, e, inverse) {
 
 function shouldActive(props, condition) {
   const fields = getPositionField(props);
-  return !_.isFunction(condition) && fields.indexOf(condition.name);
+  return !isFunction(condition) && fields.indexOf(condition.name);
 }
 
 function getPositionField(props) {
   const fields = [];
-  _.each(POSITION_MAPPER, (v) => {
-    if (_.has(props, v)) {
+  each(POSITION_MAPPER, (v) => {
+    if (has(props, v)) {
       fields.push(v);
     }
   });

--- a/src/geoms/area/main.ts
+++ b/src/geoms/area/main.ts
@@ -1,5 +1,5 @@
 import { Datum } from '@antv/g2/lib/interface';
-import * as _ from '@antv/util';
+import { has, isString, isFunction, get } from '@antv/util';
 import ElementParser from '../base';
 
 export default class AreaParser extends ElementParser {
@@ -31,11 +31,11 @@ export default class AreaParser extends ElementParser {
     if (colorMappingField) {
       config.fields = colorMappingField;
     }
-    if (_.has(props, 'color')) {
+    if (has(props, 'color')) {
       const color = props.color;
-      if (_.isString(color)) {
+      if (isString(color)) {
         config.values = [color];
-      } else if (_.isFunction(color)) {
+      } else if (isFunction(color)) {
         config.callback = color;
       } else {
         config.values = color as [];
@@ -48,7 +48,7 @@ export default class AreaParser extends ElementParser {
     const props = this.plot.options;
     const styleProps = props.areaStyle ? props.areaStyle : props.area.style;
     const config: Datum = {};
-    if (_.isFunction(styleProps) && props.seriesField) {
+    if (isFunction(styleProps) && props.seriesField) {
       config.fields = [props.seriesField];
       config.callback = styleProps;
     } else {
@@ -61,7 +61,7 @@ export default class AreaParser extends ElementParser {
     const props = this.plot.options;
     const colorMapper = ['stackField', 'seriesField'];
     for (const m of colorMapper) {
-      if (_.get(props, m)) {
+      if (get(props, m)) {
         return [props[m]];
       }
     }

--- a/src/geoms/area/mini.ts
+++ b/src/geoms/area/mini.ts
@@ -1,6 +1,6 @@
 /** 简化折线点 */
 import * as G2 from '@antv/g2';
-import * as _ from '@antv/util';
+import { deepMix, each } from '@antv/util';
 import { lineSimplification } from '../../util/math';
 import { getSplinePath } from '../../util/path';
 import AreaParser from './main';
@@ -10,7 +10,7 @@ G2.registerShape('area', 'miniArea', {
   draw(cfg, container) {
     const opacity = cfg.style ? cfg.style.opacity : null;
     const path = getPath(cfg, this, false);
-    const style = _.deepMix(
+    const style = deepMix(
       {},
       {
         lineJoin: 'round',
@@ -52,7 +52,7 @@ function getPath(cfg, shape, isSmooth) {
   ];
   let topLinePoints = [];
   let bottomLinePoints = [];
-  _.each(cfg.points, (point) => {
+  each(cfg.points, (point) => {
     topLinePoints.push(point[1]);
     bottomLinePoints.push(point[0]);
   });

--- a/src/geoms/base.ts
+++ b/src/geoms/base.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { ElementOption } from '../interface/config';
 
 export default class ElementParser {
@@ -10,7 +10,7 @@ export default class ElementParser {
   private widthRatio: number;
 
   constructor(cfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
     this.init();
   }
 

--- a/src/geoms/factory.ts
+++ b/src/geoms/factory.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import Area from './area/index';
 import Interval from './interval/index';
 import Line from './line/index';

--- a/src/geoms/heatmap/linear.ts
+++ b/src/geoms/heatmap/linear.ts
@@ -1,6 +1,6 @@
 import { registerGeometry, Geometry } from '@antv/g2';
 import { Canvas } from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { isNumber, get } from '@antv/util';
 import * as colorUtil from '../../util/color';
 
 const GAUSS_COEF = 0.3989422804014327;
@@ -62,7 +62,7 @@ class LinearHeatmap extends Geometry {
     let radius = this.radius;
     if (!this.radius) {
       radius = this.getDefaultValue('size');
-      if (!_.isNumber(radius)) {
+      if (!isNumber(radius)) {
         radius = this.getDefaultSize();
       }
       this.radius = radius;
@@ -70,8 +70,8 @@ class LinearHeatmap extends Geometry {
   }
 
   private prepareBlur() {
-    let blur = _.get(this.styleOption, ['style', 'shadowBlur']);
-    if (!_.isNumber(blur)) {
+    let blur = get(this.styleOption, ['style', 'shadowBlur']);
+    if (!isNumber(blur)) {
       blur = this.radius / 2;
     }
     this.blur = blur;

--- a/src/geoms/interval/main.ts
+++ b/src/geoms/interval/main.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { isString, isFunction, isArray, isObject, get } from '@antv/util';
 import ElementParser from '../base';
 
 const COLOR_MAPPER = ['colorField', 'stackField', 'groupField'];
@@ -32,13 +32,13 @@ export default class IntervalParser extends ElementParser {
       config.fields = colorField;
     }
     if (props.color) {
-      if (_.isString(props.color)) {
+      if (isString(props.color)) {
         config.values = [props.color];
-      } else if (_.isFunction(props.color)) {
+      } else if (isFunction(props.color)) {
         config.callback = props.color;
-      } else if (_.isArray(props.color)) {
+      } else if (isArray(props.color)) {
         config.values = props.color;
-      } else if (_.isObject(props.color)) {
+      } else if (isObject(props.color)) {
         config.fields = colorField;
         config.callback = (d) => {
           return props.color[d];
@@ -51,7 +51,7 @@ export default class IntervalParser extends ElementParser {
   public parseSize(sizeProps) {
     const props = this.plot.options;
     const config: any = {};
-    if (_.isFunction(props[sizeProps])) {
+    if (isFunction(props[sizeProps])) {
       config.fields = [this.config.position.fields];
       config.callback = props[sizeProps];
     } else {
@@ -63,7 +63,7 @@ export default class IntervalParser extends ElementParser {
   public parseStyle(styleProps) {
     const style = this.plot.options[styleProps];
     const config: any = {};
-    if (_.isFunction(style)) {
+    if (isFunction(style)) {
       config.fields = [this.config.position.fields];
       config.callback = style;
     } else {
@@ -76,7 +76,7 @@ export default class IntervalParser extends ElementParser {
   private _getSizeProps(props) {
     const sizeMapper = ['columnSize', 'barSize'];
     for (const m of sizeMapper) {
-      if (_.get(props, m)) {
+      if (get(props, m)) {
         return m;
       }
     }
@@ -85,7 +85,7 @@ export default class IntervalParser extends ElementParser {
   private _getStyleProps(props) {
     const sizeMapper = ['columnStyle', 'barStyle', 'pieStyle', 'ringStyle'];
     for (const m of sizeMapper) {
-      if (_.get(props, m)) {
+      if (get(props, m)) {
         return m;
       }
     }
@@ -96,7 +96,7 @@ export default class IntervalParser extends ElementParser {
      * 如没有特别设定，则一般是callback中的传参，传入位置映射的字段
      */
     for (const m of COLOR_MAPPER) {
-      if (_.get(props, m)) {
+      if (get(props, m)) {
         return [props[m]];
       }
     }

--- a/src/geoms/line/guide.ts
+++ b/src/geoms/line/guide.ts
@@ -1,5 +1,5 @@
-import { DataPointType } from '@antv/g2/lib/interface';
-import * as _ from '@antv/util';
+import { LooseObject } from '@antv/g2/lib/interface';
+import { isString, isFunction, isArray, get } from '@antv/util';
 import LineParser from './main';
 
 export default class GuideLineParser extends LineParser {
@@ -32,7 +32,7 @@ export default class GuideLineParser extends LineParser {
 
   public parseSize() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     if (props.line.size) {
       config.values = [props.line.size];
     } else {
@@ -44,7 +44,7 @@ export default class GuideLineParser extends LineParser {
 
   public parseColor() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     let colorField = this._getColorMappingField();
     if (colorField) {
       config.fields = colorField;
@@ -56,12 +56,12 @@ export default class GuideLineParser extends LineParser {
         colorField = this.config.position.fields;
       }
       // line作为辅助图形没有在style里指定color属性的情况下，默认接受主体图形的透传
-      if (_.isString(props.color)) {
+      if (isString(props.color)) {
         config.values = [props.color];
-      } else if (_.isFunction(props.color)) {
+      } else if (isFunction(props.color)) {
         config.fields = colorField;
         config.callback = props.color;
-      } else if (_.isArray(props.color)) {
+      } else if (isArray(props.color)) {
         config.fields = colorField;
         config.values = props.color;
       }
@@ -73,8 +73,8 @@ export default class GuideLineParser extends LineParser {
   public parseStyle() {
     const props = this.plot.options;
     const styleProps = props.line.style;
-    const config: DataPointType = {};
-    if (_.isFunction(styleProps)) {
+    const config: LooseObject = {};
+    if (isFunction(styleProps)) {
       config.fields = this.config.position.fields;
       config.callback = styleProps;
     } else {
@@ -93,7 +93,7 @@ export default class GuideLineParser extends LineParser {
     const props = this.plot.options;
     const colorMapper = ['stackField', 'seriesField'];
     for (const m of colorMapper) {
-      if (_.get(props, m)) {
+      if (get(props, m)) {
         return [props[m]];
       }
     }

--- a/src/geoms/line/main.ts
+++ b/src/geoms/line/main.ts
@@ -1,5 +1,5 @@
-import { DataPointType } from '@antv/g2/lib/interface';
-import * as _ from '@antv/util';
+import { LooseObject } from '@antv/g2/lib/interface';
+import { isFunction, has, isString } from '@antv/util';
 import ElementParser from '../base';
 
 export default class LineParser extends ElementParser {
@@ -31,8 +31,8 @@ export default class LineParser extends ElementParser {
 
   public parseSize() {
     const sizeProps = this.plot.options.lineSize;
-    const config: DataPointType = {};
-    if (_.isFunction(sizeProps)) {
+    const config: LooseObject = {};
+    if (isFunction(sizeProps)) {
       config.callback = sizeProps;
     } else {
       config.values = [sizeProps];
@@ -42,15 +42,15 @@ export default class LineParser extends ElementParser {
 
   public parseColor() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     if (props.seriesField) {
       config.fields = [props.seriesField];
     }
-    if (_.has(props, 'color')) {
+    if (has(props, 'color')) {
       const color = props.color;
-      if (_.isString(color)) {
+      if (isString(color)) {
         config.values = [color];
-      } else if (_.isFunction(color)) {
+      } else if (isFunction(color)) {
         config.callback = color;
       } else {
         config.values = color as [];
@@ -68,7 +68,7 @@ export default class LineParser extends ElementParser {
       callback: null,
       cfg: null,
     };
-    if (_.isFunction(styleProps) && props.seriesField) {
+    if (isFunction(styleProps) && props.seriesField) {
       config.fields = [props.seriesField];
       config.callback = styleProps;
     } else {

--- a/src/geoms/line/mini.ts
+++ b/src/geoms/line/mini.ts
@@ -1,6 +1,6 @@
 /** 简化折线点 */
 import * as G2 from '@antv/g2';
-import * as _ from '@antv/util';
+import { deepMix, mix } from '@antv/util';
 import { lineSimplification } from '../../util/math';
 import { getSplinePath } from '../../util/path';
 import LineParser from './main';
@@ -15,7 +15,7 @@ G2.registerShape('line', 'miniLine', {
       const flag = i === 0 ? 'M' : 'L';
       path.push([flag, p.x, p.y]);
     }
-    const style = _.deepMix(
+    const style = deepMix(
       {},
       {
         lineJoin: 'round',
@@ -24,7 +24,7 @@ G2.registerShape('line', 'miniLine', {
       cfg.style
     );
     const shape = container.addShape('path', {
-      attrs: _.mix(
+      attrs: mix(
         {
           path,
           stroke: cfg.color || getGlobalTheme().defaultColor,
@@ -46,7 +46,7 @@ G2.registerShape('line', 'miniLineSmooth', {
     ];
     const path = getSplinePath(points, false, constraint);
     const shape = container.addShape('path', {
-      attrs: _.mix(
+      attrs: mix(
         {
           path,
           stroke: cfg.color || getGlobalTheme().defaultColor,

--- a/src/geoms/point/circle.ts
+++ b/src/geoms/point/circle.ts
@@ -1,5 +1,5 @@
-import { DataPointType } from '@antv/g2/lib/interface';
-import * as _ from '@antv/util';
+import { LooseObject } from '@antv/g2/lib/interface';
+import { isArray, isFunction, isString } from '@antv/util';
 import ElementParser from '../base';
 
 export default class CircleParser extends ElementParser {
@@ -28,10 +28,10 @@ export default class CircleParser extends ElementParser {
 
   public parseColor() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     const colorField = props.colorField;
     if (colorField) {
-      config.fields = _.isArray(colorField) ? colorField : [colorField];
+      config.fields = isArray(colorField) ? colorField : [colorField];
     }
     if (props.color) {
       this._parseColor(props, config);
@@ -41,7 +41,7 @@ export default class CircleParser extends ElementParser {
 
   public parseSize() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     if (props.sizeField) {
       config.fields = [props.sizeField];
     }
@@ -52,7 +52,7 @@ export default class CircleParser extends ElementParser {
   }
 
   public parseShape(shapeName) {
-    const config: DataPointType = {
+    const config: LooseObject = {
       values: [shapeName],
     };
     this.config.shape = config;
@@ -67,9 +67,9 @@ export default class CircleParser extends ElementParser {
       cfg: null,
     };
     const { xField, yField, colorField } = props;
-    if (_.isFunction(styleProps)) {
+    if (isFunction(styleProps)) {
       if (colorField) {
-        config.fields = _.isArray(colorField)
+        config.fields = isArray(colorField)
           ? [xField, yField, colorField].concat(colorField)
           : [xField, yField, colorField];
       } else {
@@ -83,11 +83,11 @@ export default class CircleParser extends ElementParser {
   }
 
   private _parseColor(props, config) {
-    if (_.isString(props.color)) {
+    if (isString(props.color)) {
       config.values = [props.color];
-    } else if (_.isFunction(props.color)) {
+    } else if (isFunction(props.color)) {
       config.callback = props.color;
-    } else if (_.isArray(props.color)) {
+    } else if (isArray(props.color)) {
       config.values = props.color;
     }
   }

--- a/src/geoms/point/guide.ts
+++ b/src/geoms/point/guide.ts
@@ -1,14 +1,14 @@
-import { DataPointType } from '@antv/g2/lib/interface';
-import * as _ from '@antv/util';
+import { LooseObject } from '@antv/g2/lib/interface';
+import { each, uniq, keys, isFunction, isString, isArray, has, get } from '@antv/util';
 import ElementParser from '../base';
 
 function getValuesByField(field, data) {
   const values = [];
-  _.each(data, (d) => {
+  each(data, (d) => {
     const v = d[field];
     values.push(v);
   });
-  return _.uniq(values);
+  return uniq(values);
 }
 
 const COLOR_MAPPER = ['seriesField', 'stackField'];
@@ -42,7 +42,7 @@ export default class GuidePointParser extends ElementParser {
 
   public parseColor() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     const mappingField = this._getColorMappingField(props);
     if (mappingField) {
       this._parseColorByField(props, config, mappingField);
@@ -53,20 +53,20 @@ export default class GuidePointParser extends ElementParser {
         this._parseColor(props, config);
       }
     }
-    if (_.keys(config).length > 0) {
+    if (keys(config).length > 0) {
       this.config.color = config;
     }
   }
 
   public parseSize() {
     const props = this.plot.options;
-    const config: DataPointType = {};
+    const config: LooseObject = {};
     config.values = [props.point.size];
     this.config.size = config;
   }
 
   public parseShape(shapeName) {
-    const config: DataPointType = {
+    const config: LooseObject = {
       values: [shapeName],
     };
     this.config.shape = config;
@@ -81,7 +81,7 @@ export default class GuidePointParser extends ElementParser {
       cfg: null,
     };
     const field = this._getColorMappingField(props);
-    if (_.isFunction(styleProps) && field) {
+    if (isFunction(styleProps) && field) {
       config.fields = [field];
       config.callback = styleProps;
     } else {
@@ -105,18 +105,18 @@ export default class GuidePointParser extends ElementParser {
   }
 
   private _parseColor(props, config) {
-    if (_.isString(props.color)) {
+    if (isString(props.color)) {
       config.values = [props.color];
-    } else if (_.isFunction(props.color)) {
+    } else if (isFunction(props.color)) {
       config.callback = props.color;
-    } else if (_.isArray(props.color)) {
+    } else if (isArray(props.color)) {
       config.values = props.color;
     }
   }
 
   private _needParseAttribute(attr) {
     const props = this.plot.options;
-    const condition = props.point && _.has(props.point, attr);
+    const condition = props.point && has(props.point, attr);
     return condition;
     // const condition = !this.style || this.style[attr];
     // return condition;
@@ -124,7 +124,7 @@ export default class GuidePointParser extends ElementParser {
 
   private _getColorMappingField(props) {
     for (const m of COLOR_MAPPER) {
-      if (_.get(props, m)) {
+      if (get(props, m)) {
         return [props[m]];
       }
     }

--- a/src/plots/area/event.ts
+++ b/src/plots/area/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -28,6 +28,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onPointContextmenu: 'point:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/plots/area/index.ts
+++ b/src/plots/area/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import AreaLayer, { AreaViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Area extends BasePlot<AreaConfig> {
   public static getDefaultOptions: typeof AreaLayer.getDefaultOptions = AreaLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'area';
     super.createLayers(layerProps);
   }

--- a/src/plots/area/layer.ts
+++ b/src/plots/area/layer.ts
@@ -1,5 +1,5 @@
 import { Data } from '@antv/g2/lib/interface';
-import * as _ from '@antv/util';
+import { deepMix, has, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
@@ -50,7 +50,7 @@ export interface AreaLayerConfig extends AreaViewConfig, LayerConfig {}
 
 export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       smooth: false,
       areaStyle: {
         opacity: 0.25,
@@ -114,12 +114,12 @@ export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> exte
     scales[props.xField] = {
       type: 'cat',
     };
-    if (_.has(props, 'xAxis')) {
+    if (has(props, 'xAxis')) {
       extractScale(scales[props.xField], props.xAxis);
     }
     /** 配置y-scale */
     scales[props.yField] = {};
-    if (_.has(props, 'yAxis')) {
+    if (has(props, 'yAxis')) {
       extractScale(scales[props.yField], props.yAxis);
     }
     this.setConfig('scales', scales);
@@ -160,7 +160,7 @@ export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> exte
 
   protected addLine() {
     const props = this.options;
-    const lineConfig = _.deepMix({}, props.line);
+    const lineConfig = deepMix({}, props.line);
     if (lineConfig.visible) {
       const line = getGeom('line', 'guide', {
         type: 'line',
@@ -175,7 +175,7 @@ export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> exte
 
   protected addPoint() {
     const props = this.options;
-    const pointConfig = _.deepMix({}, props.point);
+    const pointConfig = deepMix({}, props.point);
     if (pointConfig.visible) {
       const point = getGeom('point', 'guide', {
         plot: this,
@@ -220,7 +220,7 @@ export default class AreaLayer<T extends AreaLayerConfig = AreaLayerConfig> exte
 
   private applyResponsive(stage) {
     const methods = responsiveMethods[stage];
-    _.each(methods, (r) => {
+    each(methods, (r) => {
       const responsive = r as any;
       responsive.method(this);
     });

--- a/src/plots/bar/apply-responsive/axis.ts
+++ b/src/plots/bar/apply-responsive/axis.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ApplyResponsiveAxis from '../../../util/responsive/apply/axis';
 import BarLayer from '../layer';
 

--- a/src/plots/bar/event.ts
+++ b/src/plots/bar/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onBarContextmenu: 'interval:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/plots/bar/index.ts
+++ b/src/plots/bar/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import BarLayer, { BarViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Bar extends BasePlot<BarConfig> {
   public static getDefaultOptions: typeof BarLayer.getDefaultOptions = BarLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'bar';
     super.createLayers(layerProps);
   }

--- a/src/plots/bar/layer.ts
+++ b/src/plots/bar/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, has, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
@@ -97,7 +97,7 @@ export default class BaseBarLayer<T extends BarLayerConfig = BarLayerConfig> ext
         position: 'top-left',
       },
     };
-    return _.deepMix({}, super.getDefaultOptions(), cfg);
+    return deepMix({}, super.getDefaultOptions(), cfg);
   }
 
   public bar: any;
@@ -140,12 +140,12 @@ export default class BaseBarLayer<T extends BarLayerConfig = BarLayerConfig> ext
     scales[props.yField] = {
       type: 'cat',
     };
-    if (_.has(props, 'yAxis')) {
+    if (has(props, 'yAxis')) {
       extractScale(scales[props.yField], props.yAxis);
     }
     /** 配置y-scale */
     scales[props.xField] = {};
-    if (_.has(props, 'xAxis')) {
+    if (has(props, 'xAxis')) {
       extractScale(scales[props.xField], props.xAxis);
     }
     this.setConfig('scales', scales);
@@ -225,7 +225,7 @@ export default class BaseBarLayer<T extends BarLayerConfig = BarLayerConfig> ext
 
   private applyResponsive(stage) {
     const methods = responsiveMethods[stage];
-    _.each(methods, (r) => {
+    each(methods, (r) => {
       const responsive = r;
       responsive.method(this);
     });

--- a/src/plots/column/apply-responsive/axis.ts
+++ b/src/plots/column/apply-responsive/axis.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ApplyResponsiveAxis from '../../../util/responsive/apply/axis';
 import ColumnLayer from '../layer';
 

--- a/src/plots/column/apply-responsive/label.ts
+++ b/src/plots/column/apply-responsive/label.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ApplyResponsiveLabel from '../../../util/responsive/apply/label';
 import ColumnLayer from '../layer';
 

--- a/src/plots/column/apply-responsive/theme.ts
+++ b/src/plots/column/apply-responsive/theme.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import { registerResponsiveTheme } from '../../../util/responsive/theme';
 
 /** 组装theme */

--- a/src/plots/column/event.ts
+++ b/src/plots/column/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onColumnContextmenu: 'interval:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/plots/column/index.ts
+++ b/src/plots/column/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import ColumnLayer, { ColumnViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Column extends BasePlot<ColumnConfig> {
   public static getDefaultOptions: typeof ColumnLayer.getDefaultOptions = ColumnLayer.getDefaultOptions;
 
   public createLayers(props: ColumnConfig) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'column';
     super.createLayers(layerProps);
   }

--- a/src/plots/column/layer.ts
+++ b/src/plots/column/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, has, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
@@ -42,7 +42,7 @@ export interface ColumnLayerConfig extends ColumnViewConfig, LayerConfig {}
 
 export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       xAxis: {
         visible: true,
         tickLine: {
@@ -88,7 +88,7 @@ export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerCo
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();
-    return _.deepMix({}, options, defaultOptions, props);
+    return deepMix({}, options, defaultOptions, props);
   }
 
   public beforeInit() {
@@ -120,12 +120,12 @@ export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerCo
     const scales = {};
     /** 配置x-scale */
     scales[options.xField] = { type: 'cat' };
-    if (_.has(options, 'xAxis')) {
+    if (has(options, 'xAxis')) {
       extractScale(scales[options.xField], options.xAxis);
     }
     /** 配置y-scale */
     scales[options.yField] = {};
-    if (_.has(options, 'yAxis')) {
+    if (has(options, 'yAxis')) {
       extractScale(scales[options.yField], options.yAxis);
     }
     this.setConfig('scales', scales);
@@ -182,7 +182,7 @@ export default class BaseColumnLayer<T extends ColumnLayerConfig = ColumnLayerCo
 
   private applyResponsive(stage) {
     const methods = responsiveMethods[stage];
-    _.each(methods, (r) => {
+    each(methods, (r) => {
       const responsive = r;
       responsive.method(this);
     });

--- a/src/plots/group-bar/index.ts
+++ b/src/plots/group-bar/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import GroupBarLayer, { GroupBarViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class GroupBar extends BasePlot<GroupBarConfig> {
   public static getDefaultOptions: typeof GroupBarLayer.getDefaultOptions = GroupBarLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'groupBar';
     super.createLayers(layerProps);
   }

--- a/src/plots/group-bar/layer.ts
+++ b/src/plots/group-bar/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, valuesOfKey, clone } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { ElementOption, timeIntervals } from '../../interface/config';
@@ -12,7 +12,7 @@ export interface GroupBarLayerConfig extends GroupBarViewConfig, LayerConfig {}
 
 export default class GroupBarLayer extends BaseBarLayer<GroupBarLayerConfig> {
   public static getDefaultOptions(): Partial<GroupBarViewConfig> {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       xAxis: {
         visible: true,
         grid: {
@@ -43,10 +43,10 @@ export default class GroupBarLayer extends BaseBarLayer<GroupBarLayerConfig> {
 
   public afterRender() {
     super.afterRender();
-    const names = _.valuesOfKey(this.options.data, this.options.groupField);
+    const names = valuesOfKey(this.options.data, this.options.groupField);
     this.view.on('tooltip:change', (e) => {
       const { items } = e;
-      const origin_items = _.clone(items);
+      const origin_items = clone(items);
       for (let i = 0; i < names.length; i++) {
         const name = names[i];
         for (let j = 0; j < origin_items.length; j++) {
@@ -62,12 +62,12 @@ export default class GroupBarLayer extends BaseBarLayer<GroupBarLayerConfig> {
   protected scale() {
     const defaultMeta = {};
     defaultMeta[this.options.groupField] = {
-      values: _.valuesOfKey(this.options.data, this.options.groupField),
+      values: valuesOfKey(this.options.data, this.options.groupField),
     };
     if (!this.options.meta) {
       this.options.meta = defaultMeta;
     } else {
-      this.options.meta = _.deepMix({}, this.options.meta, defaultMeta);
+      this.options.meta = deepMix({}, this.options.meta, defaultMeta);
     }
     super.scale();
   }

--- a/src/plots/heatmap/index.ts
+++ b/src/plots/heatmap/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import HeatmapLayer, { HeatmapViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Heatmap extends BasePlot<HeatmapConfig> {
   public static getDefaultOptions: typeof HeatmapLayer.getDefaultOptions = HeatmapLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'heatmap';
     super.createLayers(layerProps);
   }

--- a/src/plots/heatmap/layer.ts
+++ b/src/plots/heatmap/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, each, has } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
@@ -41,7 +41,7 @@ export default class HeatmapLayer<T extends HeatmapLayerConfig = HeatmapLayerCon
   protected plotComponents: any[] = [];
 
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       xAxis: {
         visible: true,
         autoHideLabel: true,
@@ -116,7 +116,7 @@ export default class HeatmapLayer<T extends HeatmapLayerConfig = HeatmapLayerCon
   }
 
   public destroy() {
-    _.each(this.plotComponents, (component) => {
+    each(this.plotComponents, (component) => {
       component.destroy();
     });
     super.destroy();
@@ -127,12 +127,12 @@ export default class HeatmapLayer<T extends HeatmapLayerConfig = HeatmapLayerCon
     const scales = {};
     /** 配置x-scale */
     scales[props.xField] = {};
-    if (_.has(props, 'xAxis')) {
+    if (has(props, 'xAxis')) {
       extractScale(scales[props.xField], props.xAxis);
     }
     /** 配置y-scale */
     scales[props.yField] = {};
-    if (_.has(props, 'yAxis')) {
+    if (has(props, 'yAxis')) {
       extractScale(scales[props.yField], props.yAxis);
     }
     this.setConfig('scales', scales);
@@ -178,7 +178,7 @@ export default class HeatmapLayer<T extends HeatmapLayerConfig = HeatmapLayerCon
     const props = this.options;
     const defaultConfig = { visible: false, size: 0 };
     if (props.point && props.point.visible) {
-      props.point = _.deepMix(defaultConfig, props.point);
+      props.point = deepMix(defaultConfig, props.point);
     } else {
       props.point = defaultConfig;
     }
@@ -213,7 +213,7 @@ export default class HeatmapLayer<T extends HeatmapLayerConfig = HeatmapLayerCon
 
   protected renderPlotComponents() {
     const componentsType = ['legend', 'background'];
-    _.each(componentsType, (t) => {
+    each(componentsType, (t) => {
       const cfg = {
         view: this.view,
         plot: this,

--- a/src/plots/index.ts
+++ b/src/plots/index.ts
@@ -16,6 +16,7 @@ export { default as RangeColumn, RangeColumnConfig } from './range-column';
 export { default as Heatmap, HeatmapConfig } from './heatmap';
 export { default as Matrix, MatrixConfig } from './matrix';
 export { default as WordCloud, WordCloudConfig } from './word-cloud';
+export { default as StepLine, StepLineConfig } from './step-line';
 
 // export { default as Density, DensityConfig } from './density';
 // export { default as Bubble, BubbleConfig } from './bubble';
@@ -28,5 +29,4 @@ export { default as WordCloud, WordCloudConfig } from './word-cloud';
 // export { default as Funnel, FunnelConfig } from './funnel';
 // export { default as Waterfall, WaterfallConfig } from './waterfall';
 // export { default as Treemap } from './treemap';
-// export { default as StepLine, StepLineConfig } from './step-line';
 // export { default as Rose, RoseConfig } from './rose';

--- a/src/plots/line/animation/clipIn-with-data.ts
+++ b/src/plots/line/animation/clipIn-with-data.ts
@@ -1,5 +1,5 @@
 import { registerAnimation } from '@antv/g2';
-import * as _ from '@antv/util';
+import { clone, isFunction } from '@antv/util';
 
 let plotInfo;
 
@@ -10,7 +10,7 @@ function clipingWithData(shape, animateCfg, cfg) {
   const coord = geometry.coordinate;
   const scales = geometry.scales;
   const yScale = scales[plotInfo.options.yField];
-  const shapeData = _.clone(shape.get('origin'));
+  const shapeData = clone(shape.get('origin'));
   setClip(shape, coord);
   const clip = shape.get('clipShape');
   const parent = shape.get('parent');
@@ -71,11 +71,11 @@ function clipingWithData(shape, animateCfg, cfg) {
   /** 执行动画 */
   /** 准备动画参数 */
   let delay = animateCfg.delay;
-  if (_.isFunction(delay)) {
+  if (isFunction(delay)) {
     delay = animateCfg.delay(index);
   }
   let easing = animateCfg.easing;
-  if (_.isFunction(easing)) {
+  if (isFunction(easing)) {
     easing = animateCfg.easing(index);
   }
   /** 动起来 */

--- a/src/plots/line/apply-responsive/axis.ts
+++ b/src/plots/line/apply-responsive/axis.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ApplyResponsiveAxis from '../../../util/responsive/apply/axis';
 import LineLayer from '../layer';
 

--- a/src/plots/line/apply-responsive/label.ts
+++ b/src/plots/line/apply-responsive/label.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ApplyResponsiveLabel from '../../../util/responsive/apply/label';
 import LineLayer from '../layer';
 

--- a/src/plots/line/apply-responsive/theme.ts
+++ b/src/plots/line/apply-responsive/theme.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import { registerResponsiveTheme } from '../../../util/responsive/theme';
 
 /** 组装theme */

--- a/src/plots/line/event.ts
+++ b/src/plots/line/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -20,6 +20,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onPointContextmenu: 'point:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import LineLayer, { LineViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Line extends BasePlot<LineConfig> {
   public static getDefaultOptions: typeof LineLayer.getDefaultOptions = LineLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'line';
     super.createLayers(layerProps);
   }

--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, has, map, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
@@ -62,7 +62,7 @@ export interface LineLayerConfig extends LineViewConfig, LayerConfig {}
 
 export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): Partial<LineLayerConfig> {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       connectNulls: false,
       smooth: false,
       lineSize: 2,
@@ -98,7 +98,7 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
     const options = super.getOptions(props);
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();
-    return _.deepMix({}, options, defaultOptions, props);
+    return deepMix({}, options, defaultOptions, props);
   }
 
   public afterRender() {
@@ -127,18 +127,18 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
     const scales = {};
     /** 配置x-scale */
     scales[props.xField] = {};
-    if (_.has(props, 'xAxis')) {
+    if (has(props, 'xAxis')) {
       extractScale(scales[props.xField], props.xAxis);
     }
     /** 配置y-scale */
     scales[props.yField] = {};
-    if (_.has(props, 'yAxis')) {
+    if (has(props, 'yAxis')) {
       extractScale(scales[props.yField], props.yAxis);
     }
     this.setConfig('scales', scales);
     trySetScaleMinToZero(
       scales[props.yField],
-      _.map(props.data as any, (item) => item[props.yField])
+      map(props.data as any, (item) => item[props.yField])
     );
     super.scale();
   }
@@ -168,7 +168,7 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
     const props = this.options;
     const defaultConfig = { visible: false };
     if (props.point) {
-      props.point = _.deepMix(defaultConfig, props.point);
+      props.point = deepMix(defaultConfig, props.point);
     }
     if (props.point && props.point.visible) {
       this.point = getGeom('point', 'guide', {
@@ -206,7 +206,7 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
       // 关闭动画
       this.line.animate = false;
       if (this.point) this.point.animate = false;
-    } else if (_.has(props, 'animation')) {
+    } else if (has(props, 'animation')) {
       // 根据动画类型区分图形动画和群组动画
       if (props.animation.type === 'clipingWithData' && props.padding !== 'auto') {
         getPlotOption({
@@ -250,7 +250,7 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
 
   private applyResponsive(stage) {
     const methods = responsiveMethods[stage];
-    _.each(methods, (r) => {
+    each(methods, (r) => {
       const responsive = r as IObject;
       responsive.method(this);
     });

--- a/src/plots/matrix/index.ts
+++ b/src/plots/matrix/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import MatrixLayer, { MatrixLayerConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Matrix extends BasePlot<MatrixConfig> {
   public static getDefaultOptions: typeof MatrixLayer.getDefaultOptions = MatrixLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'matrix';
     super.createLayers(layerProps);
   }

--- a/src/plots/matrix/layer.ts
+++ b/src/plots/matrix/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, valuesOfKey, each } from '@antv/util';
 import BBox from '../../util/bbox';
 import { getScale } from '@antv/scale';
 import { registerPlotType } from '../../base/global';
@@ -24,7 +24,7 @@ export interface MatrixLayerConfig extends MatrixViewConfig, LayerConfig {}
 
 export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       forceSquare: false,
       shapeType: 'rect',
       legend: {
@@ -85,8 +85,8 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
     if (this.options.forceSquare) {
       const panelRange = this.view.coordinateBBox;
       const { xField, yField, data } = this.options;
-      const xCount = _.valuesOfKey(data, xField).length;
-      const yCount = _.valuesOfKey(data, yField).length;
+      const xCount = valuesOfKey(data, xField).length;
+      const yCount = valuesOfKey(data, yField).length;
       const rangeSize = Math.min(panelRange.width, panelRange.height);
       const count = Math.max(xCount, yCount);
       const gridSize = rangeSize / count;
@@ -121,7 +121,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
     }
     this.options.sizeField = field;
     // 创建scale
-    const values = _.valuesOfKey(this.options.data, field);
+    const values = valuesOfKey(this.options.data, field);
     const min = Math.min(...values);
     const max = Math.max(...values);
     const LinearScale = getScale('linear');
@@ -244,15 +244,15 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
       const { padding, xField, yField, data } = this.options;
       const width = viewRange.width - padding[1] - padding[3];
       const height = viewRange.height - padding[0] - padding[2];
-      const xCount = _.valuesOfKey(data, xField).length;
-      const yCount = _.valuesOfKey(data, yField).length;
+      const xCount = valuesOfKey(data, xField).length;
+      const yCount = valuesOfKey(data, yField).length;
       return [width / xCount, height / yCount];
     }
   }
 
   private circleToRect(shapes) {
     const gridSize = this.gridSize;
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const { x, y, size } = shape.get('origin');
       let sizeRatio = (size * 2) / Math.min(gridSize[0], gridSize[1]);
       if (!this.options.sizeField) {
@@ -273,11 +273,11 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
   }
 
   private rectToCircle(shapes) {
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const coord = shape.get('coord');
       const { points } = shape.get('origin');
       const ps = [];
-      _.each(points, (p) => {
+      each(points, (p) => {
         ps.push(coord.convertPoint(p));
       });
       const bbox = shape.getBBox();
@@ -303,7 +303,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
   }
 
   private rectSizeMapping(shapes, scale, field) {
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const data = shape.get('origin').data;
       const ratio = 0.3 + scale.scale(data[field]) * 0.6;
       shape.get('origin').size = ratio;
@@ -325,7 +325,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
   }
 
   private circleSizeMapping(shapes, scale, field) {
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const data = shape.get('origin').data;
       const ratio = 0.3 + scale.scale(data[field]) * 0.6;
       const { x, y, size } = shape.get('origin');
@@ -344,7 +344,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
 
   private circleDisableSizeMapping(shapes) {
     this.options.sizeField = null;
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const { x, y } = shape.get('origin');
       const size = Math.min(this.gridSize[0], this.gridSize[1]) * 0.9;
       shape.get('origin').size = size / 2;
@@ -362,7 +362,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
 
   private rectDisableSizeMapping(shapes) {
     this.options.sizeField = null;
-    _.each(shapes, (shape) => {
+    each(shapes, (shape) => {
       const bbox = shape.getBBox();
       const width = bbox.width;
       const height = bbox.height;
@@ -384,7 +384,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
   private getShapes() {
     const elements = this.view.geometries[0].elements;
     const shapes = [];
-    _.each(elements, (ele) => {
+    each(elements, (ele) => {
       shapes.push(ele.shape);
     });
     return shapes;
@@ -392,7 +392,7 @@ export default class MatrixLayer<T extends MatrixLayerConfig = MatrixLayerConfig
 
   protected renderPlotComponents() {
     const componentsType = ['label', 'legend'];
-    _.each(componentsType, (t) => {
+    each(componentsType, (t) => {
       const cfg = {
         view: this.view,
         plot: this,

--- a/src/plots/percentage-stack-area/index.ts
+++ b/src/plots/percentage-stack-area/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import PercentageStackAreaLayer, { PercentageStackAreaLayerConfig } from './layer';
 
@@ -11,7 +11,7 @@ export default class PercentageStackArea<
     PercentageStackAreaLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'percentageStackArea';
     super.createLayers(layerProps);
   }

--- a/src/plots/percentage-stack-area/layer.ts
+++ b/src/plots/percentage-stack-area/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import StackArea, { StackAreaViewConfig } from '../stack-area/layer';
@@ -10,7 +10,7 @@ export interface PercentageStackAreaLayerConfig extends PercentageStackAreaViewC
 
 export default class PercentageStackAreaLayer extends StackArea<PercentageStackAreaLayerConfig> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       yAxis: {
         visible: true,
         label: {
@@ -44,7 +44,7 @@ export default class PercentageStackAreaLayer extends StackArea<PercentageStackA
         return `${formattedValue}%`;
       },
     };
-    this.options.meta = _.deepMix({}, metaConfig, this.options.meta);
+    this.options.meta = deepMix({}, metaConfig, this.options.meta);
     super.scale();
   }
 }

--- a/src/plots/percentage-stack-bar/index.ts
+++ b/src/plots/percentage-stack-bar/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import PercentageStackBarLayer, { PercentageStackBarLayerConfig } from './layer';
 
@@ -11,7 +11,7 @@ export default class PercentageStackBar<T extends PercentageStackBarConfig = Per
     PercentageStackBarLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'percentageStackBar';
     super.createLayers(layerProps);
   }

--- a/src/plots/percentage-stack-bar/layer.ts
+++ b/src/plots/percentage-stack-bar/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import StackBar, { StackBarViewConfig } from '../stack-bar/layer';
@@ -10,7 +10,7 @@ export interface PercentageStackBarLayerConfig extends PercentageStackBarViewCon
 
 export default class PercentageStackBarLayer extends StackBar<PercentageStackBarLayerConfig> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       xAxis: {
         visible: true,
         tickLine: {

--- a/src/plots/pie/component/label/base-label.ts
+++ b/src/plots/pie/component/label/base-label.ts
@@ -1,7 +1,7 @@
 import { IGroup, IShape } from '@antv/g-canvas';
 import { View } from '@antv/g2';
 import * as matrixUtil from '@antv/matrix-util';
-import * as _ from '@antv/util';
+import { deepMix, isString } from '@antv/util';
 import { getEndPoint } from './utils';
 import { Label } from '../../../../interface/config';
 import PieLayer from '../../layer';
@@ -54,7 +54,7 @@ export default abstract class PieBaseLabel {
 
   constructor(plot: PieLayer, cfg: PieLabelConfig) {
     this.plot = plot;
-    const options = _.deepMix(this.getDefaultOptions(), cfg, {});
+    const options = deepMix(this.getDefaultOptions(), cfg, {});
     this.adjustOption(options);
     this.options = options;
     this.init();
@@ -113,7 +113,7 @@ export default abstract class PieBaseLabel {
       const content = formatter ? formatter(shapeInfo.name, { _origin: shapeInfo.origin }, idx) : shapeInfo.name;
       const itemGroup = this.container.addGroup({ name: 'itemGroup', index: idx });
       const textShape = itemGroup.addShape('text', {
-        attrs: _.deepMix(
+        attrs: deepMix(
           {},
           {
             ...shapeInfo,
@@ -200,7 +200,7 @@ export default abstract class PieBaseLabel {
   protected adjustOption(options: PieLabelConfig): void {
     let offset = options.offset;
     const { radius } = this.getCoordinate();
-    if (_.isString(offset)) {
+    if (isString(offset)) {
       offset = radius * percent2Number(offset);
     }
     options.offset = offset;

--- a/src/plots/pie/component/label/inner-label.ts
+++ b/src/plots/pie/component/label/inner-label.ts
@@ -1,5 +1,5 @@
 import { IShape } from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { each, clone } from '@antv/util';
 import PieBaseLabel, { LabelItem, PieLabelConfig } from './base-label';
 import { getOverlapInfo } from './utils';
 import { distBetweenPoints } from '../../../../util/math';
@@ -30,7 +30,7 @@ export default class PieInnerLabel extends PieBaseLabel {
   protected layout(labels: IShape[], shapeInfos: LabelItem[]) {
     labels.forEach((label, idx) => {
       if (idx > 0) {
-        _.each(labels.slice(0, idx), (prevLabel) => {
+        each(labels.slice(0, idx), (prevLabel) => {
           this.resolveCollision(label, prevLabel, shapeInfos[idx]);
         });
       }
@@ -61,9 +61,9 @@ export default class PieInnerLabel extends PieBaseLabel {
     const pos = { x: (box.minX + box.maxX) / 2, y: (box.minY + box.maxY) / 2 };
     // 两种调整方案
     /** 先偏移 x 方向 -> 再计算 y 位置 */
-    const pos1 = _.clone(pos);
+    const pos1 = clone(pos);
     /** 先偏移 y 方向 -> 再计算 x 位置 */
-    const pos2 = _.clone(pos);
+    const pos2 = clone(pos);
     // check overlap
     if (prev.get('id') !== label.get('id')) {
       const { xOverlap, yOverlap } = getOverlapInfo(box, prevBBox);

--- a/src/plots/pie/component/label/outer-center-label.ts
+++ b/src/plots/pie/component/label/outer-center-label.ts
@@ -1,5 +1,4 @@
 import { IShape, BBox } from '@antv/g-canvas';
-import * as _ from '@antv/util';
 import PieBaseLabel, { LabelItem, PieLabelConfig } from './base-label';
 import { getOverlapArea, near } from './utils';
 

--- a/src/plots/pie/component/label/outer-label.ts
+++ b/src/plots/pie/component/label/outer-label.ts
@@ -1,5 +1,5 @@
 import { IShape } from '@antv/g-canvas';
-import * as _ from '@antv/util';
+import { filter, last, head, map } from '@antv/util';
 import PieBaseLabel, { LabelItem, PieLabelConfig } from './base-label';
 import { getEndPoint } from './utils';
 
@@ -32,8 +32,8 @@ export default class PieOuterLabel extends PieBaseLabel {
   /** label 碰撞调整 */
   protected layout(labels: IShape[]) {
     const { center } = this.getCoordinate();
-    const leftHalf = _.filter(labels, (l) => l.attr('x') <= center.x);
-    const rightHalf = _.filter(labels, (l) => l.attr('x') > center.x);
+    const leftHalf = filter(labels, (l) => l.attr('x') <= center.x);
+    const rightHalf = filter(labels, (l) => l.attr('x') > center.x);
     [rightHalf, leftHalf].forEach((half, isLeft) => {
       this._antiCollision(half, !isLeft);
     });
@@ -89,7 +89,7 @@ export default class PieOuterLabel extends PieBaseLabel {
     }
     while (overlapping) {
       boxes.forEach((box) => {
-        const target = _.last(box.targets);
+        const target = last(box.targets);
         box.pos = Math.max(minY, Math.min(box.pos, target - box.size));
       });
       // detect overlapping and join boxes
@@ -104,7 +104,7 @@ export default class PieOuterLabel extends PieBaseLabel {
             previousBox.size += box.size;
             previousBox.targets = previousBox.targets.concat(box.targets);
             // overflow, shift up
-            const target = _.last(previousBox.targets);
+            const target = last(previousBox.targets);
             if (previousBox.pos + previousBox.size > target) {
               previousBox.pos = target - previousBox.size;
             }
@@ -145,14 +145,14 @@ export default class PieOuterLabel extends PieBaseLabel {
         return;
       }
       let ry = isBottom
-        ? _.last(adjustLabels).getBBox().maxY - center.y
-        : center.y - _.head(adjustLabels).getBBox().minY;
+        ? last(adjustLabels).getBBox().maxY - center.y
+        : center.y - head(adjustLabels).getBBox().minY;
       ry = Math.max(totalR, ry);
       const distance = offset > 4 ? 4 : 0;
       const maxLabelWidth =
         Math.max.apply(
           0,
-          _.map(labels, (label) => label.getBBox().width)
+          map(labels, (label) => label.getBBox().width)
         ) +
         offset +
         distance;
@@ -195,7 +195,7 @@ export default class PieOuterLabel extends PieBaseLabel {
   /** 获取label height */
   private getLabelHeight(labels: IShape[]): number {
     if (!this.options.labelHeight) {
-      return _.head(labels) ? _.head(labels).getBBox().height : 14;
+      return head(labels) ? head(labels).getBBox().height : 14;
     }
     return this.options.labelHeight;
   }

--- a/src/plots/pie/component/label/spider-label.ts
+++ b/src/plots/pie/component/label/spider-label.ts
@@ -1,6 +1,6 @@
 import { IGroup, Group, IShape, Shape } from '@antv/g-canvas';
 import { View } from '@antv/g2';
-import * as _ from '@antv/util';
+import { deepMix, clone, each, isString, mix } from '@antv/util';
 import { LooseMap } from '../../../../interface/types';
 import { getCenter } from './utils';
 
@@ -65,7 +65,7 @@ export default class SpiderLabel {
 
   constructor(cfg: ISpiderLabel) {
     this.view = cfg.view;
-    this.options = _.deepMix({}, this.getDefaultOptions(), cfg);
+    this.options = deepMix({}, this.getDefaultOptions(), cfg);
     this._adjustOptions(this.options);
     this.init();
   }
@@ -82,11 +82,11 @@ export default class SpiderLabel {
       return;
     }
     /** 如果有formatter则事先处理数据 */
-    const data = _.clone(this.view.getData());
+    const data = clone(this.view.getData());
     this.halves = [[], []];
     const shapes = [];
     const elements = this.view.geometries[0].elements;
-    _.each(elements, (ele) => {
+    each(elements, (ele) => {
       shapes.push(ele.shape);
     });
     this.coord = this.view.geometries[0].coordinate;
@@ -133,12 +133,12 @@ export default class SpiderLabel {
       };
       // 创建label文本
       let texts = [];
-      _.each(this.options.fields, (f) => {
+      each(this.options.fields, (f) => {
         texts.push(d[f]);
       });
       if (this.options.formatter) {
         let formatted: any = this.options.formatter(d[angleField], { _origin: d, color }, idx);
-        if (_.isString(formatted)) {
+        if (isString(formatted)) {
           formatted = [formatted];
         }
         texts = formatted;
@@ -157,12 +157,12 @@ export default class SpiderLabel {
       if (this.options.formatter) {
         lowerText = texts[0];
       }
-      const lowerTextAttrs = _.clone(textAttrs);
+      const lowerTextAttrs = clone(textAttrs);
       if (texts.length === 2) {
         lowerTextAttrs.fontWeight = 700;
       }
       const lowerTextShape: any = textGroup.addShape('text', {
-        attrs: _.mix(
+        attrs: mix(
           {
             textBaseline: texts.length === 2 ? 'top' : 'middle',
             text: lowerText,
@@ -177,7 +177,7 @@ export default class SpiderLabel {
       /** label2:上部label */
       if (texts.length === 2) {
         const topTextShape: any = textGroup.addShape('text', {
-          attrs: _.mix(
+          attrs: mix(
             {
               textBaseline: 'bottom',
               text: texts[1],
@@ -206,7 +206,7 @@ export default class SpiderLabel {
     /** 绘制label */
     const maxCountForOneSide = Math.floor(height / this.options.lineHeight);
 
-    _.each(this.halves, (half) => {
+    each(this.halves, (half) => {
       if (half.length > maxCountForOneSide) {
         half.splice(maxCountForOneSide, half.length - maxCountForOneSide);
       }

--- a/src/plots/pie/component/label/utils/text.ts
+++ b/src/plots/pie/component/label/utils/text.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { memoize, isString, values } from '@antv/util';
 const canvas = document.createElement('canvas');
 const ctx = canvas.getContext('2d');
 
@@ -13,13 +13,13 @@ interface Font {
 /**
  * 计算文本在画布中的宽度
  */
-export const measureTextWidth = _.memoize(
+export const measureTextWidth = memoize(
   (text: any, font: Font = {}): number => {
     const { fontSize, fontFamily, fontWeight, fontStyle, fontVariant } = font;
     ctx.font = [fontStyle, fontVariant, fontWeight, `${fontSize}px`, fontFamily].join(' ');
-    return ctx.measureText(_.isString(text) ? text : '').width;
+    return ctx.measureText(isString(text) ? text : '').width;
   },
-  (text: any, font: Font) => (font ? [text, ..._.values(font)].join('') : text)
+  (text: any, font: Font) => (font ? [text, ...values(font)].join('') : text)
 );
 
 /**
@@ -38,8 +38,8 @@ export const getEllipsisText = (text: any, maxWidth: number, font: Font, priorit
 
   let leftText;
 
-  if (!_.isString(text)) {
-    leftText = _.toString(text);
+  if (!isString(text)) {
+    leftText = toString(text);
   } else {
     leftText = text;
   }

--- a/src/plots/pie/event.ts
+++ b/src/plots/pie/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onPieContextmenu: 'interval:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import PieLayer, { PieViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class Pie extends BasePlot<PieConfig> {
   public static getDefaultOptions: typeof PieLayer.getDefaultOptions = PieLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'pie';
     super.createLayers(layerProps);
   }

--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -1,5 +1,5 @@
 import { Coordinate } from '@antv/g2/lib/dependents';
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import * as EventParser from './event';
 import ViewLayer, { ViewConfig } from '../../base/view-layer';
 import { DataItem, Label } from '../../interface/config';
@@ -36,7 +36,7 @@ const PLOT_GEOM_MAP = {
 
 export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       width: 400,
       height: 400,
       title: {
@@ -80,7 +80,7 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
   public getOptions(props: T) {
     // @ts-ignore
     const defaultOptions = this.constructor.getDefaultOptions();
-    const options = _.deepMix({}, super.getOptions(props), defaultOptions, props);
+    const options = deepMix({}, super.getOptions(props), defaultOptions, props);
     return options;
   }
 

--- a/src/plots/range-bar/animation.ts
+++ b/src/plots/range-bar/animation.ts
@@ -1,6 +1,6 @@
 import { IShape, Shape } from '@antv/g-canvas';
 import { registerAnimation } from '@antv/g2';
-import * as _ from '@antv/util';
+import { clone, each } from '@antv/util';
 
 // 记录之前的状态
 let shapeCache: IShape[];
@@ -40,7 +40,7 @@ export function setShapeCache(shapes) {
 
 function updateFromCenter(shape, animateCfg) {
   const fromPath = getShapeFromCache(shape).attr('path');
-  const toPath = _.clone(shape.attr('path'));
+  const toPath = clone(shape.attr('path'));
   shape.attr('path', fromPath);
   shape.animate(
     {
@@ -56,7 +56,7 @@ function updateFromCenter(shape, animateCfg) {
 function getShapeFromCache(shape) {
   const { id } = shape;
   let target;
-  _.each(shapeCache, (s) => {
+  each(shapeCache, (s) => {
     if (s.id === id) {
       target = s;
     }

--- a/src/plots/range-bar/index.ts
+++ b/src/plots/range-bar/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import RangeBarLayer, { RangeBarViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class RangeBar extends BasePlot<RangeBarConfig> {
   public static getDefaultOptions: typeof RangeBarLayer.getDefaultOptions = RangeBarLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'rangeBar';
     super.createLayers(layerProps);
   }

--- a/src/plots/range-bar/layer.ts
+++ b/src/plots/range-bar/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import BaseBarLayer, { BarViewConfig } from '../bar/layer';
@@ -13,7 +13,7 @@ export interface RangeBarLayerConfig extends RangeBarViewConfig, LayerConfig {}
 
 export default class RangeBarLayer extends BaseBarLayer<RangeBarLayerConfig> {
   public static getDefaultOptions(): Partial<RangeBarViewConfig> {
-    return _.deepMix(
+    return deepMix(
       super.getDefaultOptions(),
       {
         label: {
@@ -76,9 +76,9 @@ export default class RangeBarLayer extends BaseBarLayer<RangeBarLayerConfig> {
     // 为更新动画缓存shape
     const shapeCaches = [];
     const geoms = this.view.geometries;
-    _.each(geoms, (geom) => {
+    each(geoms, (geom) => {
       const elements = geom.elements;
-      _.each(elements, (ele) => {
+      each(elements, (ele) => {
         shapeCaches.push(ele.shape);
       });
     });

--- a/src/plots/range-column/animation.ts
+++ b/src/plots/range-column/animation.ts
@@ -1,6 +1,5 @@
 import { IShape } from '@antv/g-canvas';
 import { registerAnimation } from '@antv/g2';
-import * as _ from '@antv/util';
 
 // 记录之前的状态
 let shapeCache: IShape[];
@@ -40,7 +39,7 @@ export function setShapeCache(shapes) {
 
 function updateFromCenterVertical(shape, animateCfg) {
   const fromPath = getShapeFromCache(shape).attr('path');
-  const toPath = _.clone(shape.attr('path'));
+  const toPath = clone(shape.attr('path'));
   shape.attr('path', fromPath);
   shape.animate(
     {
@@ -56,7 +55,7 @@ function updateFromCenterVertical(shape, animateCfg) {
 function getShapeFromCache(shape) {
   const { id } = shape;
   let target;
-  _.each(shapeCache, (s) => {
+  each(shapeCache, (s) => {
     if (s.id === id) {
       target = s;
     }

--- a/src/plots/range-column/index.ts
+++ b/src/plots/range-column/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import RangeColumnLayer, { RangeColumnViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class RangeColumn extends BasePlot<RangeColumnConfig> {
   public static getDefaultOptions: typeof RangeColumnLayer.getDefaultOptions = RangeColumnLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'rangeColumn';
     super.createLayers(layerProps);
   }

--- a/src/plots/range-column/layer.ts
+++ b/src/plots/range-column/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import BaseColumnLayer, { ColumnViewConfig } from '../column/layer';
@@ -13,7 +13,7 @@ export interface RangeColumnLayerConfig extends RangeColumnViewConfig, LayerConf
 
 export default class RangeColumnLayer extends BaseColumnLayer<RangeColumnLayerConfig> {
   public static getDefaultOptions(): Partial<RangeColumnViewConfig> {
-    return _.deepMix(
+    return deepMix(
       super.getDefaultOptions(),
       {
         label: {
@@ -32,9 +32,9 @@ export default class RangeColumnLayer extends BaseColumnLayer<RangeColumnLayerCo
     // 为更新动画缓存shape
     const shapeCaches = [];
     const geoms = this.view.geometries;
-    _.each(geoms, (geom) => {
+    each(geoms, (geom) => {
       const elements = geom.elements;
-      _.each(elements, (ele) => {
+      each(elements, (ele) => {
         shapeCaches.push(ele.shape);
       });
     });

--- a/src/plots/stack-area/component/label/line-label.ts
+++ b/src/plots/stack-area/component/label/line-label.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { reduce, size } from '@antv/util';
 import LineLabel from '../../../line/component/label/line-label';
 
 /**
@@ -13,13 +13,13 @@ export default class AreaLineLabel extends LineLabel {
     const name = shape.get('origin').data[0][stackField];
 
     const y =
-      _.reduce(
+      reduce(
         lastPoint.y,
         (r: number, a: number): number => {
           return r + a;
         },
         0
-      ) / _.size(lastPoint.y);
+      ) / size(lastPoint.y);
 
     return { x: lastPoint.x, y, color, name };
   }

--- a/src/plots/stack-area/index.ts
+++ b/src/plots/stack-area/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import StackAreaLayer, { StackAreaLayerConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class StackArea extends BasePlot<StackAreaConfig> {
   public static getDefaultOptions: typeof StackAreaLayer.getDefaultOptions = StackAreaLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'stackArea';
     super.createLayers(layerProps);
   }

--- a/src/plots/stack-area/layer.ts
+++ b/src/plots/stack-area/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, get, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { ElementOption, Label } from '../../interface/config';
@@ -15,7 +15,7 @@ export default class StackAreaLayer<T extends StackAreaLayerConfig = StackAreaLa
   protected plotComponents: any[] = [];
 
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       label: {
         visible: false,
         type: 'area',
@@ -26,8 +26,8 @@ export default class StackAreaLayer<T extends StackAreaLayerConfig = StackAreaLa
   public type: string = 'stackArea';
 
   public beforeInit() {
-    const visible = _.get(this.options, ['label', 'visible']);
-    const type = _.get(this.options, ['label', 'type']);
+    const visible = get(this.options, ['label', 'visible']);
+    const type = get(this.options, ['label', 'type']);
     const options: any = this.options;
     if (visible) {
       if (type === 'line') {
@@ -74,7 +74,7 @@ export default class StackAreaLayer<T extends StackAreaLayerConfig = StackAreaLa
 
   protected renderPlotComponents() {
     const componentsType = ['areaLabel', 'lineLabel'];
-    _.each(componentsType, (t) => {
+    each(componentsType, (t) => {
       const cfg = {
         view: this.view,
         plot: this,

--- a/src/plots/stack-bar/index.ts
+++ b/src/plots/stack-bar/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import StackBarLayer, { StackBarViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class StackBar extends BasePlot<StackBarConfig> {
   public static getDefaultOptions: typeof StackBarLayer.getDefaultOptions = StackBarLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'stackBar';
     super.createLayers(layerProps);
   }

--- a/src/plots/stack-bar/layer.ts
+++ b/src/plots/stack-bar/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { ElementOption, Label } from '../../interface/config';
@@ -13,7 +13,7 @@ export interface StackBarLayerConfig extends StackBarViewConfig, LayerConfig {}
 
 export default class StackBarLayer<T extends StackBarLayerConfig = StackBarLayerConfig> extends BaseBarLayer<T> {
   public static getDefaultOptions() {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       xAxis: {
         visible: true,
         autoHideLabel: false,

--- a/src/plots/stack-column/component/label/stack-column-label.ts
+++ b/src/plots/stack-column/component/label/stack-column-label.ts
@@ -1,5 +1,4 @@
-import { registerElementLabels } from '@antv/g2';
-import * as _ from '@antv/util';
+import { registerGeometryLabel } from '@antv/g2';
 import { ColumnLabels } from '../../../column/component/label/column-label';
 
 class StackColumnLabels extends ColumnLabels {
@@ -15,4 +14,4 @@ class StackColumnLabels extends ColumnLabels {
   }
 }
 
-registerElementLabels('stackColumnLabel', StackColumnLabels);
+registerGeometryLabel('stackColumnLabel', StackColumnLabels);

--- a/src/plots/stack-column/index.ts
+++ b/src/plots/stack-column/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import StackColumnLayer, { StackColumnViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class StackColumn extends BasePlot<StackColumnConfig> {
   public static getDefaultOptions: typeof StackColumnLayer.getDefaultOptions = StackColumnLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'stackColumn';
     super.createLayers(layerProps);
   }

--- a/src/plots/step-line/index.ts
+++ b/src/plots/step-line/index.ts
@@ -1,0 +1,20 @@
+import { deepMix } from '@antv/util';
+import { PlotConfig } from '../..';
+import { StepLineViewConfig, StepLineLayer } from './layer';
+import BasePlot from '../../base/plot';
+
+export interface StepLineConfig extends StepLineViewConfig, PlotConfig {}
+
+export default class StepLine extends BasePlot<StepLineConfig> {
+  public static getDefaultOptions: typeof StepLineLayer.getDefaultOptions = StepLineLayer.getDefaultOptions;
+
+  /**
+   * 复写父类方法
+   * @param props
+   */
+  protected createLayers(props) {
+    const layerProps = deepMix({}, props);
+    layerProps.type = 'step-line';
+    super.createLayers(layerProps);
+  }
+}

--- a/src/plots/step-line/layer.ts
+++ b/src/plots/step-line/layer.ts
@@ -1,0 +1,23 @@
+import { deepMix } from '@antv/util';
+
+import LineLayer, { LineLayerConfig, LineViewConfig } from '../line/layer';
+import { LayerConfig } from '../..';
+import { registerPlotType } from '../../base/global';
+
+export interface StepLineViewConfig extends LineViewConfig {
+  readonly step?: 'hv' | 'vh' | 'vhv' | 'hvh'; // 默认为 hv
+}
+
+export interface StepLineLayerConfig extends StepLineViewConfig, LayerConfig {}
+
+export class StepLineLayer extends LineLayer<StepLineLayerConfig> {
+  public type: string = 'step-line'; // 覆写父类的 type
+
+  public static getDefaultOptions(): Partial<LineLayerConfig> {
+    return deepMix({}, super.getDefaultOptions(), {
+      step: 'hv',
+    });
+  }
+}
+
+registerPlotType('step-line', StepLineLayer);

--- a/src/plots/word-cloud/index.ts
+++ b/src/plots/word-cloud/index.ts
@@ -2,7 +2,7 @@
  * Create By Bruce Too
  * On 2020-02-14
  */
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import WordCloudLayer, { WordCloudViewConfig } from './layer';
 import { registerPlotType } from '../../base/global';
@@ -19,7 +19,7 @@ export default class WordCloud extends BasePlot<WordCloudConfig> {
     super(container, props);
   }
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'wordCloud';
     layerProps.container = this.containerDOM;
     super.createLayers(layerProps);

--- a/src/plots/word-cloud/layer.ts
+++ b/src/plots/word-cloud/layer.ts
@@ -3,7 +3,7 @@
  * On 2020-02-14
  */
 import { LayerConfig } from '../..';
-import * as _ from '@antv/util';
+import { get, deepMix } from '@antv/util';
 import Layer from '../../base/layer';
 import WordCloudTooltips from './word-cloud-tooltips';
 
@@ -123,8 +123,8 @@ export default class WordCloudLayer extends Layer<WordCloudLayerConfig> {
   constructor(props: WordCloudLayerConfig) {
     super(props);
     this._configHoverAction = props.onWordCloudHover;
-    this._enableToolTips = _.get(props, 'tooltip.visible', true);
-    this.options = _.deepMix(
+    this._enableToolTips = get(props, 'tooltip.visible', true);
+    this.options = deepMix(
       {},
       {
         width: 400,
@@ -226,7 +226,7 @@ export default class WordCloudLayer extends Layer<WordCloudLayerConfig> {
     } else {
       active = false;
     }
-    this.options = _.deepMix({}, this.options, {
+    this.options = deepMix({}, this.options, {
       minFontSize: fontSize[0],
       maxFontSize: fontSize[1],
       minRotation: rotation[0],
@@ -274,7 +274,7 @@ export default class WordCloudLayer extends Layer<WordCloudLayerConfig> {
     // but here i need scale it back
     const pixelRatio = this.canvas.get('width') / this.canvas.get('el').width;
     targetCtx.scale(pixelRatio, pixelRatio);
-    this.options = _.deepMix({}, this.options, { clearCanvas: false });
+    this.options = deepMix({}, this.options, { clearCanvas: false });
 
     this._start();
   }

--- a/src/plots/word-cloud/word-cloud-tooltips.ts
+++ b/src/plots/word-cloud/word-cloud-tooltips.ts
@@ -2,13 +2,13 @@
  * Create By Bruce Too
  * On 2020-02-14
  */
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import HtmlTooltip from '@antv/component/lib/tooltip/html';
 import { TooltipCfg } from '@antv/component/lib/tooltip/interface';
 
 export default class WordCloudTooltips extends HtmlTooltip {
   constructor(cfg: TooltipCfg) {
-    const newCfg = _.deepMix({}, cfg, {
+    const newCfg = deepMix({}, cfg, {
       itemTpl: `<div data-index={index}>
         <span style="background-color:{color};" class="g2-tooltip-marker"></span>
         {name}<span class="g2-tooltip-value">{value}</span></div>`,

--- a/src/sparkline/progress/component/marker.ts
+++ b/src/sparkline/progress/component/marker.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign, deepMix } from '@antv/util';
 import { View } from '@antv/g2';
 import { IGroup, IShape, Canvas } from '@antv/g-canvas';
 
@@ -21,7 +21,7 @@ export default class Marker<T extends MarkerConfig = MarkerConfig> {
   protected shape: IShape;
 
   constructor(cfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
     this.init();
   }
 
@@ -33,7 +33,7 @@ export default class Marker<T extends MarkerConfig = MarkerConfig> {
 
   public update(cfg: MarkerConfig, duration: number, easing: string) {
     let updateCfg: any = {};
-    _.assign(this, cfg);
+    assign(this, cfg);
     this.coord = this.view.geometries[0].coordinate;
     if (cfg.value) {
       const x = this.coord.convert({ x: 0, y: this.value }).x;
@@ -43,8 +43,8 @@ export default class Marker<T extends MarkerConfig = MarkerConfig> {
     if (cfg.style) {
       const shape: any = this.shape;
       const origin_attr = shape.attrs;
-      const attrs = _.deepMix({}, origin_attr, cfg.style);
-      updateCfg = _.deepMix({}, attrs, updateCfg);
+      const attrs = deepMix({}, origin_attr, cfg.style);
+      updateCfg = deepMix({}, attrs, updateCfg);
     }
     this.shape.stopAnimate();
     this.shape.animate(updateCfg, duration, easing);
@@ -56,7 +56,7 @@ export default class Marker<T extends MarkerConfig = MarkerConfig> {
     const x = this.coord.convert({ x: 0, y: this.value }).x; // progress坐标系是转置坐标系
     const y0 = this.coord.center.y - this.progressSize / 2 - 2;
     const y1 = this.coord.center.y + this.progressSize / 2 + 2;
-    const style = _.deepMix({}, { stroke: 'grey', lineWidth: 1 }, this.style);
+    const style = deepMix({}, { stroke: 'grey', lineWidth: 1 }, this.style);
     this.shape = this.container.addShape('path', {
       attrs: {
         path: [

--- a/src/sparkline/progress/event.ts
+++ b/src/sparkline/progress/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onProgressContextmenu: 'interval:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/sparkline/progress/index.ts
+++ b/src/sparkline/progress/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyPlot from '../tiny-plot';
 import ProgressLayer, { ProgressViewConfig } from './layer';
@@ -9,7 +9,7 @@ export default class Progress extends BasePlot<ProgressConfig> {
   public static getDefaultOptions: typeof ProgressLayer.getDefaultOptions = ProgressLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'progress';
     super.createLayers(layerProps);
   }

--- a/src/sparkline/progress/layer.ts
+++ b/src/sparkline/progress/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
@@ -57,7 +57,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
       barStyle: props.progressStyle,
       color: this.parseColorProps(props) || DEFAULT_COLOR,
     } as any;
-    props = _.mix(props, cfg);
+    props = mix(props, cfg);
   }
 
   public init() {
@@ -67,7 +67,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
 
   public update(cfg: UpdateConfig) {
     const props = this.options;
-    if (_.hasKey(cfg, 'percent')) {
+    if (hasKey(cfg, 'percent')) {
       props.percent = cfg.percent;
       this.changeData(this.processData());
     }
@@ -79,7 +79,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
 
     if (cfg.color) {
       let style;
-      if (_.isArray(cfg.color)) {
+      if (isArray(cfg.color)) {
         this.options.color = cfg.color;
         style = [{ fill: cfg.color[0] }, { fill: cfg.color[1] }];
       } else {
@@ -97,7 +97,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
 
   public destroy() {
     if (this.markers && this.markers.length > 0) {
-      _.each(this.markers, (marker) => {
+      each(this.markers, (marker) => {
         marker.destroy();
       });
       this.markers = [];
@@ -108,8 +108,8 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
   public afterRender() {
     if (this.options.marker && !this.markers) {
       this.markers = [];
-      _.each(this.options.marker, (cfg) => {
-        const markerCfg = _.mix(
+      each(this.options.marker, (cfg) => {
+        const markerCfg = mix(
           {
             canvas: this.canvas,
             view: this.view,
@@ -177,7 +177,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
         type: 'stack',
       },
     ];
-    if (_.has(props, 'animation')) {
+    if (has(props, 'animation')) {
       bar.animate = props.animation;
     }
     this.setConfig('geometry', bar);
@@ -190,13 +190,13 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
   protected parseColorProps(props) {
     let colorOption;
     if (props.color) {
-      if (_.isFunction(props.color)) {
+      if (isFunction(props.color)) {
         colorOption = props.color(props.percent);
       } else {
         colorOption = props.color;
       }
-      if (_.isString(colorOption)) {
-        const color = _.clone(DEFAULT_COLOR);
+      if (isString(colorOption)) {
+        const color = clone(DEFAULT_COLOR);
         color[0] = colorOption;
         return color;
       } else {
@@ -219,7 +219,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
     const markerLength = markerCfg.length;
     const animationOptions = this.getUpdateAnimationOptions();
     // marker diff
-    _.each(this.markers, (marker, index) => {
+    each(this.markers, (marker, index) => {
       if (index > markerLength - 1) {
         marker.destroy();
       } else {
@@ -230,7 +230,7 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
     if (this.markers.length < markerLength) {
       const startIndex = this.markers.length;
       for (let i = startIndex; i < markerLength; i++) {
-        const cfg = _.deepMix(
+        const cfg = deepMix(
           {},
           {
             canvas: this.canvas,
@@ -260,16 +260,16 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
     const progressShapes = [];
     const { view } = this;
     const geometry = view.geometries;
-    _.each(geometry, (geom) => {
+    each(geometry, (geom) => {
       if (geom.type === 'interval') {
         const elements = geom.elements;
-        _.each(elements, (ele) => {
+        each(elements, (ele) => {
           progressShapes.push(...ele.shape);
         });
       }
     });
-    if (_.isArray(style)) {
-      _.each(style, (s, index) => {
+    if (isArray(style)) {
+      each(style, (s, index) => {
         progressShapes[index].animate(s, duration, easing);
       });
     } else {
@@ -293,8 +293,8 @@ export default class ProgressLayer<T extends ProgressLayerConfig = ProgressLayer
   }
 
   private updateColorConfigByStyle(style) {
-    if (_.isArray(style)) {
-      _.each(style, (s, index) => {
+    if (isArray(style)) {
+      each(style, (s, index) => {
         if (s.fill) {
           this.options.color[index] = s.fill;
         }

--- a/src/sparkline/ring-progress/event.ts
+++ b/src/sparkline/ring-progress/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onRingProgressContextmenu: 'interval:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/sparkline/ring-progress/index.ts
+++ b/src/sparkline/ring-progress/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyPlot from '../tiny-plot';
 import RingProgressLayer, { RingProgressViewConfig } from './layer';
@@ -9,7 +9,7 @@ export default class RingProgress extends BasePlot<RingProgressConfig> {
   public static getDefaultOptions: typeof RingProgressLayer.getDefaultOptions = RingProgressLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'ringProgress';
     super.createLayers(layerProps);
   }

--- a/src/sparkline/ring-progress/layer.ts
+++ b/src/sparkline/ring-progress/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { mix } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
@@ -25,7 +25,7 @@ export default class RingProgressLayer extends ProgressLayer<RingProgressLayerCo
       barStyle: props.progressStyle,
       color: this.parseColorProps(props) || DEFAULT_COLOR,
     } as any;
-    props = _.mix(props, cfg);
+    props = mix(props, cfg);
   }
 
   protected coord() {

--- a/src/sparkline/tiny-area/event.ts
+++ b/src/sparkline/tiny-area/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -20,6 +20,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onLineContextmenu: 'line:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/sparkline/tiny-area/index.ts
+++ b/src/sparkline/tiny-area/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyAreaLayer, { TinyAreaViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class TinyArea extends BasePlot<TinyAreaConfig> {
   public static getDefaultOptions: typeof TinyAreaLayer.getDefaultOptions = TinyAreaLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'tinyArea';
     super.createLayers(layerProps);
   }

--- a/src/sparkline/tiny-area/layer.ts
+++ b/src/sparkline/tiny-area/layer.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';

--- a/src/sparkline/tiny-column/event.ts
+++ b/src/sparkline/tiny-column/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onColumnContextmenu: 'interval:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/sparkline/tiny-column/index.ts
+++ b/src/sparkline/tiny-column/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyColumnLayer, { TinyColumnLayerConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class TinyColumn extends BasePlot<TinyColumnConfig> {
   public static getDefaultOptions: typeof TinyColumnLayer.getDefaultOptions = TinyColumnLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'tinyColumn';
     super.createLayers(layerProps);
   }

--- a/src/sparkline/tiny-column/layer.ts
+++ b/src/sparkline/tiny-column/layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { mix, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';
@@ -65,7 +65,7 @@ export default class TinyColumnLayer extends TinyLayer<TinyColumnLayerConfig> {
       padding: [0, 0, 0, 0],
       columnSize: this.getSize(),
     } as any;
-    props = _.mix(props, cfg);
+    props = mix(props, cfg);
   }
 
   private getSize() {
@@ -77,7 +77,7 @@ export default class TinyColumnLayer extends TinyLayer<TinyColumnLayerConfig> {
 
   private getColumnNum(data, field) {
     const values = [];
-    _.each(data, (d) => {
+    each(data, (d) => {
       const v = d[field];
       if (values.indexOf(v) < 0) {
         values.push(v);

--- a/src/sparkline/tiny-layer.ts
+++ b/src/sparkline/tiny-layer.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix, each } from '@antv/util';
 import { LayerConfig } from '../base/layer';
 import ViewLayer, { ViewConfig } from '../base/view-layer';
 import { getComponent } from '../components/factory';
@@ -13,7 +13,7 @@ export interface TinyLayerConfig extends TinyViewConfig, LayerConfig {}
 
 export default abstract class TinyLayer<T extends TinyLayerConfig = TinyLayerConfig> extends ViewLayer<T> {
   public static getDefaultOptions(): any {
-    return _.deepMix({}, super.getDefaultOptions(), {
+    return deepMix({}, super.getDefaultOptions(), {
       title: {
         visible: false,
       },
@@ -51,10 +51,10 @@ export default abstract class TinyLayer<T extends TinyLayerConfig = TinyLayerCon
         },
       },
     };
-    _.each(props.guideLine, (line) => {
+    each(props.guideLine, (line) => {
       const guideLine = getComponent('guideLine', {
         plot: this,
-        cfg: _.deepMix({}, defaultGuidelineCfg, line),
+        cfg: deepMix({}, defaultGuidelineCfg, line),
       });
       config.push(guideLine);
     });

--- a/src/sparkline/tiny-line/event.ts
+++ b/src/sparkline/tiny-line/event.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { EVENT_MAP, IEventmap, onEvent } from '../../util/event';
 
 const SHAPE_EVENT_MAP: IEventmap = {
@@ -12,6 +12,6 @@ const SHAPE_EVENT_MAP: IEventmap = {
   onLineContextmenu: 'line:contextmenu',
 };
 
-_.assign(EVENT_MAP, SHAPE_EVENT_MAP);
+assign(EVENT_MAP, SHAPE_EVENT_MAP);
 
 export { EVENT_MAP, onEvent };

--- a/src/sparkline/tiny-line/index.ts
+++ b/src/sparkline/tiny-line/index.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import BasePlot, { PlotConfig } from '../../base/plot';
 import TinyLineLayer, { TinyLineViewConfig } from './layer';
 
@@ -8,7 +8,7 @@ export default class TinyLine extends BasePlot<TinyLineConfig> {
   public static getDefaultOptions: typeof TinyLineLayer.getDefaultOptions = TinyLineLayer.getDefaultOptions;
 
   public createLayers(props) {
-    const layerProps = _.deepMix({}, props);
+    const layerProps = deepMix({}, props);
     layerProps.type = 'tinyLine';
     super.createLayers(layerProps);
   }

--- a/src/sparkline/tiny-line/layer.ts
+++ b/src/sparkline/tiny-line/layer.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { getGeom } from '../../geoms/factory';

--- a/src/theme/global.ts
+++ b/src/theme/global.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import { DEFAULT_GLOBAL_THEME } from './default';
 import { DEFAULT_DARK_THEME } from './dark';
 
@@ -15,7 +15,7 @@ const GLOBAL_THEME_MAP: Record<string, any> = {
  */
 export function registerGlobalTheme(name: string, theme: any): void {
   const defaultTheme = getGlobalTheme();
-  GLOBAL_THEME_MAP[name.toLowerCase()] = _.deepMix({}, defaultTheme, theme);
+  GLOBAL_THEME_MAP[name.toLowerCase()] = deepMix({}, defaultTheme, theme);
 }
 
 /**

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import { getGlobalTheme } from './global';
 
 /**

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { clone } from '@antv/util';
 
 /**
  * mutable 的方式修改 axis 配置
@@ -8,17 +8,17 @@ import * as _ from '@antv/util';
 //   if (axis.line && axis.line.style) {
 //     const lineStyle = axis.line.style;
 //     delete axis.line.style;
-//     _.mix(axis.line, lineStyle);
+//     mix(axis.line, lineStyle);
 //   }
 //   if (axis.tickLine) {
 //     const tickLineStyle = axis.tickLine.style;
 //     delete axis.tickLine.style;
-//     _.mix(axis.tickLine, tickLineStyle);
+//     mix(axis.tickLine, tickLineStyle);
 //   }
 //   if (axis.grid) {
 //     const gridStyle = axis.grid.style;
 //     delete axis.grid.style;
-//     _.mix(axis.grid, gridStyle);
+//     mix(axis.grid, gridStyle);
 //   }
 //   if (axis.label) {
 //     if (axis.label.style) {
@@ -39,7 +39,7 @@ import * as _ from '@antv/util';
  * @param plotTheme
  */
 export function convertToG2Theme(plotTheme: any): any {
-  const g2Theme = _.clone(plotTheme);
+  const g2Theme = clone(plotTheme);
   /** tempo: legend margin设置为0 */
   if (!g2Theme.legend) {
     g2Theme.legend = {};
@@ -49,17 +49,17 @@ export function convertToG2Theme(plotTheme: any): any {
   //   if (g2Theme.axis.x) {
   //     convertToG2Axis(g2Theme.axis.x);
   //     g2Theme.axis.bottom = {};
-  //     _.deepMix(g2Theme.axis.bottom, g2Theme.axis.x, { position: 'bottom' });
+  //     deepMix(g2Theme.axis.bottom, g2Theme.axis.x, { position: 'bottom' });
   //     g2Theme.axis.top = {};
-  //     _.deepMix(g2Theme.axis.top, g2Theme.axis.x, { position: 'top' });
+  //     deepMix(g2Theme.axis.top, g2Theme.axis.x, { position: 'top' });
   //     delete g2Theme.axis.x;
   //   }
   //   if (g2Theme.axis.y) {
   //     convertToG2Axis(g2Theme.axis.y);
   //     g2Theme.axis.left = {};
-  //     _.deepMix(g2Theme.axis.left, g2Theme.axis.y, { position: 'left' });
+  //     deepMix(g2Theme.axis.left, g2Theme.axis.y, { position: 'left' });
   //     g2Theme.axis.right = {};
-  //     _.deepMix(g2Theme.axis.right, g2Theme.axis.y, { position: 'right' });
+  //     deepMix(g2Theme.axis.right, g2Theme.axis.y, { position: 'right' });
   //     delete g2Theme.axis.y;
   //   }
   // }

--- a/src/util/event.ts
+++ b/src/util/event.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ViewLayer from '../base/view-layer';
 import { LooseMap } from '../interface/types';
 

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,10 +1,10 @@
 import BBox from './bbox';
 import * as matrixUtil from '@antv/matrix-util';
-import * as _ from '@antv/util';
+import { each, clone } from '@antv/util';
 
 function magnitude(v) {
   let sum = 0;
-  _.each(v, (value) => {
+  each(v, (value) => {
     sum += value * value;
   });
   return Math.sqrt(sum);
@@ -139,7 +139,7 @@ function distBetweenPointLine(p, p1, p2) {
 function minDistBetweenPointPolygon(p, polygon) {
   let min = Infinity;
   /** vertice to vertice */
-  _.each(polygon, (v) => {
+  each(polygon, (v) => {
     const dist = Math.sqrt(dist2(v, p));
     if (min > dist) {
       min = dist;
@@ -176,13 +176,13 @@ function minDistBetweenConvexPolygon(polyA, polyB) {
   }
   let minA = Infinity;
   let minB = Infinity;
-  _.each(polyA, (v) => {
+  each(polyA, (v) => {
     const localMin = minDistBetweenPointPolygon(v, polyB);
     if (minA > localMin) {
       minA = localMin;
     }
   });
-  _.each(polyB, (v) => {
+  each(polyB, (v) => {
     const localMin = minDistBetweenPointPolygon(v, polyA);
     if (minB > localMin) {
       minB = localMin;
@@ -295,7 +295,7 @@ function DouglasPeucker(points, threshold) {
 
 /** 统计的以后迁出去，暂时先放这里 */
 function getMedian(array) {
-  const list = _.clone(array);
+  const list = clone(array);
   list.sort((a, b) => {
     return a - b;
   });
@@ -311,7 +311,7 @@ function getMedian(array) {
 
 function getMean(array) {
   let sum: number = 0;
-  _.each(array, (num: number) => {
+  each(array, (num: number) => {
     sum += num;
   });
   return sum / array.length;

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -3,7 +3,7 @@
  */
 
 import * as matrixUtil from '@antv/matrix-util';
-import * as _ from '@antv/util';
+import { each } from '@antv/util';
 const vector2 = matrixUtil.vec2;
 
 interface PointObject {
@@ -85,7 +85,7 @@ function _convertPolarPath(pre: any[], cur: any[], coord): any[] {
 
 // 当存在整体的圆时，去除圆前面和后面的线，防止出现直线穿过整个圆的情形
 function _filterFullCirleLine(path: any[]): void {
-  _.each(path, (subPath, index) => {
+  each(path, (subPath, index) => {
     const cur = subPath;
     if (cur[0].toLowerCase() === 'a') {
       const pre = path[index - 1];
@@ -227,7 +227,7 @@ export function getSplinePath(points: PointObject[], isInCircle: boolean, consta
     // 两点以内直接绘制成路径
     return getLinePath(points, isInCircle);
   }
-  _.each(points, (point) => {
+  each(points, (point) => {
     if (!prePoint || !(prePoint.x === point.x && prePoint.y === point.y)) {
       data.push(point.x);
       data.push(point.y);
@@ -257,7 +257,7 @@ export function getPointAngle(coord, point: PointObject): number {
 
 export function convertNormalPath(coord, path: any[]): any[] {
   const tmp = [];
-  _.each(path, (subPath) => {
+  each(path, (subPath) => {
     const action = subPath[0];
     switch (action.toLowerCase()) {
       case 'm':
@@ -280,7 +280,7 @@ export function convertPolarPath(coord, path: any[]): any[] {
   let cur: any[];
   let transposed: boolean;
   let equals: boolean;
-  _.each(path, (subPath, index) => {
+  each(path, (subPath, index) => {
     const action = subPath[0];
 
     switch (action.toLowerCase()) {

--- a/src/util/responsive/apply/axis.ts
+++ b/src/util/responsive/apply/axis.ts
@@ -1,5 +1,5 @@
 import { Axis } from '@antv/component';
-import * as _ from '@antv/util';
+import { each } from '@antv/util';
 import ShapeNodes from '../node/shape-nodes';
 import Responsive from '../responsive';
 import ApplyResponsive from './base';
@@ -25,12 +25,12 @@ function updateTicks(nodes, axis) {
   const ticks = axis.get('ticks');
   const tickItems = axis.get('tickItems');
   const tickTexts = [];
-  _.each(ticks, (tick) => {
+  each(ticks, (tick) => {
     const t = tick as any;
     tickTexts.push(t.text);
   });
   let pathes = [];
-  _.each(nodes.nodes, (node) => {
+  each(nodes.nodes, (node) => {
     const n = node as any;
     if (n.width > 0 && n.height > 0) {
       const text = n.shape.get('origin').text;

--- a/src/util/responsive/apply/base.ts
+++ b/src/util/responsive/apply/base.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 
 export default abstract class ApplyResponsive {
   public plot: any;
@@ -6,7 +6,7 @@ export default abstract class ApplyResponsive {
   public responsiveTheme: any;
 
   constructor(cfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
     this.init();
   }
 

--- a/src/util/responsive/apply/label.ts
+++ b/src/util/responsive/apply/label.ts
@@ -1,4 +1,3 @@
-import * as _ from '@antv/util';
 import ShapeNodes from '../node/shape-nodes';
 import Responsive from '../responsive';
 import ApplyResponsive from './base';

--- a/src/util/responsive/node/shape-nodes.ts
+++ b/src/util/responsive/node/shape-nodes.ts
@@ -1,6 +1,6 @@
 /** 负责将shape数据转为node，使shape根据node数据进行update */
 import { Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { deepMix, each } from '@antv/util';
 import * as MathUtil from '../../math';
 
 interface NodesCfg {
@@ -31,19 +31,19 @@ export default class ShapeNodes {
     this.shapes = cfg.shapes;
     this.nodes = [];
     this._parserNodes();
-    this.origion_nodes = _.deepMix([], this.nodes);
+    this.origion_nodes = deepMix([], this.nodes);
   }
 
   public measure(shape) {
-    const node = _.deepMix({}, MathUtil.bboxOnRotate(shape), { shape });
+    const node = deepMix({}, MathUtil.bboxOnRotate(shape), { shape });
     return node;
   }
 
   public measureNodes() {
     const nodes = [];
     const shapes = [];
-    _.each(this.shapes, (shape, index) => {
-      const node = _.deepMix({}, this.nodes[index], this.measure(shape));
+    each(this.shapes, (shape, index) => {
+      const node = deepMix({}, this.nodes[index], this.measure(shape));
       if (node.width !== 0 && node.height !== 0) {
         nodes.push(node);
         shapes.push(shape);
@@ -57,7 +57,7 @@ export default class ShapeNodes {
   public updateShapes() {}
 
   private _parserNodes() {
-    _.each(this.shapes, (shape) => {
+    each(this.shapes, (shape) => {
       const node = this.measure(shape);
       this.nodes.push(node);
     });

--- a/src/util/responsive/node/shape-nodes.ts
+++ b/src/util/responsive/node/shape-nodes.ts
@@ -1,10 +1,10 @@
 /** 负责将shape数据转为node，使shape根据node数据进行update */
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 import { deepMix, each } from '@antv/util';
 import * as MathUtil from '../../math';
 
 interface NodesCfg {
-  shapes: Shape[];
+  shapes: IShape[];
 }
 export interface IShapeNode {
   width: number;
@@ -19,11 +19,11 @@ export interface IShapeNode {
   topRight?: {};
   bottomLeft?: {};
   bottomRight?: {};
-  shape?: Shape;
+  shape?: IShape;
 }
 
 export default class ShapeNodes {
-  public shapes: Shape[];
+  public shapes: IShape[];
   public nodes: IShapeNode[];
   public origion_nodes: IShapeNode[];
   public type: string = 'shape';

--- a/src/util/responsive/node/variable-node.ts
+++ b/src/util/responsive/node/variable-node.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 
 interface NodesCfg {
   nodes: IVariableNode[];
@@ -13,7 +13,7 @@ export default class VariableNodes {
   public nodes: IVariableNode[];
   public type: string = 'variable';
   constructor(cfg: NodesCfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
   }
   public normalize() {}
 }

--- a/src/util/responsive/responsive.ts
+++ b/src/util/responsive/responsive.ts
@@ -1,6 +1,6 @@
 /** 可插拔的responsive模块 */
 import { BBox, Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { assign } from '@antv/util';
 import { constraintsLib } from './constraints/index';
 import ShapeNodes, { IShapeNode } from './node/shape-nodes';
 import VariableNodes from './node/variable-node';
@@ -47,7 +47,7 @@ export default class Responsive {
   public onEnd: (nodes: ShapeNodes | VariableNodes) => void;
 
   constructor(cfg: ResponsiveCfg) {
-    _.assign(this, cfg);
+    assign(this, cfg);
     this.currentConstraint = this.constraints[0];
     if (this.rules) {
       this.iterationTime = this.rules[this.currentConstraint.name].length;

--- a/src/util/responsive/responsive.ts
+++ b/src/util/responsive/responsive.ts
@@ -1,5 +1,6 @@
 /** 可插拔的responsive模块 */
-import { BBox, Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
+import { BBox } from '@antv/g-base/lib/types';
 import { assign } from '@antv/util';
 import { constraintsLib } from './constraints/index';
 import ShapeNodes, { IShapeNode } from './node/shape-nodes';
@@ -209,7 +210,7 @@ export default class Responsive {
     // }
   }
 
-  private _applyRule(shape: Shape, rule, option, index) {
+  private _applyRule(shape: IShape, rule, option, index) {
     const cfg = {
       nodes: this.nodes,
       region: this.region,

--- a/src/util/responsive/rules/clear-overlapping.ts
+++ b/src/util/responsive/rules/clear-overlapping.ts
@@ -1,5 +1,5 @@
 import { Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { each } from '@antv/util';
 import textHide from './text-hide';
 
 export default function clearOverlapping(shape: Shape, option, index, cfg) {
@@ -26,7 +26,7 @@ export default function clearOverlapping(shape: Shape, option, index, cfg) {
       return b.top - a.top;
     });
     /** 隐藏除最高点以外的node */
-    _.each(overlapped, (node: any, idx: number) => {
+    each(overlapped, (node: any, idx: number) => {
       if (idx > 0) {
         const _shape = node.shape;
         textHide(_shape);

--- a/src/util/responsive/rules/clear-overlapping.ts
+++ b/src/util/responsive/rules/clear-overlapping.ts
@@ -1,8 +1,8 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 import { each } from '@antv/util';
 import textHide from './text-hide';
 
-export default function clearOverlapping(shape: Shape, option, index, cfg) {
+export default function clearOverlapping(shape: IShape, option, index, cfg) {
   const nodes = cfg.nodes.nodes;
   const current = nodes[index];
   const overlapped = [];

--- a/src/util/responsive/rules/datetime-string-abbrevaite.ts
+++ b/src/util/responsive/rules/datetime-string-abbrevaite.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { each } from '@antv/util';
 import fecha from 'fecha';
 
 const SECOND = 1000;
@@ -69,7 +69,7 @@ function getDateTimeMode(a, b) {
     month: [MONTH, YEAR],
     year: [YEAR, Infinity],
   };
-  _.each(mapper, (range, key) => {
+  each(mapper, (range, key) => {
     if (dist >= range[0] && dist < range[1]) {
       mode = key;
     }

--- a/src/util/responsive/rules/digits-abbreviate.ts
+++ b/src/util/responsive/rules/digits-abbreviate.ts
@@ -1,4 +1,4 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 import { has, each } from '@antv/util';
 import { getMedian } from '../../math';
 
@@ -18,7 +18,7 @@ const unitMapper = {
 // https://jburrows.wordpress.com/2014/11/18/abbreviating-numbers/
 /*tslint:disable*/
 
-export default function digitsAbbreviate(shape: Shape, option: DigitsAbbreviateCfg, index, cfg) {
+export default function digitsAbbreviate(shape: IShape, option: DigitsAbbreviateCfg, index, cfg) {
   if (!has(cfg, 'node') || !has(cfg.node, 'node')) {
     return;
   }

--- a/src/util/responsive/rules/digits-abbreviate.ts
+++ b/src/util/responsive/rules/digits-abbreviate.ts
@@ -1,5 +1,5 @@
 import { Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { has, each } from '@antv/util';
 import { getMedian } from '../../math';
 
 interface DigitsAbbreviateCfg {
@@ -19,7 +19,7 @@ const unitMapper = {
 /*tslint:disable*/
 
 export default function digitsAbbreviate(shape: Shape, option: DigitsAbbreviateCfg, index, cfg) {
-  if (!_.has(cfg, 'node') || !_.has(cfg.node, 'node')) {
+  if (!has(cfg, 'node') || !has(cfg.node, 'node')) {
     return;
   }
   const nodes = cfg.nodes.nodes;
@@ -74,7 +74,7 @@ function getUnitByNumber(number) {
 
 function extractNumbers(nodes) {
   const numbers = [];
-  _.each(nodes, (node) => {
+  each(nodes, (node) => {
     const n = node as any;
     const number = parseFloat(n.shape.get('origin').text);
     numbers.push(number);

--- a/src/util/responsive/rules/node-jitter-upward.ts
+++ b/src/util/responsive/rules/node-jitter-upward.ts
@@ -1,10 +1,10 @@
-import { Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { IShape } from '@antv/g-base/lib/interfaces';
+import { each } from '@antv/util';
 import { isNodeOverlap } from './clear-overlapping';
 
 /** 图形向上抖开并拉线 */
 // todo 允许设置offset和拉线样式
-export default function nodeJitterUpward(shape: Shape, option, index, cfg) {
+export default function nodeJitterUpward(shape: IShape, option, index, cfg) {
   const nodes = cfg.nodes.nodes;
   if (index === 0) {
     return;
@@ -48,9 +48,9 @@ export default function nodeJitterUpward(shape: Shape, option, index, cfg) {
 
 function getShapeById(shapeId, shapes) {
   let target;
-  _.each(shapes, (shape) => {
-    const s = shape as Shape;
-    const id = s.id;
+  each(shapes, (shape) => {
+    const s = shape as IShape;
+    const id = s.get('id');
     if (id === shapeId) {
       target = s;
     }

--- a/src/util/responsive/rules/node-jitter.ts
+++ b/src/util/responsive/rules/node-jitter.ts
@@ -1,8 +1,8 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 import { dotProduct2D } from '../../math';
 
 /** 图形在水平或垂直方向抖开 */
-export default function nodeJitter(shape: Shape, option, index, cfg) {
+export default function nodeJitter(shape: IShape, option, index, cfg) {
   const nodes = cfg.nodes.nodes;
   if (index === nodes.length - 1) {
     return;

--- a/src/util/responsive/rules/nodes-resampling-by-change.ts
+++ b/src/util/responsive/rules/nodes-resampling-by-change.ts
@@ -1,9 +1,9 @@
-import { Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { IShape } from '@antv/g-base/lib/interfaces';
+import { deepMix } from '@antv/util';
 import textHide from './text-hide';
 
 /** 根据变化进行抽样，保留变化较大的点，类似于点简化算法 */
-export default function nodesResamplingByChange(shape: Shape, option, index, cfg) {
+export default function nodesResamplingByChange(shape: IShape, option, index, cfg) {
   const nodes = cfg.nodes.nodes;
   const tolerance = getGlobalTolerance(nodes);
   if (index <= 1) {
@@ -31,7 +31,7 @@ function findPrevious(index, nodes) {
 }
 
 function getGlobalTolerance(nodes) {
-  const nodesClone = _.deepMix([], nodes);
+  const nodesClone = deepMix([], nodes);
   nodesClone.sort((a, b) => {
     return b.width - a.width;
   });

--- a/src/util/responsive/rules/nodes-resampling-by-state.ts
+++ b/src/util/responsive/rules/nodes-resampling-by-state.ts
@@ -1,8 +1,8 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 import { each, clone } from '@antv/util';
 import textHide from './text-hide';
 
-export default function nodesResamplingByState(shape: Shape, option, index, cfg) {
+export default function nodesResamplingByState(shape: IShape, option, index, cfg) {
   const nodes = cfg.nodes.nodes;
   const current = nodes[index];
   if (current.line) {

--- a/src/util/responsive/rules/nodes-resampling-by-state.ts
+++ b/src/util/responsive/rules/nodes-resampling-by-state.ts
@@ -1,5 +1,5 @@
 import { Shape } from '@antv/g';
-import * as _ from '@antv/util';
+import { each, clone } from '@antv/util';
 import textHide from './text-hide';
 
 export default function nodesResamplingByState(shape: Shape, option, index, cfg) {
@@ -14,7 +14,7 @@ export default function nodesResamplingByState(shape: Shape, option, index, cfg)
   const stateNodes = getStateNodes(data, field, nodes);
 
   let isState = false;
-  _.each(stateNodes, (node) => {
+  each(stateNodes, (node) => {
     // @ts-ignore
     if (node.shape.get('origin') === current.shape.get('origin')) {
       isState = true;
@@ -33,7 +33,7 @@ export default function nodesResamplingByState(shape: Shape, option, index, cfg)
 
 function getStateNodes(data, field, nodes) {
   const extract_data = [];
-  _.each(data, (d) => {
+  each(data, (d) => {
     extract_data.push(d[field]);
   });
   extract_data.sort((a, b) => {
@@ -50,7 +50,7 @@ function getStateNodes(data, field, nodes) {
 }
 
 function getMedian(array) {
-  const list = _.clone(array);
+  const list = clone(array);
   list.sort((a, b) => {
     return a - b;
   });

--- a/src/util/responsive/rules/nodes-resampling.ts
+++ b/src/util/responsive/rules/nodes-resampling.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { each, isNumber } from '@antv/util';
 import textHide from './text-hide';
 
 export interface NodesResamplingCfg {
@@ -23,12 +23,12 @@ export default function nodesResampling(shape, option: NodesResamplingCfg, index
 export function isKeep(keepCfg, index, nodes) {
   /** 允许设置start end 或任意index */
   const conditions = [];
-  _.each(keepCfg, (cfg) => {
+  each(keepCfg, (cfg) => {
     if (cfg === 'start') {
       conditions.push(index === 0);
     } else if (cfg === 'end') {
       conditions.push(index === nodes.length - 1);
-    } else if (_.isNumber(cfg)) {
+    } else if (isNumber(cfg)) {
       conditions.push(index === cfg);
     }
   });

--- a/src/util/responsive/rules/robust-abbrevaite.ts
+++ b/src/util/responsive/rules/robust-abbrevaite.ts
@@ -1,4 +1,4 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 
 import datetimeStringAbbrevaite, { isTime } from './datetime-string-abbrevaite';
 import digitsAbbreviate from './digits-abbreviate';
@@ -11,7 +11,7 @@ interface RobustAbbrevaiteCfg {
   decimal?: number;
 }
 
-export default function robustAbbrevaite(shape: Shape, option: RobustAbbrevaiteCfg, index, cfg) {
+export default function robustAbbrevaite(shape: IShape, option: RobustAbbrevaiteCfg, index, cfg) {
   const nodes = cfg.nodes.nodes;
   const text = shape.attr('text');
   /** 判断text类型： 数字、时间、文本 */

--- a/src/util/responsive/rules/text-abbreviate.ts
+++ b/src/util/responsive/rules/text-abbreviate.ts
@@ -1,9 +1,9 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 
 interface TextAbbreviateCfg {
   abbreviateBy?: 'start' | 'middle' | 'end';
 }
-export default function textAbbreviate(shape: Shape, option: TextAbbreviateCfg) {
+export default function textAbbreviate(shape: IShape, option: TextAbbreviateCfg) {
   const abbreviateBy = option.abbreviateBy ? option.abbreviateBy : 'end';
   const text = shape.attr('text');
   let abbravateText;

--- a/src/util/responsive/rules/text-hide.ts
+++ b/src/util/responsive/rules/text-hide.ts
@@ -1,5 +1,5 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 
-export default function textHide(shape: Shape) {
+export default function textHide(shape: IShape) {
   shape.attr('text', '');
 }

--- a/src/util/responsive/rules/text-rotation.ts
+++ b/src/util/responsive/rules/text-rotation.ts
@@ -1,10 +1,10 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 
 interface TextRotationCfg {
   degree: number;
 }
 
-export default function textRotation(shape: Shape, option: TextRotationCfg) {
+export default function textRotation(shape: IShape, option: TextRotationCfg) {
   shape.resetMatrix();
   shape.attr({
     rotate: 360 - option.degree,

--- a/src/util/responsive/rules/text-wrapper.ts
+++ b/src/util/responsive/rules/text-wrapper.ts
@@ -1,10 +1,10 @@
-import { Shape } from '@antv/g';
+import { IShape } from '@antv/g-base/lib/interfaces';
 
 interface TextWrapperCfg {
   lineNumber: number;
 }
 
-export default function textWrapper(shape: Shape, option: TextWrapperCfg) {
+export default function textWrapper(shape: IShape, option: TextWrapperCfg) {
   const text = shape.attr('text');
   const step = Math.ceil(text.length / option.lineNumber);
   let wrapperText = '';

--- a/src/util/responsive/theme.ts
+++ b/src/util/responsive/theme.ts
@@ -1,4 +1,4 @@
-import * as _ from '@antv/util';
+import { deepMix } from '@antv/util';
 import { DEFAULT_RESPONSIVE_THEME } from './default';
 
 /**
@@ -14,7 +14,7 @@ const RESPONSIVE_THEME_MAP = {
  * @param theme
  */
 export function registerResponsiveTheme(name: string, theme) {
-  RESPONSIVE_THEME_MAP[name.toLowerCase()] = _.deepMix({}, DEFAULT_RESPONSIVE_THEME, theme);
+  RESPONSIVE_THEME_MAP[name.toLowerCase()] = deepMix({}, DEFAULT_RESPONSIVE_THEME, theme);
 }
 
 /**

--- a/src/util/state-manager.ts
+++ b/src/util/state-manager.ts
@@ -3,7 +3,7 @@
  */
 // todo: 后续还需要加入交互互斥的维护机制
 import EventEmitter from '@antv/event-emitter';
-import * as _ from '@antv/util';
+import { each } from '@antv/util';
 import { LooseMap } from '../interface/types';
 
 type States = LooseMap;
@@ -55,7 +55,7 @@ export default class StateManager extends EventEmitter {
 
     this._changeTimer = setTimeout(() => {
       // for (const name in stateStack) {
-      _.each(stateStack, (exp, name) => {
+      each(stateStack, (exp, name) => {
         const state = stateStack[name];
         if (!this._states[name] || this._states[name] !== exp) {
           // update states

--- a/src/util/style-parser.ts
+++ b/src/util/style-parser.ts
@@ -1,11 +1,11 @@
-import * as _ from '@antv/util';
+import { clone } from '@antv/util';
 
 function AxisStyleParser(axisCfg, axis) {
   if (axis.line) {
     if (axis.line.visible === false) {
       axisCfg.line = null;
     } else if (axis.line.style) {
-      axisCfg.line = _.clone(axis.line.style);
+      axisCfg.line = clone(axis.line.style);
     }
   }
   if (axis.title) {
@@ -18,7 +18,7 @@ function AxisStyleParser(axisCfg, axis) {
       if (axisCfg.autoRotate) {
         axisCfg.autoRotateTitle = axisCfg.autoRotate;
       }
-      axisCfg.title = _.clone(axis.title);
+      axisCfg.title = clone(axis.title);
       if (axisCfg.title.style) {
         axisCfg.title.textStyle = axisCfg.title.style;
         delete axisCfg.title.style;
@@ -29,7 +29,7 @@ function AxisStyleParser(axisCfg, axis) {
     if (axis.tickLine.visible === false) {
       axisCfg.tickLine = null;
     } else if (axis.tickLine.style) {
-      axisCfg.tickLine = _.clone(axis.tickLine.style);
+      axisCfg.tickLine = clone(axis.tickLine.style);
     }
   }
   if (Object.prototype.hasOwnProperty.call(axis, 'autoHideLabel')) {
@@ -42,7 +42,7 @@ function AxisStyleParser(axisCfg, axis) {
     if (axis.label.visible === false) {
       axisCfg.label = null;
     } else {
-      const newLabel = _.clone(axis.label);
+      const newLabel = clone(axis.label);
       if (newLabel.style) {
         newLabel.textStyle = newLabel.style;
         delete newLabel.style;
@@ -62,9 +62,9 @@ function AxisStyleParser(axisCfg, axis) {
     if (axis.grid.visible === false) {
       axisCfg.grid = null;
     } else {
-      axisCfg.grid = _.clone(axis.grid);
+      axisCfg.grid = clone(axis.grid);
       if (axis.grid.style) {
-        axisCfg.grid = _.clone(axis.grid.style);
+        axisCfg.grid = clone(axis.grid.style);
       }
     }
   }


### PR DESCRIPTION
- 迁移 step line
- 将 @antv/util 的应用全部改为按需引用
- 将 @antv/g 的错误纠正 

对于 G.Shape 和 G.Group 的类型定义，建议引用 g-base 提供的通用接口定义：

```ts
import { IShape } from '@antv/g-base/lib/interfaces';

import { BBox } from '@antv/g-base/lib/types';
```

建议对于一些依赖模块的引用，可以统一放置在 dependents.ts 下，然后内部使用全部从该文件引入，统一入口，方便后续管理。