### PR TITLE
feat: support legend style & formatter Closes #966, #876, #856, #877

### DIFF
--- a/__tests__/unit/components/legend-spec.ts
+++ b/__tests__/unit/components/legend-spec.ts
@@ -1,0 +1,144 @@
+import { GroupedColumn } from '../../../src';
+import { getLegendShapes } from '../../../src/util/common';
+
+describe('legend', () => {
+  const div = document.createElement('div');
+  div.style.width = '600px';
+  div.style.height = '600px';
+  div.style.left = '30px';
+  div.style.top = '30px';
+  document.body.append(div);
+
+  const data = [
+    {
+      name: 'London',
+      月份: 'Jan.',
+      月均降雨量: 18.9,
+    },
+    {
+      name: 'London',
+      月份: 'Feb.',
+      月均降雨量: 28.8,
+    },
+    {
+      name: 'London',
+      月份: 'Mar.',
+      月均降雨量: 39.3,
+    },
+    {
+      name: 'London',
+      月份: 'Apr.',
+      月均降雨量: 81.4,
+    },
+    {
+      name: 'London',
+      月份: 'May',
+      月均降雨量: 47,
+    },
+    {
+      name: 'London',
+      月份: 'Jun.',
+      月均降雨量: 20.3,
+    },
+    {
+      name: 'London',
+      月份: 'Jul.',
+      月均降雨量: 24,
+    },
+    {
+      name: 'London',
+      月份: 'Aug.',
+      月均降雨量: 35.6,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Jan.',
+      月均降雨量: 12.4,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Feb.',
+      月均降雨量: 23.2,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Mar.',
+      月均降雨量: 34.5,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Apr.',
+      月均降雨量: 99.7,
+    },
+    {
+      name: 'Berlin',
+      月份: 'May',
+      月均降雨量: 52.6,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Jun.',
+      月均降雨量: 35.5,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Jul.',
+      月均降雨量: 37.4,
+    },
+    {
+      name: 'Berlin',
+      月份: 'Aug.',
+      月均降雨量: 42.4,
+    },
+  ];
+
+  it('legend text style & formatter', () => {
+    const columnPlot = new GroupedColumn(div, {
+      data,
+      xField: '月份',
+      yField: '月均降雨量',
+      yAxis: {
+        min: 0,
+      },
+      label: {
+        visible: true,
+      },
+      groupField: 'name',
+      legend: {
+        text: {
+          style: {
+            fill: '#5B8FF9',
+          },
+          formatter: () => 'test',
+        },
+      },
+    });
+    columnPlot.render();
+    const view = columnPlot.getLayers()[0].view;
+    const legendShapes = getLegendShapes(view)[0].get('children')[0].get('children');
+    expect(legendShapes[1].attr('fill')).toBe('#5B8FF9');
+    expect(legendShapes[2].attr('text')).toBe('test');
+    columnPlot.destroy();
+  });
+
+  it('legend style in dark theme', () => {
+    const columnPlot = new GroupedColumn(div, {
+      theme: 'dark',
+      data,
+      xField: '月份',
+      yField: '月均降雨量',
+      yAxis: {
+        min: 0,
+      },
+      label: {
+        visible: true,
+      },
+      groupField: 'name',
+    });
+    columnPlot.render();
+    const view = columnPlot.getLayers()[0].view;
+    const legendShapes = getLegendShapes(view)[0].get('children')[0].get('children');
+    expect(legendShapes[1].attr('fill')).toBe('#5B8FF9');
+    columnPlot.destroy();
+  });
+});

--- a/__tests__/unit/components/legend-spec.ts
+++ b/__tests__/unit/components/legend-spec.ts
@@ -141,4 +141,36 @@ describe('legend', () => {
     expect(legendShapes[1].attr('fill')).toBe('#5B8FF9');
     columnPlot.destroy();
   });
