### PR TITLE
fix: cleanup webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,10 +59,6 @@ module.exports = {
     new webpack.optimize.AggressiveMergingPlugin(),
     ...(process.env.MODE === 'ANALYZER' ? [new BundleAnalyzerPlugin({ analyzerMode: 'static' })] : []),
   ],
-  externals: {
-    moment: 'moment',
-    '../moment': 'moment',
-  },
   performance: {
     hints: false,
   },


### PR DESCRIPTION
- moment依赖的问题在 https://github.com/antvis/component/pull/148 中修复
- 现在打包产物还有G有两份的问题，等G2升级G发布后，再发G2Plot