### PR TITLE
fix(word-cloud2): under the IE11 settings.animatable not allowed duplicate define

### DIFF
--- a/src/plots/word-cloud/wordcloud2.ts
+++ b/src/plots/word-cloud/wordcloud2.ts
@@ -223,7 +223,6 @@ var WordCloud = function WordCloud(elements, options) {
     ellipticity: 1,
 
     active: true,
-    animatable: true,
     selected: -1,
     shadowColor: '#333',
     shadowBlur: 10,


### PR DESCRIPTION
strict mode does not allow multiple definitions of an attribute（strict 模式下不允许一个属性有多个定义）