### PR TITLE
feat: 修复updateConfig后状态量更新失效

### DIFF
--- a/src/base/controller/state.ts
+++ b/src/base/controller/state.ts
@@ -52,10 +52,8 @@ export default class StateController {
 
   public setState(cfg) {
     const { type, condition, related } = cfg;
-    if (!this.shapes) {
-      this.shapes = this._getShapes();
-      this.originAttrs = this._getOriginAttrs();
-    }
+    this.shapes = this._getShapes();
+    this.originAttrs = this._getOriginAttrs();
     // this.resetZIndex();
     each(this.shapes, (shape, index) => {
       const shapeOrigin = shape.get('origin').data;


### PR DESCRIPTION
当图表updateConfig后，view重新destory并更新，但是stateController中缓存了旧的shapes，导致新设置的状态apply到了旧的图形中，并且旧的图形已经被销毁，所以导致无法通过 shape.get('origin').data 获取到数据。