### PR TITLE
feat(lint-md): add markdown lint & fix markdown error

### DIFF
--- a/examples/biax/basic/API.zh.md
+++ b/examples/biax/basic/API.zh.md
@@ -265,13 +265,3 @@ pointStyle: (x, y, colorField) => {
 ## 图表组件
 
 `xAxis`、`yAxis` 、`legend` 、`tooltip` 、`label`、`theme` 等通用组件请参考图表通用配置
-
-## 事件
-
-[通用 events]()
-
-### 点图形事件
-
-| onPointClick<br />点点击事件         | onPointDblClick<br />点双击事件     | onPointDblClick<br />点双击事件    | onPointMouseleave<br />点鼠标离开事件 |
-| ------------------------------------ | ----------------------------------- | ---------------------------------- | ------------------------------------- |
-| onPointMousemove<br />点鼠标移动事件 | onPlotMousedown<br />点鼠标按下事件 | onPointMouseup<br />点鼠标松开事件 | onPointMouseenter<br />点鼠标进入事件 |

--- a/examples/histogram/basic/API.en.md
+++ b/examples/histogram/basic/API.en.md
@@ -1,5 +1,5 @@
 ---
-title: API
+title: API 
 ---
 
 # 配置属性
@@ -76,7 +76,7 @@ HistogramPlot.render();
 
 **可选**, _string_
 
-功能描述： 设置直方图的分箱宽度，binWidth 影响直方图分成多少箱, 不能与binNumber一起使用。
+功能描述： 设置直方图的分箱宽度，binWidth 影响直方图分成多少箱, 不能与 binNumber 一起使用。
 
 默认配置： Sturges formula 计算得到
 

--- a/examples/histogram/basic/API.zh.md
+++ b/examples/histogram/basic/API.zh.md
@@ -76,7 +76,7 @@ HistogramPlot.render();
 
 **可选**, _string_
 
-功能描述： 设置直方图的分箱宽度，binWidth 影响直方图分成多少箱, 不能与binNumber一起使用。
+功能描述： 设置直方图的分箱宽度，binWidth 影响直方图分成多少箱, 不能与 binNumber 一起使用。
 
 默认配置： Sturges formula 计算得到
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "jest": "^26.0.1",
     "jest-electron": "^0.1.7",
     "jest-extended": "^0.11.2",
-    "lint-md": "^0.2.0",
     "lint-md-cli": "^0.1.2",
     "lint-staged": "^10.0.7",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "site:build": "npm run site:clean && gatsby build --prefix-paths",
     "site:clean": "gatsby clean",
     "site:deploy": "npm run site:build && gh-pages -d public",
-    "fix": "eslint --ext .ts ./src ./__tests__ --fix && prettier --write ./src ./__tests__",
+    "fix": "eslint --ext .ts ./src ./__tests__ --fix && prettier --write ./src ./__tests__ && lint-md --fix ./examples",
     "build": "run-s clean lib dist",
     "clean": "rimraf lib esm dist",
     "lib": "run-p lib:*",
     "lib:cjs": "tsc -p tsconfig.json --target ES5 --module commonjs --outDir lib",
     "lib:esm": "tsc -p tsconfig.json --target ES5 --module ESNext --outDir esm",
     "dist": "webpack --config webpack.config.js --mode production",
-    "lint": "eslint --ext .ts ./src ./__tests__",
+    "lint": "eslint --ext .ts ./src ./__tests__ && prettier --check ./src ./__tests__ && lint-md ./examples",
     "lint-staged": "lint-staged",
     "test": "jest",
     "test-live": "cross-env DEBUG_MODE=1 jest --watch ./__tests__",
@@ -80,6 +80,8 @@
     "jest": "^26.0.1",
     "jest-electron": "^0.1.7",
     "jest-extended": "^0.11.2",
+    "lint-md": "^0.2.0",
+    "lint-md-cli": "^0.1.2",
     "lint-staged": "^10.0.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.1",
@@ -112,6 +114,9 @@
     "*.ts": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "*.md": [
+      "lint-md --fix"
     ]
   },
   "license": "MIT"


### PR DESCRIPTION
 - [x] 添加 markdown lint 能力，并集成到 ci 中
 - [x] 修复现有文档的问题
 - [x] lint 增加 prettier --check

[lint-md](https://github.com/lint-md/lint-md) 自卖自夸，目前社区最好的中文 markdown lint 工具。现在加入用来检测 markdown 文档。规则可以看这个项目的 [README 最下面](https://github.com/lint-md/lint-md#%E6%A3%80%E6%9F%A5%E7%B1%BB%E5%9E%8B)。