### PR TITLE
折线图的 point stroke 不能写死，shape为空心的时候stroke无法配置

### DIFF
--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -1,3 +1,9 @@
+// dependents是基础依赖，以便按需使用plot
+import GestureController from '@antv/g2/lib/chart/controller/gesture';
+import { registerComponentController } from '@antv/g2';
+export { GestureController };
+registerComponentController('gesture', GestureController);
+
 // G
 export { IElement, ICanvas, IGroup, IShape, BBox, Event as GraphicEvent } from '@antv/g-base';
 export { Canvas } from '@antv/g-canvas';
@@ -24,7 +30,6 @@ export {
   registerComponentController,
 } from '@antv/g2';
 export { VIEW_LIFE_CIRCLE, COMPONENT_TYPE, FIELD_ORIGIN } from '@antv/g2/lib/constant';
-export { default as GestureController } from '@antv/g2/lib/chart/controller/gesture';
 export { default as TooltipController } from '@antv/g2/lib/chart/controller/tooltip';
 export { MarkerSymbols } from '@antv/g2/lib/util/marker';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-import { registerComponentController, GestureController } from './dependents';
-registerComponentController('gesture', GestureController);
-
 // 通用配置
 export * from './interface/config';
 export { default as Layer, LayerConfig } from './base/layer';

--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -83,9 +83,6 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
         visible: false,
         size: 3,
         shape: 'circle',
-        style: {
-          stroke: '#fff',
-        },
       },
       label: {
         visible: false,


### PR DESCRIPTION
1 . 折线图的 point stroke 不能写死，shape为空心的时候stroke无法配置
2. GestureController 注册放到了dependence中，作为核心依赖，便于按需使用。