### PR TITLE
【0.1.x】fix: 支持饼图 label line 上的样式配置

### DIFF
--- a/src/plots/pie/layer.ts
+++ b/src/plots/pie/layer.ts
@@ -240,7 +240,7 @@ export default class PieLayer<T extends PieLayerConfig = PieLayerConfig> extends
       labelConfig.labelLine = false;
     } else {
       // @ts-ignore
-      labelConfig.labelLine = true;
+      labelConfig.labelLine = labelConfig && labelConfig.line ? labelConfig.line : true;
     }
     if (labelConfig.formatter) {
       const customFormatter = labelConfig.formatter;


### PR DESCRIPTION
在 pie 图 label 上 line 为配置项，G2 3.6.x 内部是 labelLine，需要对齐