### PR TITLE
【1.x】G2Plot label.formatter 兼容 G2 4.x label.content

### DIFF
--- a/__tests__/unit/plots/scatter/scatter-spec.ts
+++ b/__tests__/unit/plots/scatter/scatter-spec.ts
@@ -305,6 +305,51 @@ describe('Scatter plot', () => {
     expect(labelShapes.length).toBe(0);
   });
 
+  it('scatter label formatter', () => {
+    const scatterPlot = new Scatter(canvasDiv, {
+      width: 600,
+      height: 600,
+      data,
+      xField: 'GDP',
+      yField: 'LifeExpectancy',
+      colorField: 'continent',
+      label: {
+        visible: true,
+        formatter: (text, data, index) => {
+          return `${data['continent']} ${index}`;
+        },
+      },
+    });
+    scatterPlot.render();
+
+    let view = scatterPlot.getLayer().view;
+    let labelShapes = view.foregroundGroup.findAll((el) => {
+      return el.get('name') === 'label';
+    });
+    labelShapes.forEach((label, index) => {
+      // @ts-ignore
+      expect(label.cfg.children[0].attr('text')).toBe(`${data[index]['continent']} ${index}`);
+    });
+
+    scatterPlot.updateConfig({
+      label: {
+        formatter: (text) => {
+          return text;
+        },
+      },
+    });
+    scatterPlot.render();
+
+    view = scatterPlot.getLayer().view;
+    labelShapes = view.foregroundGroup.findAll((el) => {
+      return el.get('name') === 'label';
+    });
+    labelShapes.forEach((label, index) => {
+      // @ts-ignore
+      expect(label.cfg.children[0].attr('text')).toBe(data[index]['LifeExpectancy']);
+    });
+  });
+
   it('scatter animate', () => {
     const scatterPlot = new Scatter(canvasDiv, {
       width: 600,

--- a/src/components/label/parser.ts
+++ b/src/components/label/parser.ts
@@ -71,16 +71,17 @@ export default class LabelParser {
 
   protected parseFormatter(config: LooseMap, ...values: any[]) {
     const labelProps = this.originConfig;
-    config.formatter = combineFormatter(
-      getNoopFormatter(),
-      getPrecisionFormatter(labelProps.precision),
-      getSuffixFormatter(labelProps.suffix)
-    );
-    if (labelProps.formatter) {
-      config.formatter = combineFormatter(
-        config.formatter,
-        labelProps.formatter as (text: string, item: any, idx: number) => string
-      );
-    }
+    config.content = (data, mappingData, index) => {
+      // @ts-ignore
+      const text = data[labelProps.fields[0]];
+      return combineFormatter(
+        getNoopFormatter(),
+        getPrecisionFormatter(labelProps.precision),
+        getSuffixFormatter(labelProps.suffix),
+        (labelProps.formatter as (text: string, item: any, idx: number) => string)
+          ? labelProps.formatter
+          : getNoopFormatter()
+      )(text, data, index);
+    };
   }
 }

--- a/src/plots/scatter/layer.ts
+++ b/src/plots/scatter/layer.ts
@@ -225,6 +225,7 @@ export default class ScatterLayer<T extends ScatterLayerConfig = ScatterLayerCon
 
     const label = getComponent('label', {
       fields: [props.yField],
+      ...props.label,
       plot: this,
     });
 


### PR DESCRIPTION
在 G2 4.x 中 label 上没有 formatter 了，只有 content，并且参数上存在增强，目前做法是兼容老的 API，label.content 中的 mappingData 是否要从 G2Plot 中透出？

![image](https://user-images.githubusercontent.com/9314735/76230495-c2a0fe00-625e-11ea-8555-8965a6d18446.png)
