### PR TITLE
fix(waterfall): 修复瀑布图label.formatter失效问题

### DIFF
--- a/__tests__/unit/plots/waterfall/waterfall-spec.ts
+++ b/__tests__/unit/plots/waterfall/waterfall-spec.ts
@@ -20,7 +20,6 @@ describe('waterfall plot', () => {
     forceFit: true,
     data,
     padding: 'auto',
-    data,
     xField: 'type',
     yField: 'money',
     meta: {
@@ -126,6 +125,26 @@ describe('waterfall plot', () => {
     const labelShapes = diffLabel.container.get('children')[0];
     expect(labelShapes.attr('text')).toBe('涨 120');
     expect(labelShapes.attr('fill')).toBe('red');
+  });
+
+  it('label.formatter', () => {
+    waterfallPlot.updateConfig({
+      data,
+      xField: 'type',
+      yField: 'money',
+      label: {
+        visible: true,
+        formatter: (text) => {
+          return text + '__abc';
+        },
+      },
+    });
+
+    waterfallPlot.render();
+    // @ts-ignore
+    const view = waterfallPlot.getView();
+    const labels = view.geometries[0].labelsContainer.getChildByIndex(0).getChildren();
+    expect(labels[0].attr('text')).toInclude('__abc');
   });
 
   it('hidden diff-label', () => {

--- a/docs/manual/plots/waterfall.en.md
+++ b/docs/manual/plots/waterfall.en.md
@@ -69,7 +69,6 @@ const waterfallPlot = new Waterfall(document.getElementById('container'), {
   forceFit: true,
   data,
   padding: 'auto',
-  data,
   xField: 'type',
   yField: 'money',
   meta: {
@@ -361,7 +360,7 @@ title: {
 
 功能描述： y方向上的坐标轴，用于展示yField对应的映射信息
 
-默认配置： 
+默认配置：
 ```js
 visible: true,
 grid: {

--- a/docs/manual/plots/waterfall.zh.md
+++ b/docs/manual/plots/waterfall.zh.md
@@ -69,7 +69,6 @@ const waterfallPlot = new Waterfall(document.getElementById('container'), {
   forceFit: true,
   data,
   padding: 'auto',
-  data,
   xField: 'type',
   yField: 'money',
   meta: {
@@ -361,7 +360,7 @@ title: {
 
 功能描述： y方向上的坐标轴，用于展示yField对应的映射信息
 
-默认配置： 
+默认配置：
 ```js
 visible: true,
 grid: {

--- a/examples/column/waterfall/demo/basic.js
+++ b/examples/column/waterfall/demo/basic.js
@@ -18,7 +18,6 @@ const waterfallPlot = new Waterfall(document.getElementById('container'), {
   forceFit: true,
   data,
   padding: 'auto',
-  data,
   xField: 'type',
   yField: 'money',
   meta: {

--- a/src/plots/waterfall/component/label/waterfall-label.ts
+++ b/src/plots/waterfall/component/label/waterfall-label.ts
@@ -6,8 +6,9 @@ import { isArray } from '@antv/util';
 
 import ColumnLabel from '../../../column/component/label';
 import { IShape, Element } from '../../../../dependents';
-import { VALUE_FIELD } from '../../layer';
+import { VALUE_FIELD, INDEX_FIELD } from '../../layer';
 import { registerLabelComponent } from '../../../../components/label/base';
+import { MappingDatum, _ORIGIN } from '../../../../dependents';
 
 const MARGIN = 2;
 
@@ -19,6 +20,22 @@ export default class WaterfallLabel extends ColumnLabel {
     const values = data[VALUE_FIELD];
     const diff = data[this.layer.options.yField];
     const value = isArray(values) ? values[1] : values;
+    const { formatter } = this.options;
+    const mappingData: MappingDatum[] = [].concat(element.getModel().mappingData);
+    const elementIndex = formatter ? mappingData[0] && mappingData[0]['_origin'][INDEX_FIELD] : 0;
+    const formatterValue = formatter
+      ? formatter(
+          value,
+          {
+            [_ORIGIN]: mappingData[0]?._origin,
+            mappingDatum: mappingData[0],
+            mappingDatumIndex: 0,
+            element,
+            elementIndex,
+          },
+          elementIndex
+        )
+      : value;
     let yPos = (shapeBox.minY + shapeBox.maxY) / 2;
     let textBaseline = 'bottom';
 
@@ -30,7 +47,7 @@ export default class WaterfallLabel extends ColumnLabel {
     }
 
     label.attr('y', yPos);
-    label.attr('text', value);
+    label.attr('text', formatterValue);
     label.attr('textBaseline', textBaseline);
   }
 }

--- a/src/plots/waterfall/layer.ts
+++ b/src/plots/waterfall/layer.ts
@@ -26,7 +26,7 @@ const PLOT_GEOM_MAP = {
 
 export const VALUE_FIELD = '$$value$$';
 export const IS_TOTAL = '$$total$$';
-const INDEX_FIELD = '$$index$$';
+export const INDEX_FIELD = '$$index$$';
 
 export interface WaterfallViewConfig extends ViewConfig {
   showTotal?: {


### PR DESCRIPTION
> 需求点：瀑布图存在js显示精度问题，`diffLabel` 可以通过 `formatter` 处理，不过 `label.formatter`失效。[演示链接](https://codesandbox.io/s/vigilant-lichterman-zfhz0)
1. 因为瀑布图中的 `label` 内容展示是通过后续计算得到的，处理方式是把原有的 `label.formatter` 处理逻辑重新载入
2. 在原有的 `waterfall-spec.ts` 中新增单测
3. 删除瀑布图多余的默认配置项 `data`