### PR TITLE
fix：修复 pie outer-center-label 下引线 path 问题 

### DIFF
--- a/src/plots/pie/component/label/outer-center-label.ts
+++ b/src/plots/pie/component/label/outer-center-label.ts
@@ -63,7 +63,7 @@ class OuterCenterPieLabel extends BasePieLabel {
     path = [`M ${start.x}`, `${start.y} Q${breakAt.x}`, `${breakAt.y} ${end.x}`, end.y].join(',');
     if (smooth === false) {
       // normal path rule, draw path is "M -> L -> H"
-      path = [`M ${start.x}`, `${start.y} L${breakAt.x - distance}`, `${end.y} H${end.x}`].join(',');
+      path = [`M ${start.x}`, `${start.y} L${breakAt.x}`, `${breakAt.y} H${end.x}`].join(',');
     }
     return path;
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9314735/75094486-831fb400-55c6-11ea-9985-47c7a52de222.png)

复现链接：https://riddle.alibaba-inc.com/riddles/266d13e6


