### PR TITLE
feat(pie-layout): 初步完成饼图 outer-label 布局算法

### DIFF
--- a/__tests__/unit/plots/pie/interaction-spec.ts
+++ b/__tests__/unit/plots/pie/interaction-spec.ts
@@ -91,6 +91,5 @@ describe('G2 内置interactions', () => {
     });
 
     expect(pie.chart.interactions['pie-legend-active']).toBeDefined();
-    expect(pie.chart.interactions['legend-active']).toBeDefined();
   });
 });

--- a/__tests__/unit/plots/pie/outer-label-layout-spec.ts
+++ b/__tests__/unit/plots/pie/outer-label-layout-spec.ts
@@ -1,0 +1,332 @@
+import { deepMix } from '@antv/util';
+import { Pie } from '../../../../src';
+import { CountryEconomy } from '../../../data/country-economy';
+import { createDiv } from '../../../utils/dom';
+
+describe('pie-outer label', () => {
+  it('50+ 标签', () => {
+    const dom = createDiv();
+    dom.style.border = '1px solid #999';
+    const pie = new Pie(dom, {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: CountryEconomy,
+      angleField: 'Population',
+      colorField: 'Country',
+      radius: 0.6,
+      label: {
+        content: '{name}: {percentage}',
+        labelLine: {
+          // @ts-ignore
+          smooth: false,
+        },
+        layout: { type: 'pie-outer' },
+      },
+    });
+    pie.render();
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBeLessThan(CountryEconomy.length);
+  });
+
+  it('50+ 标签: 平滑拉线', () => {
+    const dom = createDiv();
+    dom.style.border = '1px solid #999';
+    const pie = new Pie(dom, {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: CountryEconomy,
+      angleField: 'Population',
+      colorField: 'Country',
+      radius: 0.6,
+      label: {
+        content: '{name}: {percentage}',
+        layout: { type: 'pie-outer' },
+      },
+    });
+    pie.render();
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBeLessThan(CountryEconomy.length);
+  });
+
+  it('标签: 第一象限密集', () => {
+    let smooth = false;
+    const pie = new Pie(createDiv(), {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: [
+        { Country: '1', value: 10 },
+        { Country: '2', value: 10 },
+        { Country: '3', value: 1 },
+        { Country: '4', value: 1 },
+        { Country: '5', value: 1 },
+        { Country: '6', value: 1 },
+        { Country: '7', value: 1 },
+        { Country: '8', value: 1 },
+        { Country: '9', value: 100 },
+        { Country: '10', value: 1 },
+      ],
+      angleField: 'value',
+      colorField: 'Country',
+      radius: 0.64,
+      label: {
+        content: '{name}: {percentage}',
+        offset: 12,
+        layout: { type: 'pie-outer' },
+        // @ts-ignore
+        labelHeight: 18,
+        labelLine: {
+          smooth,
+        },
+      },
+      interactions: [
+        {
+          name: 'element-active',
+        },
+      ],
+    });
+    pie.render();
+
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(10);
+
+    document.body.addEventListener('click', () => {
+      smooth = !smooth;
+      pie.update(
+        deepMix({}, pie.options, {
+          label: { labelLine: { smooth } },
+        })
+      );
+    });
+  });
+
+  // todo fixme
+  it('标签: 第二象限密集', () => {
+    let smooth = true;
+    const pie = new Pie(createDiv(), {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: [
+        { Country: '1', value: 10 },
+        { Country: '2', value: 20 },
+        { Country: '3', value: 5 },
+        { Country: '4', value: 10 },
+        { Country: '5', value: 1 },
+        { Country: '5.0', value: 1 },
+        { Country: '5.1', value: 1 },
+        { Country: '5.2', value: 1 },
+        { Country: '5.3', value: 5 },
+        { Country: '5.4', value: 1 },
+        { Country: '5.5', value: 1 },
+        { Country: '5.6', value: 1 },
+        { Country: '6', value: 1 },
+        { Country: '7', value: 1 },
+        { Country: '7.0', value: 50 },
+        { Country: '8', value: 1 },
+        { Country: '9', value: 1 },
+        { Country: '10', value: 1 },
+      ],
+      angleField: 'value',
+      colorField: 'Country',
+      radius: 0.64,
+      label: {
+        content: '{name}: {percentage}',
+        offset: 12,
+        layout: { type: 'pie-outer' },
+        // @ts-ignore
+        labelHeight: 18,
+        labelLine: {
+          smooth,
+        },
+      },
+      interactions: [
+        {
+          name: 'element-active',
+        },
+      ],
+    });
+    pie.render();
+
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(18);
+
+    document.body.addEventListener('click', () => {
+      smooth = !smooth;
+      pie.update(
+        deepMix({}, pie.options, {
+          label: { labelLine: { smooth } },
+        })
+      );
+    });
+  });
+
+  // todo-fixme 标签
+  it('标签: 第三象限密集 ①', () => {
+    let smooth = false;
+    const pie = new Pie(createDiv(), {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: [
+        { Country: '1', value: 10 },
+        { Country: '2', value: 50 },
+        { Country: '3', value: 10 },
+        { Country: '4', value: 10 },
+        { Country: '5', value: 10 },
+        { Country: '6', value: 1 },
+        { Country: '7', value: 1 },
+        { Country: '7.0', value: 50 },
+        { Country: '8', value: 1 },
+        { Country: '9', value: 1 },
+        { Country: '10', value: 1 },
+      ],
+      angleField: 'value',
+      colorField: 'Country',
+      radius: 0.64,
+      label: {
+        content: '{name}: {percentage}',
+        offset: 12,
+        layout: { type: 'pie-outer' },
+        // @ts-ignore
+        labelHeight: 18,
+        labelLine: {
+          smooth,
+        },
+      },
+      interactions: [
+        {
+          name: 'element-active',
+        },
+      ],
+    });
+    pie.render();
+
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(11);
+
+    document.body.addEventListener('click', () => {
+      smooth = !smooth;
+      pie.update(
+        deepMix({}, pie.options, {
+          label: { labelLine: { smooth } },
+        })
+      );
+    });
+  });
+
+  it('标签: 第三象限密集 ②', () => {
+    let smooth = false;
+    const pie = new Pie(createDiv(), {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: [
+        { Country: '1', value: 10 },
+        { Country: '2', value: 10 },
+        { Country: '2.0', value: 50 },
+        { Country: '3', value: 1 },
+        { Country: '4', value: 1 },
+        { Country: '5', value: 1 },
+        { Country: '6', value: 1 },
+        { Country: '7', value: 1 },
+        { Country: '8', value: 1 },
+        { Country: '9', value: 50 },
+        { Country: '10', value: 1 },
+      ],
+      angleField: 'value',
+      colorField: 'Country',
+      radius: 0.64,
+      label: {
+        content: '{name}: {percentage}',
+        offset: 12,
+        layout: { type: 'pie-outer' },
+        // @ts-ignore
+        labelHeight: 18,
+        labelLine: {
+          smooth,
+        },
+      },
+      interactions: [
+        {
+          name: 'element-active',
+        },
+      ],
+    });
+    pie.render();
+
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(11);
+
+    document.body.addEventListener('click', () => {
+      smooth = !smooth;
+      pie.update(
+        deepMix({}, pie.options, {
+          label: { labelLine: { smooth } },
+        })
+      );
+    });
+  });
+
+  it('标签: 第三象限密集, 延伸至第四象限', () => {
+    let smooth = true;
+    const pie = new Pie(createDiv(), {
+      width: 400,
+      height: 400,
+      padding: [10, 10, 10, 10],
+      data: [
+        { Country: '1', value: 10 },
+        { Country: '2', value: 50 },
+        { Country: '3', value: 10 },
+        { Country: '4', value: 1 },
+        { Country: '5', value: 1 },
+        { Country: '5.0', value: 1 },
+        { Country: '5.1', value: 1 },
+        { Country: '5.2', value: 1 },
+        { Country: '5.3', value: 1 },
+        { Country: '5.4', value: 1 },
+        { Country: '5.5', value: 1 },
+        { Country: '5.6', value: 1 },
+        { Country: '6', value: 1 },
+        { Country: '7', value: 1 },
+        { Country: '7.0', value: 50 },
+        { Country: '8', value: 1 },
+        { Country: '9', value: 1 },
+        { Country: '10', value: 1 },
+      ],
+      angleField: 'value',
+      colorField: 'Country',
+      radius: 0.64,
+      label: {
+        content: '{name}: {percentage}',
+        offset: 12,
+        layout: { type: 'pie-outer' },
+        // @ts-ignore
+        labelHeight: 18,
+        labelLine: {
+          smooth,
+        },
+      },
+      interactions: [
+        {
+          name: 'element-active',
+        },
+      ],
+    });
+    pie.render();
+
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(18);
+
+    document.body.addEventListener('click', () => {
+      smooth = !smooth;
+      pie.update(
+        deepMix({}, pie.options, {
+          label: { labelLine: { smooth } },
+        })
+      );
+    });
+  });
+});

