### PR TITLE
docs: fix English gallery page wrong order

### DIFF
--- a/examples/step-line/basic/index.en.md
+++ b/examples/step-line/basic/index.en.md
@@ -1,5 +1,5 @@
 ---
-title: Line Chart
+title: Basic StepLine Chart
 order: 0
 ---
 

--- a/examples/step-line/multiple/index.en.md
+++ b/examples/step-line/multiple/index.en.md
@@ -1,5 +1,5 @@
 ---
-title: Multiple Line Chart
+title: Multiple StepLine Chart
 order: 1
 ---
 


### PR DESCRIPTION
close antvis/gatsby-theme-antv#120

阶梯图里的英文分类名和折线图里的重名，导致了两个分类的 demo 混在一起了。