### PR TITLE
fix: prevent js error when adjust tooltip

### DIFF
--- a/src/plots/grouped-bar/layer.ts
+++ b/src/plots/grouped-bar/layer.ts
@@ -1,4 +1,4 @@
-import { deepMix, valuesOfKey, clone } from '@antv/util';
+import { deepMix, valuesOfKey } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { ElementOption } from '../../interface/config';
@@ -44,19 +44,12 @@ export default class GroupedBarLayer extends BaseBarLayer<GroupedBarLayerConfig>
 
   public afterRender() {
     super.afterRender();
-    const names = valuesOfKey(this.options.data, this.options.groupField);
     this.view.on('tooltip:change', (e) => {
-      const { items } = e;
-      const origin_items = clone(items);
-      for (let i = 0; i < names.length; i++) {
-        const name = names[i];
-        for (let j = 0; j < origin_items.length; j++) {
-          const item = origin_items[j];
-          if (item.name === name) {
-            e.items[i] = item;
-          }
-        }
-      }
+      const { items = [] } = e;
+      const fixedItems = items.slice().reverse();
+      fixedItems.forEach((item, idx) => {
+        e.items[idx] = item;
+      });
     });
   }
 

--- a/src/plots/grouped-bar/layer.ts
+++ b/src/plots/grouped-bar/layer.ts
@@ -1,4 +1,4 @@
-import { deepMix, valuesOfKey } from '@antv/util';
+import { deepMix, valuesOfKey, sortBy } from '@antv/util';
 import { registerPlotType } from '../../base/global';
 import { LayerConfig } from '../../base/layer';
 import { ElementOption } from '../../interface/config';
@@ -44,9 +44,12 @@ export default class GroupedBarLayer extends BaseBarLayer<GroupedBarLayerConfig>
 
   public afterRender() {
     super.afterRender();
+    const names = valuesOfKey(this.options.data, this.options.groupField) || [];
     this.view.on('tooltip:change', (e) => {
       const { items = [] } = e;
-      const fixedItems = items.slice().reverse();
+      const fixedItems = sortBy(items.slice(), (item) => {
+        return names.indexOf(item.name);
+      }).reverse();
       fixedItems.forEach((item, idx) => {
         e.items[idx] = item;
       });


### PR DESCRIPTION
临时先修复下分组中拆分少的情况下js报错的问题

![image](https://user-images.githubusercontent.com/1142242/86210807-d246a880-bba7-11ea-8df3-a93af14c1cde.png)