--- a/__tests__/unit/plots/pie/outer-label-layout-spec.ts
+++ b/__tests__/unit/plots/pie/outer-label-layout-spec.ts
@@ -24,6 +24,7 @@ describe('pie-outer label', () => {
         },
         layout: { type: '' },
       },
+      interactions: [{ name: 'element-active' }],
     });
     pie.render();
 
@@ -68,6 +69,7 @@ describe('pie-outer label', () => {
         content: '{name}: {percentage}',
         layout: { type: 'pie-outer' },
       },
+      interactions: [{ name: 'element-active' }],
     });
     pie.render();
     const labels = pie.chart.geometries[0].labelsContainer.getChildren();
@@ -102,6 +104,7 @@ describe('pie-outer label', () => {
         // @ts-ignore
         labelHeight: 18,
         labelLine: {
+          // @ts-ignore
           smooth,
         },
       },
@@ -162,6 +165,7 @@ describe('pie-outer label', () => {
         // @ts-ignore
         labelHeight: 18,
         labelLine: {
+          // @ts-ignore
           smooth,
         },
       },
@@ -215,6 +219,7 @@ describe('pie-outer label', () => {
         // @ts-ignore
         labelHeight: 18,
         labelLine: {
+          // @ts-ignore
           smooth,
         },
       },
@@ -233,6 +238,7 @@ describe('pie-outer label', () => {
       smooth = !smooth;
       pie.update(
         deepMix({}, pie.options, {
+          // @ts-ignore
           label: { labelLine: { smooth } },
         })
       );
@@ -268,6 +274,7 @@ describe('pie-outer label', () => {
         // @ts-ignore
         labelHeight: 18,
         labelLine: {
+          // @ts-ignore
           smooth,
         },
       },
@@ -286,6 +293,7 @@ describe('pie-outer label', () => {
       smooth = !smooth;
       pie.update(
         deepMix({}, pie.options, {
+          // @ts-ignore
           label: { labelLine: { smooth } },
         })
       );
@@ -328,6 +336,7 @@ describe('pie-outer label', () => {
         // @ts-ignore
         labelHeight: 18,
         labelLine: {
+          // @ts-ignore
           smooth,
         },
       },
@@ -346,6 +355,7 @@ describe('pie-outer label', () => {
       smooth = !smooth;
       pie.update(
         deepMix({}, pie.options, {
+          // @ts-ignore
           label: { labelLine: { smooth } },
         })
       );

--- a/__tests__/unit/plots/pie/outer-label-layout-spec.ts
+++ b/__tests__/unit/plots/pie/outer-label-layout-spec.ts
@@ -24,7 +24,7 @@ describe('pie-outer label', () => {
         },
         layout: { type: '' },
       },
-      interactions: [{ name: 'element-active' }],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
 
@@ -41,7 +41,7 @@ describe('pie-outer label', () => {
       expect(maxY - minY).not.toBeGreaterThanOrEqual(leftLabels.length * labelHeight);
     }
 
-    pie.update({ ...pie.options, label: { layout: { type: 'pie-outer' } } });
+    pie.update(deepMix({}, pie.options, { label: { layout: { type: 'pie-outer' } } }));
     labels = pie.chart.geometries[0].labelsContainer.getChildren();
     expect(labels.length).toBeLessThan(CountryEconomy.length);
     leftLabels = labels.filter((label) => label.attr('x') < center.x);
@@ -69,7 +69,7 @@ describe('pie-outer label', () => {
         content: '{name}: {percentage}',
         layout: { type: 'pie-outer' },
       },
-      interactions: [{ name: 'element-active' }],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
     const labels = pie.chart.geometries[0].labelsContainer.getChildren();
@@ -108,11 +108,7 @@ describe('pie-outer label', () => {
           smooth,
         },
       },
-      interactions: [
-        {
-          name: 'element-active',
-        },
-      ],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
 
@@ -169,11 +165,7 @@ describe('pie-outer label', () => {
           smooth,
         },
       },
-      interactions: [
-        {
-          name: 'element-active',
-        },
-      ],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
 
@@ -223,11 +215,7 @@ describe('pie-outer label', () => {
           smooth,
         },
       },
-      interactions: [
-        {
-          name: 'element-active',
-        },
-      ],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
 
@@ -278,11 +266,7 @@ describe('pie-outer label', () => {
           smooth,
         },
       },
-      interactions: [
-        {
-          name: 'element-active',
-        },
-      ],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
 
@@ -340,11 +324,7 @@ describe('pie-outer label', () => {
           smooth,
         },
       },
-      interactions: [
-        {
-          name: 'element-active',
-        },
-      ],
+      interactions: [{ name: 'element-active' }, { name: 'pie-legend-active' }],
     });
     pie.render();
 

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -20,7 +20,7 @@ function field(params: Params<PieOptions>): Params<PieOptions> {
   const processData = filter(data, (d) => typeof d[angleField] === 'number' || isNil(d[angleField]));
 
   // 打印异常数据情况
-  log(LEVEL.WARN, processData.length !== data.length, 'illegal data existed in chart data.');
+  log(LEVEL.WARN, processData.length === data.length, 'illegal data existed in chart data.');
 
   const allZero = every(processData, (d) => d[angleField] === 0);
   if (allZero) {

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -3,6 +3,7 @@ import { PieOptions } from './types';
 import { adaptor } from './adaptor';
 import { Adaptor } from '../../core/adaptor';
 import './interaction';
+import './label-layout';
 
 export { PieOptions };
 

--- a/src/plots/pie/interaction/index.ts
+++ b/src/plots/pie/interaction/index.ts
@@ -11,5 +11,5 @@ registerInteraction('pie-statistic-active', {
 registerAction('pie-legend', PieLegendAction);
 registerInteraction('pie-legend-active', {
   start: [{ trigger: 'legend-item:mouseenter', action: 'pie-legend:active' }],
-  end: [{ trigger: 'legend-item:mouseleave', action: [] }],
+  end: [{ trigger: 'legend-item:mouseleave', action: 'pie-legend:reset' }],
 });

--- a/src/plots/pie/label-layout/index.ts
+++ b/src/plots/pie/label-layout/index.ts
@@ -1,0 +1,1 @@
+import './outer';

--- a/src/plots/pie/label-layout/outer.ts
+++ b/src/plots/pie/label-layout/outer.ts
@@ -1,0 +1,336 @@
+import { BBox, IGroup, IShape, IElement } from '@antv/g-base';
+import { registerGeometryLabelLayout } from '@antv/g2';
+import { polarToCartesian } from '@antv/g2/lib/util/graphics';
+import { isObject, each, find, get } from '@antv/util';
+import { LabelItem } from '@antv/g2/lib/geometry/label/interface';
+import { Coordinate, Point } from '@antv/g2/lib/dependents';
+
+/** label text和line距离 4px */
+const MARGIN = 4;
+
+function antiCollision(
+  labelShapes: IGroup[],
+  labels: LabelItem[],
+  labelHeight: number,
+  plotRange,
+  center: Point,
+  radius: number,
+  isRight
+) {
+  // sorted by y, mutable
+  labels.sort((a, b) => a.y - b.y);
+
+  // adjust y position of labels to avoid overlapping
+  const start = plotRange.start;
+  const end = plotRange.end;
+  const startY = Math.min(start.y, end.y);
+  const endY = Math.max(start.y, end.y);
+  let i;
+
+  const boxes = labels.map((label) => {
+    return {
+      content: label.content,
+      size: labelHeight,
+      pos: label.y,
+      targets: [label.y],
+    };
+  });
+
+  const maxPos = Math.max(...boxes.map((b) => b.pos));
+  const minPos = Math.min(...boxes.map((b) => b.pos));
+  /**
+   * when in right, shift from up to down
+   */
+  if (isRight) {
+    const minY = Math.min(minPos, endY - (boxes.length - 1) * labelHeight);
+    const maxY = Math.max(minY + boxes.length * labelHeight, maxPos + labelHeight);
+    let overlapping = true;
+    while (overlapping) {
+      // detect overlapping and join boxes
+      overlapping = false;
+      let i = boxes.length;
+      while (i--) {
+        if (i > 0) {
+          const previousBox = boxes[i - 1];
+          const box = boxes[i];
+          // overlap
+          if (previousBox.pos + previousBox.size > box.pos) {
+            if (box.pos + i * labelHeight < maxY) {
+              // join boxes
+              previousBox.size += box.size;
+              previousBox.targets = previousBox.targets.concat(box.targets);
+              // removing box
+              boxes.splice(i, 1);
+            } else {
+              previousBox.pos = box.pos - previousBox.size;
+            }
+            overlapping = true;
+          }
+        }
+      }
+    }
+  } else {
+    const maxY = Math.max(startY + (boxes.length - 1) * labelHeight, maxPos);
+    const minY = Math.min(minPos, maxY - (boxes.length - 1) * labelHeight);
+    let overlapping = true;
+    while (overlapping) {
+      // detect overlapping and join boxes
+      overlapping = false;
+      let i = boxes.length;
+      while (i--) {
+        if (i > 0) {
+          const previousBox = boxes[i - 1];
+          const box = boxes[i];
+          // overlap
+          if (previousBox.pos + previousBox.size > box.pos) {
+            if (previousBox.pos - minY > i * labelHeight) {
+              previousBox.pos -= previousBox.size;
+            } else {
+              // join boxes
+              previousBox.size += box.size;
+              previousBox.targets = previousBox.targets.concat(box.targets);
+              // removing box
+              boxes.splice(i, 1);
+            }
+            overlapping = true;
+          }
+        }
+      }
+    }
+  }
+
+  // step 4: normalize y and adjust x
+  i = 0;
+  boxes.forEach((b) => {
+    let posInCompositeBox = b.pos;
+    b.targets.forEach(() => {
+      labels[i].y = posInCompositeBox;
+      posInCompositeBox += labelHeight;
+      i++;
+    });
+  });
+
+  const labelsMap = {};
+  for (const labelShape of labelShapes) {
+    labelsMap[labelShape.get('id')] = labelShape;
+  }
+
+  // (x - cx)^2 + (y - cy)^2 = totalR^2
+  let totalR = (Math.max(...labels.map((l) => l.y)) - Math.min(...labels.map((l) => l.y))) / 2;
+  totalR = Math.max(totalR, radius);
+  labels.forEach((label) => {
+    const labelShape = labelsMap[label.id];
+
+    // because group could not effect text-shape, should set text-shape position manually
+    const textShape = find(labelShape.getChildren(), (ele) => ele.get('type') === 'text') as IElement;
+
+    // textShape 发生过调整
+    if (textShape && textShape.attr('y') !== label.y) {
+      const rPow2 = totalR * totalR;
+      const dyPow2 = Math.pow(Math.abs(label.y - center.y), 2);
+      if (rPow2 < dyPow2) {
+        label.x = center.x;
+      } else {
+        const dx = Math.sqrt(rPow2 - dyPow2);
+        if (!isRight) {
+          // left
+          label.x = center.x - dx;
+        } else {
+          // right
+          label.x = center.x + dx;
+        }
+      }
+    }
+
+    // adjust labelShape
+    labelShape.attr('x', label.x);
+    labelShape.attr('y', label.y);
+
+    // @ts-ignore
+    if (textShape) {
+      textShape.attr('y', label.y);
+      textShape.attr('x', label.x);
+    }
+  });
+}
+
+export function distribute(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+  const offset = items[0] ? items[0].offset : 0;
+  const coordinate: Coordinate = labels[0].get('coordinate');
+  const radius = coordinate.getRadius();
+  const center = coordinate.getCenter();
+
+  if (offset > 0) {
+    // note labelHeight 可以控制 label 的行高
+    const lineHeight: number = get(items[0], 'labelHeight', 14);
+    const totalR = radius + offset;
+    const totalHeight = totalR * 2 + lineHeight * 2;
+    const plotRange = {
+      start: coordinate.start,
+      end: coordinate.end,
+    };
+
+    // step 1: separate labels
+    const halves: LabelItem[][] = [
+      [], // left
+      [], // right
+    ];
+    items.forEach((labelItem) => {
+      if (!labelItem) {
+        return;
+      }
+      if (labelItem.x < center.x) {
+        // left
+        halves[0].push(labelItem);
+      } else {
+        // right or center will be put on the right side
+        halves[1].push(labelItem);
+      }
+    });
+
+    halves.forEach((half, index) => {
+      // step 2: reduce labels
+      const maxLabelsCountForOneSide = totalHeight / lineHeight;
+      if (half.length > maxLabelsCountForOneSide) {
+        half.sort((a, b) => {
+          // sort by percentage DESC
+          // fixme-xinming 目前还获取不到，需要使用 scale 去获取 percent
+          return b['data.percent'] - a['data.percent'];
+        });
+
+        const hidden = half.splice(maxLabelsCountForOneSide, half.length - maxLabelsCountForOneSide + 1);
+        hidden.forEach((l) => {
+          const idx = labels.findIndex((item) => item.get('id') === l.id);
+          if (labels[idx]) {
+            labels[idx].remove(true);
+            // 同时移除
+            labels.splice(idx, 1);
+          }
+        });
+      }
+      antiCollision(labels, half, lineHeight, plotRange, center, totalR, index === 1);
+    });
+  }
+
+  // 配置 labelLine
+  each(items, (item) => {
+    if (item && item.labelLine) {
+      const { offset = 0, angle } = item;
+      // 贴近圆周
+      const startPoint = polarToCartesian(center.x, center.y, radius, angle);
+      const itemX = item.x + get(item, 'offsetX', 0) * (Math.cos(angle) > 0 ? 1 : -1);
+      const itemY = item.y + get(item, 'offsetY', 0) * (Math.sin(angle) > 0 ? 1 : -1);
+
+      const endPoint = {
+        x: itemX - Math.cos(angle) * MARGIN,
+        y: itemY - Math.sin(angle) * MARGIN,
+      };
+
+      const smoothConnector = item.labelLine.smooth;
+      const path = [];
+      const dx = endPoint.x - center.x;
+      const dy = endPoint.y - center.y;
+      let endAngle = Math.atan(dy / dx);
+      // 第三象限 & 第四象限
+      if (dx < 0) {
+        endAngle += Math.PI;
+      }
+
+      // 默认 smooth, undefined 也为 smooth
+      if (smoothConnector === false) {
+        if (!isObject(item.labelLine)) {
+          // labelLine: true
+          item.labelLine = {};
+        }
+
+        // 表示弧线的方向，0 表示从起点到终点沿逆时针画弧, 1 表示顺时针
+        let sweepFlag = 0;
+
+        // 第一象限
+        if ((angle < 0 && angle > -Math.PI / 2) || angle > Math.PI * 1.5) {
+          if (endPoint.y > startPoint.y) {
+            sweepFlag = 1;
+          }
+        }
+
+        // 第二象限
+        if (angle >= 0 && angle < Math.PI / 2) {
+          if (endPoint.y > startPoint.y) {
+            sweepFlag = 1;
+          }
+        }
+
+        // 第三象限
+        if (angle >= Math.PI / 2 && angle < Math.PI) {
+          if (startPoint.y > endPoint.y) {
+            sweepFlag = 1;
+          }
+        }
+
+        // 第四象限
+        if (angle < -Math.PI / 2 || (angle >= Math.PI && angle < Math.PI * 1.5)) {
+          if (startPoint.y > endPoint.y) {
+            sweepFlag = 1;
+          }
+        }
+
+        const distance = offset / 2 > 4 ? 4 : Math.max(offset / 2 - 1, 0);
+        const breakPoint = polarToCartesian(center.x, center.y, radius + distance, angle);
+        // 圆弧的结束点
+        const breakPoint3 = polarToCartesian(center.x, center.y, radius + offset / 2, endAngle);
+
+        /**
+         * @example
+         * M 100 100 L100 90 A 50 50 0 0 0 150 50
+         * 移动至 (100, 100), 连接到 (100, 90), 以 (50, 50) 为圆心，绘制圆弧至 (150, 50);
+         * A 命令的第 4 个参数 large-arc-flag, 决定弧线是大于还是小于 180 度: 0 表示小角度弧，1 表示大角
+         * 第 5 个参数: 是否顺时针绘制
+         */
+        // 默认小弧(TODO)
+        const largeArcFlag = 0;
+        // step1: 移动至起点
+        path.push(`M ${startPoint.x} ${startPoint.y}`);
+        // step2: 连接拐点
+        path.push(`L ${breakPoint.x} ${breakPoint.y}`);
+        // step3: 绘制圆弧 至 结束点
+        path.push(`A ${center.x} ${center.y} 0 ${largeArcFlag} ${sweepFlag} ${breakPoint3.x} ${breakPoint3.y}`);
+        // step4: 连接结束点
+        path.push(`L ${endPoint.x} ${endPoint.y}`);
+      } else {
+        const breakPoint = polarToCartesian(
+          center.x,
+          center.y,
+          radius + (offset / 2 > 4 ? 4 : Math.max(offset / 2 - 1, 0)),
+          angle
+        );
+        // G2 旧的拉线
+        // path.push('Q', `${breakPoint.x}`, `${breakPoint.y}`, `${endPoint.x}`, `${endPoint.y}`);
+        const xSign = startPoint.x < center.x ? 1 : -1;
+        // step1: 连接结束点
+        path.push(`M ${endPoint.x} ${endPoint.y}`);
+        const slope1 = (startPoint.y - center.y) / (startPoint.x - center.x);
+        const slope2 = (endPoint.y - center.y) / (endPoint.x - center.x);
+        if (Math.abs(slope1 - slope2) > Math.pow(Math.E, -16)) {
+          // step2: 绘制 curve line (起点 & 结合点与圆心的斜率不等时, 由于存在误差, 使用近似处理)
+          path.push(
+            ...[
+              'C',
+              endPoint.x + xSign * 4,
+              endPoint.y,
+              2 * breakPoint.x - startPoint.x,
+              2 * breakPoint.y - startPoint.y,
+              startPoint.x,
+              startPoint.y,
+            ]
+          );
+        }
+        // step3: 连接至起点
+        path.push(`L ${startPoint.x} ${startPoint.y}`);
+      }
+
+      item.labelLine.path = path.join(' ');
+    }
+  });
+}
+
+registerGeometryLabelLayout('pie-outer', distribute);


### PR DESCRIPTION
- [x] 优化smooth拉线,当起点&结束点与圆心的连线斜率相等时，直接连线
- [x] 优化右半圆标签的布局调整

**补充**
- 整体上还是从保留标签数量越多的角度考虑处理，以及还存在一些 G2 label 位置调整的问题，后续继续优化（**可能会考虑将标签线在element上的标签直接移除**）
- 待一些 label 交互都做好后，再直接替换 G2 内置 `distribute` 算法

**预览**
> `label: { labelLine: { smooth: boolean } }` 后面会在 G2 label 定义一个 `smooth` 的配置项

|平滑拉线|非平滑拉线|
|:---|:---|
![image](https://user-images.githubusercontent.com/15646325/89114675-ca816900-d4b1-11ea-8415-8ebe33ef0d8b.png)|![image](https://user-images.githubusercontent.com/15646325/89114668-c2292e00-d4b1-11ea-9f00-809291869d02.png)|
![image](https://user-images.githubusercontent.com/15646325/89114654-a32a9c00-d4b1-11ea-801c-7db9455f306b.png)|![image](https://user-images.githubusercontent.com/15646325/89114696-05839c80-d4b2-11ea-9538-b6d3c5ea30ad.png)
![image](https://user-images.githubusercontent.com/15646325/89114706-19c79980-d4b2-11ea-82f9-cb73b24bc17b.png)|![image](https://user-images.githubusercontent.com/15646325/89114709-1e8c4d80-d4b2-11ea-9615-3f8d5d01d8d3.png)


