### PR TITLE
feat: line point shape callback

### DIFF
--- a/src/geoms/point/guide.ts
+++ b/src/geoms/point/guide.ts
@@ -1,5 +1,5 @@
 import { LooseObject } from '../../dependents';
-import { each, uniq, keys, isFunction, isString, isArray, has, get } from '@antv/util';
+import { each, uniq, keys, isFunction, isString, isArray, has, get, isObject } from '@antv/util';
 import ElementParser from '../base';
 
 function getValuesByField(field, data) {
@@ -12,6 +12,8 @@ function getValuesByField(field, data) {
 }
 
 const COLOR_MAPPER = ['seriesField', 'stackField'];
+
+type PointShape =  string | { fields?:[]; callback:()=>string; }
 
 export default class GuidePointParser extends ElementParser {
   public init() {
@@ -66,10 +68,14 @@ export default class GuidePointParser extends ElementParser {
     this.config.size = config;
   }
 
-  public parseShape(shapeName) {
-    const config: LooseObject = {
-      values: [shapeName],
-    };
+  public parseShape(shapeCfg:PointShape) {
+    const config: LooseObject = {};
+    if(isString(shapeCfg)){
+      config.values = [shapeCfg];
+    }else if(isObject(shapeCfg)){
+      config.fields = shapeCfg.fields;
+      config.callback = shapeCfg.callback;
+    }
     this.config.shape = config;
   }
 

--- a/src/geoms/point/guide.ts
+++ b/src/geoms/point/guide.ts
@@ -13,7 +13,7 @@ function getValuesByField(field, data) {
 
 const COLOR_MAPPER = ['seriesField', 'stackField'];
 
-type PointShape =  string | { fields?:[]; callback:()=>string; }
+type PointShape = string | { fields?: []; callback: () => string };
 
 export default class GuidePointParser extends ElementParser {
   public init() {
@@ -68,11 +68,11 @@ export default class GuidePointParser extends ElementParser {
     this.config.size = config;
   }
 
-  public parseShape(shapeCfg:PointShape) {
+  public parseShape(shapeCfg: PointShape) {
     const config: LooseObject = {};
-    if(isString(shapeCfg)){
+    if (isString(shapeCfg)) {
       config.values = [shapeCfg];
-    }else if(isObject(shapeCfg)){
+    } else if (isObject(shapeCfg)) {
       config.fields = shapeCfg.fields;
       config.callback = shapeCfg.callback;
     }

--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -36,6 +36,8 @@ type AreaInteraction =
   | { type: 'slider'; cfg: ISliderInteractionConfig }
   | { type: 'scrollBar'; cfg: IScrollbarInteractionConfig };
 
+type PointShape =  string | { fields?:[]; callback:()=>string; }
+
 export interface LineViewConfig extends ViewConfig {
   /** 分组字段 */
   seriesField?: string;
@@ -48,7 +50,7 @@ export interface LineViewConfig extends ViewConfig {
   /** 折线数据点图形样式 */
   point?: {
     visible?: boolean;
-    shape?: string;
+    shape?: PointShape;
     size?: number;
     color?: string;
     style?: GraphicStyle;

--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -36,7 +36,7 @@ type AreaInteraction =
   | { type: 'slider'; cfg: ISliderInteractionConfig }
   | { type: 'scrollBar'; cfg: IScrollbarInteractionConfig };
 
-type PointShape =  string | { fields?:[]; callback:()=>string; }
+type PointShape = string | { fields?: []; callback: () => string };
 
 export interface LineViewConfig extends ViewConfig {
   /** 分组字段 */


### PR DESCRIPTION
```
point:{
    visible: true,
    size:4,
    shape:{
      fields:['type'],
      callback:(v)=>{
        const mapping = {
         download:'circle',
          bill:'square',
          register:'diamond'
        };
        return mapping[v];
      }
    }
  },
```

<img width="686" alt="屏幕快照 2020-04-03 下午10 54 51" src="https://user-images.githubusercontent.com/5888974/78374398-6089ad80-75fe-11ea-9bdf-06ace2ea0063.png">

先以满足DI业务为优先，还有一些图表应该开放shape callback，后续再支持