### PR TITLE
fix(ring): 修复环图中心文本定位问题

### DIFF
--- a/src/plots/ring/layer.ts
+++ b/src/plots/ring/layer.ts
@@ -1,3 +1,4 @@
+import { modifyCSS } from '@antv/dom-util';
 import { deepMix, each } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
@@ -67,8 +68,10 @@ export default class RingLayer<T extends RingLayerConfig = RingLayerConfig> exte
     const options = this.options;
     /**环图中心文本 */
     if (this.options.statistic && this.options.statistic.visible) {
+      const container = this.canvas.get('container');
+      modifyCSS(container, { position: 'relative' });
       this.statistic = new RingStatistic({
-        container: this.canvas.get('container'),
+        container,
         view: this.view,
         plot: this,
         statisticClass: this.statisticClass,


### PR DESCRIPTION
master 版本会自动给container加上position relative, 1.x 版本在环图存在中心文本的时候处理.后续看清楚再做统一处理