### PR TITLE
fix: fix line renderer without data

### DIFF
--- a/src/plots/line/layer.ts
+++ b/src/plots/line/layer.ts
@@ -166,7 +166,7 @@ export default class LineLayer<T extends LineLayerConfig = LineLayerConfig> exte
     this.setConfig('scales', scales);
     trySetScaleMinToZero(
       scales[props.yField],
-      map(props.data as any, (item) => item[props.yField])
+      map(props.data || [], (item) => item[props.yField])
     );
     super.scale();
   }


### PR DESCRIPTION
fix `LineChart` render error without data provide

```
Uncaught TypeError: Cannot read property 'length' of undefined
```

demo: https://codesandbox.io/s/condescending-flower-qrffp