### PR TITLE
feat(event): add plot events bind

### DIFF
--- a/__tests__/unit/core/index-spec.ts
+++ b/__tests__/unit/core/index-spec.ts
@@ -77,4 +77,42 @@ describe('core', () => {
 
     expect(line.chart.getTheme().colors10).toEqual(['green']);
   });
+
+  it('event', async () => {
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      appendPadding: 10,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      theme: {
+        colors10: ['red'],
+      },
+    });
+
+    line.render();
+
+    function click(): Promise<Event> {
+      return new Promise((resolve, reject) => {
+        line.on('element:click', (e) => {
+          resolve(e);
+        });
+
+        line.chart.emit('element:click', {
+          _data: 1,
+          type: 'element:click',
+        });
+      });
+    }
+
+    const e = await click();
+
+    // 直接接受 G2 透传的事件
+    expect(e).toEqual({
+      type: 'element:click',
+      _data: 1,
+    });
+  });
 });

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -1,4 +1,4 @@
-import { Chart } from '@antv/g2';
+import { Chart, Event } from '@antv/g2';
 import { deepMix } from '@antv/util';
 import EE from '@antv/event-emitter';
 import { bind } from 'size-sensor';
@@ -55,7 +55,7 @@ export abstract class Plot<O extends ChartOptions> extends EE {
    */
   private bindEvents() {
     if (this.chart) {
-      this.chart.on('*', (e) => {
+      this.chart.on('*', (e: Event) => {
         if (e?.type) {
           this.emit(e.type, e);
         }

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -49,7 +49,7 @@ export abstract class Plot<O extends ChartOptions> extends EE {
       localRefresh: false, // 默认关闭，目前 G 还有一些位置问题，难以排查！
     });
   }
-  
+
   /**
    * 绑定代理所有 G2 的事件
    */


### PR DESCRIPTION
### 方案有二个

 - 属性配置的方式

```ts
const line = new Line({
   event: {
      'element:click': () => {},
   }
});
```

> 优点：保持兼容性，完全配置化
> 缺点：代码相对复杂，需要去 diff events 配置，然后做 bind 和 unbind（echarts 做 react 包装的时候遇到这个问题）

 - API 的方式

```ts
const line = new Line({ /*...*/ });

line.on('element:click', () => {});
```

> 优点：代码简单，完全继承 G2 能力（echarts 使用这个方式）
> 缺点：和 v1 不兼容


大家看看哪种比较好，或者还有其他的方面没有考虑到

----

- [x] 为 plot 提供事件机制（目前是 API 方式）
- [x] 单测