+
+  it('legend title visible', () => {
+    const columnPlot = new GroupedColumn(div, {
+      data,
+      xField: '月份',
+      yField: '月均降雨量',
+      yAxis: {
+        min: 0,
+      },
+      label: {
+        visible: true,
+      },
+      groupField: 'name',
+      legend: {
+        position: 'right-center',
+        title: {
+          visible: true,
+          text: 'aa',
+        },
+      },
+    });
+    columnPlot.render();
+    const view = columnPlot.getLayers()[0].view;
+    const titleShape = view.foregroundGroup.findAll((el) => {
+      if (el.get('name')) {
+        console.log(el.get('name'));
+        return el.get('name') === 'legend-title';
+      }
+    });
+    expect(titleShape[0].attr('text')).toBe('aa');
+    columnPlot.destroy();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint-fix:examples": "prettier --write 'examples/**/*.{js,md}'",
     "lint-staged": "lint-staged",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch ./__tests__/unit/components/legend-spec.ts",
+    "test-live": "DEBUG_MODE=1 jest --watch ./__tests__",
     "coverage": "jest --coverage",
     "ci": "run-s lint build coverage",
     "compare-live": "node scripts/compare.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint-fix:examples": "prettier --write 'examples/**/*.{js,md}'",
     "lint-staged": "lint-staged",
     "test": "jest",
-    "test-live": "DEBUG_MODE=1 jest --watch ./__tests__",
+    "test-live": "DEBUG_MODE=1 jest --watch ./__tests__/unit/components/legend-spec.ts",
     "coverage": "jest --coverage",
     "ci": "run-s lint build coverage",
     "compare-live": "node scripts/compare.js",

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -212,7 +212,6 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
   public init() {
     super.init();
     this.theme = this.themeController.getTheme(this.options, this.type);
-    console.log(this.theme);
     this.config = {
       data: this.processData(this.options.data),
       scales: {},

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -3,7 +3,6 @@ import {
   isEmpty,
   mapValues,
   get,
-  isUndefined,
   each,
   assign,
   isFunction,
@@ -213,6 +212,7 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
   public init() {
     super.init();
     this.theme = this.themeController.getTheme(this.options, this.type);
+    console.log(this.theme);
     this.config = {
       data: this.processData(this.options.data),
       scales: {},
@@ -468,19 +468,17 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
       this.setConfig('legends', false);
       return;
     }
-    const flipOption = get(this.options, 'legend.flipPage');
-    const clickable = get(this.options, 'legend.clickable');
-    this.setConfig('legends', {
-      position: this.getLegendPosition(get(this.options, 'legend.position')),
-      formatter: get(this.options, 'legend.formatter'),
-      offsetX: get(this.options, 'legend.offsetX'),
-      offsetY: get(this.options, 'legend.offsetY'),
-      clickable: isUndefined(clickable) ? true : clickable,
-      // wordSpacing: get(this.options, 'legend.wordSpacing'),
-      flipPage: flipOption,
-      marker: get(this.options, 'legend.marker'),
-      title: get(this.options, 'legend.title'),
-    });
+    const options = deepMix({}, this.theme.legend, this.options.legend);
+    const legendConfig = {
+      position: this.getLegendPosition(get(options, 'position')),
+      offsetX: get(options, 'offsetX'),
+      offsetY: get(options, 'offsetY'),
+      flipPage: get(options, 'flipPage'),
+      marker: get(options, 'marker'),
+      title: options.title?.visible ? get(options, 'legend.title') : null,
+      itemName: get(options, 'text'),
+    };
+    this.setConfig('legends', legendConfig);
   }
 
   protected annotation() {

--- a/src/base/view-layer.ts
+++ b/src/base/view-layer.ts
@@ -474,9 +474,10 @@ export default abstract class ViewLayer<T extends ViewLayerConfig = ViewLayerCon
       offsetY: get(options, 'offsetY'),
       flipPage: get(options, 'flipPage'),
       marker: get(options, 'marker'),
-      title: options.title?.visible ? get(options, 'legend.title') : null,
+      title: options.title?.visible ? get(options, 'title') : null,
       itemName: get(options, 'text'),
     };
+
     this.setConfig('legends', legendConfig);
   }
 

--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -166,20 +166,30 @@ export type LegendPosition =
   | 'bottom-center'
   | 'bottom-right';
 
+interface LegendMarkerStyle extends GraphicStyle {
+  r?: number;
+}
+
 export interface Legend {
   visible?: boolean;
   /** 位置 */
   position?: LegendPosition;
   /** 翻页 */
   flipPage?: boolean;
-  formatter?: (...args: any) => string;
   offsetX?: number;
   offsetY?: number;
   clickable?: boolean;
   title?: {
     visible?: boolean;
-    spacing?: number;
     style?: TextStyle;
+  };
+  marker?: {
+    symbol?: string;
+    style: LegendMarkerStyle;
+  };
+  text?: {
+    style?: TextStyle;
+    formatter?: (text: string, cfg: any) => string;
   };
 }
 

--- a/src/interface/config.ts
+++ b/src/interface/config.ts
@@ -181,6 +181,7 @@ export interface Legend {
   clickable?: boolean;
   title?: {
     visible?: boolean;
+    text?: string;
     style?: TextStyle;
   };
   marker?: {

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -182,6 +182,17 @@ export const DEFAULT_DARK_THEME = {
     position: 'bottom',
     // 距离panelRange的距离
     innerPadding: [16, 16, 16, 16],
+    title: {
+      visible: false,
+      style: {
+        fill: '#bdc8d3',
+      },
+    },
+    text: {
+      style: {
+        fill: '#bdc8d3',
+      },
+    },
   },
   label: {
     offset: 12,


### PR DESCRIPTION
说明：
G2目前支持legend除marker外再增加一个value值，但这需要预先产生一个legend.items传入，并且不同的图表，legend.value的表现可能不同，例如饼图可以直接显示value，堆叠和分组图则hover显示value更合适，没有想清楚前暂不开放配置。