### PR TITLE
fix(types): fix type definition error

### DIFF
--- a/src/plots/range-bar/layer.ts
+++ b/src/plots/range-bar/layer.ts
@@ -6,7 +6,7 @@ import RangeBarLabel, { RangeBarLabelConfig } from './component/label';
 import { setShapeCache } from './animation';
 
 export interface RangeBarViewConfig extends BarViewConfig {
-  label: RangeBarLabelConfig;
+  label?: RangeBarLabelConfig;
 }
 
 export interface RangeBarLayerConfig extends RangeBarViewConfig, LayerConfig {}

--- a/src/plots/range-column/layer.ts
+++ b/src/plots/range-column/layer.ts
@@ -6,7 +6,7 @@ import RangeColumnLabel, { RangeColumnLabelConfig } from './component/label';
 import { setShapeCache } from './animation';
 
 export interface RangeColumnViewConfig extends ColumnViewConfig {
-  label: RangeColumnLabelConfig;
+  label?: RangeColumnLabelConfig;
 }
 
 export interface RangeColumnLayerConfig extends RangeColumnViewConfig, LayerConfig {}


### PR DESCRIPTION
- mark `RangeColumnViewConfig.labe`l as optional
- mark `RangeBarViewConfig.label` as optional

`label` is optional in [document](https://g2plot.antv.vision/zh/docs/manual/plots/range-column#label), but required in type definitions

https://github.com/antvis/G2Plot/blob/f5336becba2228ed3bb1180ce07ca3791c899ab7/src/plots/range-column/layer.ts#L8-L10

