### PR TITLE
refactor: remove groupField, colorField, stackField in bar and column

### DIFF
--- a/__tests__/unit/plots/bar/index-spec.ts
+++ b/__tests__/unit/plots/bar/index-spec.ts
@@ -34,7 +34,7 @@ describe('bar', () => {
       data: salesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'area',
+      seriesField: 'area',
     });
 
     bar.render();
@@ -54,7 +54,7 @@ describe('bar', () => {
       data: salesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'area',
+      seriesField: 'area',
       color: palette,
     });
 
@@ -79,7 +79,7 @@ describe('bar', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
     });
 
@@ -100,7 +100,7 @@ describe('bar', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      groupField: 'series',
+      seriesField: 'series',
       isGroup: true,
     });
 
@@ -142,7 +142,7 @@ describe('bar', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'series',
+      seriesField: 'series',
       isStack: true,
     });
 
@@ -163,7 +163,7 @@ describe('bar', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      stackField: 'series',
+      seriesField: 'series',
       isStack: true,
     });
 
@@ -206,7 +206,7 @@ describe('bar', () => {
       xField: 'sales',
       yField: 'area',
       isGroup: true,
-      colorField: 'series',
+      seriesField: 'series',
       barWidthRatio: 0.7,
       marginRatio: 0.3,
     });
@@ -229,7 +229,7 @@ describe('bar', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'series',
+      seriesField: 'series',
       isStack: true,
       barWidthRatio: 0.5,
     });

--- a/__tests__/unit/plots/bar/label-spec.ts
+++ b/__tests__/unit/plots/bar/label-spec.ts
@@ -95,7 +95,7 @@ describe('bar label', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
       meta: {
         sales: {
@@ -131,7 +131,7 @@ describe('bar label', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
       meta: {
         sales: {
@@ -167,7 +167,7 @@ describe('bar label', () => {
       data: subSalesByArea,
       xField: 'sales',
       yField: 'area',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
       meta: {
         sales: {

--- a/__tests__/unit/plots/column/index-spec.ts
+++ b/__tests__/unit/plots/column/index-spec.ts
@@ -34,16 +34,16 @@ describe('column', () => {
       data: salesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'area',
+      seriesField: 'area',
     });
 
     column.render();
 
     const geometry = column.chart.geometries[0];
-    const colorFields = geometry.getAttribute('color').getFields();
+    const seriesFields = geometry.getAttribute('color').getFields();
 
-    expect(colorFields).toHaveLength(1);
-    expect(colorFields[0]).toBe('area');
+    expect(seriesFields).toHaveLength(1);
+    expect(seriesFields[0]).toBe('area');
   });
 
   it('x*y*color with color', () => {
@@ -54,7 +54,7 @@ describe('column', () => {
       data: salesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'area',
+      seriesField: 'area',
       color: palette,
     });
 
@@ -62,10 +62,10 @@ describe('column', () => {
 
     const geometry = column.chart.geometries[0];
     const colorAttribute = geometry.getAttribute('color');
-    const colorFields = colorAttribute.getFields();
+    const seriesFields = colorAttribute.getFields();
 
-    expect(colorFields).toHaveLength(1);
-    expect(colorFields[0]).toBe('area');
+    expect(seriesFields).toHaveLength(1);
+    expect(seriesFields[0]).toBe('area');
     geometry.elements.forEach((element, index) => {
       const color = element.getModel().color;
       expect(color).toBe(palette[index % palette.length]);
@@ -79,7 +79,7 @@ describe('column', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
     });
 
@@ -101,7 +101,7 @@ describe('column', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      groupField: 'series',
+      seriesField: 'series',
       isGroup: true,
     });
 
@@ -145,7 +145,7 @@ describe('column', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'series',
+      seriesField: 'series',
       isStack: true,
     });
 
@@ -167,7 +167,7 @@ describe('column', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      stackField: 'series',
+      seriesField: 'series',
       isStack: true,
     });
 
@@ -212,7 +212,7 @@ describe('column', () => {
       xField: 'area',
       yField: 'sales',
       isGroup: true,
-      colorField: 'series',
+      seriesField: 'series',
       columnWidthRatio: 0.7,
       marginRatio: 0.1,
     });
@@ -235,7 +235,7 @@ describe('column', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'series',
+      seriesField: 'series',
       isStack: true,
       columnWidthRatio: 0.7,
     });

--- a/__tests__/unit/plots/column/label-spec.ts
+++ b/__tests__/unit/plots/column/label-spec.ts
@@ -95,7 +95,7 @@ describe('column label', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
       meta: {
         sales: {
@@ -131,7 +131,7 @@ describe('column label', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
       meta: {
         sales: {
@@ -167,7 +167,7 @@ describe('column label', () => {
       data: subSalesByArea,
       xField: 'area',
       yField: 'sales',
-      colorField: 'series',
+      seriesField: 'series',
       isGroup: true,
       meta: {
         sales: {

--- a/examples/bar/basic/demo/color.ts
+++ b/examples/bar/basic/demo/color.ts
@@ -39,7 +39,7 @@ const barPlot = new Bar('container', {
   data,
   xField: 'sales',
   yField: 'type',
-  colorField: 'type',
+  seriesField: 'type',
   color: (val) => {
     return val === '美容洗护' ? 'red' : 'green';
   },

--- a/examples/bar/grouped/demo/basic.ts
+++ b/examples/bar/grouped/demo/basic.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isGroup: true,
   xField: 'value',
   yField: 'year',
-  groupField: 'type',
+  seriesField: 'type',
 });
 
 stackedBarPlot.render();

--- a/examples/bar/grouped/demo/label-position.ts
+++ b/examples/bar/grouped/demo/label-position.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isGroup: true,
   xField: 'value',
   yField: 'year',
-  groupField: 'type',
+  seriesField: 'type',
   label: {
     position: 'middle',
   },

--- a/examples/bar/grouped/demo/label.ts
+++ b/examples/bar/grouped/demo/label.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isGroup: true,
   xField: 'value',
   yField: 'year',
-  groupField: 'type',
+  seriesField: 'type',
   label: {},
 });
 

--- a/examples/bar/grouped/demo/margin.ts
+++ b/examples/bar/grouped/demo/margin.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isGroup: true,
   xField: 'value',
   yField: 'year',
-  groupField: 'type',
+  seriesField: 'type',
   marginRatio: 1 / 32,
 });
 

--- a/examples/bar/stacked/demo/basic.ts
+++ b/examples/bar/stacked/demo/basic.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isStack: true,
   xField: 'value',
   yField: 'year',
-  stackField: 'type',
+  seriesField: 'type',
 });
 
 stackedBarPlot.render();

--- a/examples/bar/stacked/demo/label-position.ts
+++ b/examples/bar/stacked/demo/label-position.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isStack: true,
   xField: 'value',
   yField: 'year',
-  stackField: 'type',
+  seriesField: 'type',
   label: {
     position: 'middle',
   },

--- a/examples/bar/stacked/demo/label.ts
+++ b/examples/bar/stacked/demo/label.ts
@@ -98,7 +98,7 @@ const stackedBarPlot = new Bar('container', {
   isStack: true,
   xField: 'value',
   yField: 'year',
-  stackField: 'type',
+  seriesField: 'type',
   label: {},
 });
 

--- a/examples/column/basic/demo/color.ts
+++ b/examples/column/basic/demo/color.ts
@@ -39,7 +39,7 @@ const columnPlot = new Column('container', {
   data,
   xField: 'type',
   yField: 'sales',
-  colorField: 'type',
+  seriesField: 'type',
   color: (val) => {
     return val === '美容洗护' ? 'red' : 'green';
   },

--- a/examples/column/grouped/demo/basic.ts
+++ b/examples/column/grouped/demo/basic.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isGroup: true,
   xField: 'year',
   yField: 'value',
-  groupField: 'type',
+  seriesField: 'type',
 });
 
 stackedColumnPlot.render();

--- a/examples/column/grouped/demo/label-position.ts
+++ b/examples/column/grouped/demo/label-position.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isGroup: true,
   xField: 'year',
   yField: 'value',
-  groupField: 'type',
+  seriesField: 'type',
   label: {
     position: 'middle',
   },

--- a/examples/column/grouped/demo/label.ts
+++ b/examples/column/grouped/demo/label.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isGroup: true,
   xField: 'year',
   yField: 'value',
-  groupField: 'type',
+  seriesField: 'type',
   label: {},
 });
 

--- a/examples/column/grouped/demo/margin.ts
+++ b/examples/column/grouped/demo/margin.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isGroup: true,
   xField: 'year',
   yField: 'value',
-  groupField: 'type',
+  seriesField: 'type',
   marginRatio: 1 / 32,
 });
 

--- a/examples/column/stacked/demo/basic.ts
+++ b/examples/column/stacked/demo/basic.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isStack: true,
   xField: 'year',
   yField: 'value',
-  stackField: 'type',
+  seriesField: 'type',
 });
 
 stackedColumnPlot.render();

--- a/examples/column/stacked/demo/label-position.ts
+++ b/examples/column/stacked/demo/label-position.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isStack: true,
   xField: 'year',
   yField: 'value',
-  stackField: 'type',
+  seriesField: 'type',
   label: {
     position: 'middle',
   },

--- a/examples/column/stacked/demo/label.ts
+++ b/examples/column/stacked/demo/label.ts
@@ -98,7 +98,7 @@ const stackedColumnPlot = new Column('container', {
   isStack: true,
   xField: 'year',
   yField: 'value',
-  stackField: 'type',
+  seriesField: 'type',
   label: {},
 });
 

--- a/examples/dual-axes/dual-line/API.en.md
+++ b/examples/dual-axes/dual-line/API.en.md
@@ -93,7 +93,7 @@ const data = [
   { country: 'Europe', year: '1800', value: 203,},
 ];
 
-const scatterPlot = new Scatter(document.getElementById('container'), {
+const scatterPlot = new Bar(document.getElementById('container'), {
   data,
   // highlight-start
   meta: {
@@ -109,7 +109,7 @@ const scatterPlot = new Scatter(document.getElementById('container'), {
   // highlight-end
   xField: 'year',
   yField: 'value',
-  colorField: 'country',
+  seriesField: 'country',
 });
 scatterPlot.render();
 
@@ -139,11 +139,6 @@ scatterPlot.render();
 
 默认配置： `jitter`
 
-### colorField
-
-**可选**, _string_
-
-功能描述: 点颜色映射对应的数据字段名。
 
 ## 图形样式
 
@@ -161,10 +156,10 @@ scatterPlot.render();
 // 设置单一颜色
 color: '#a8ddb5'
 // 设置多色
-colorField: 'type',
+seriesField: 'type',
 color: ['#d62728', '#2ca02c', '#000000'],
 // Function
-colorField: 'type',
+seriesField: 'type',
 color: (type) => {
   if(type === 'male'){
     return 'red';
@@ -261,8 +256,8 @@ pointStyle: {
   opacity: 0.8
 }
 // 回调
-pointStyle: (x, y, colorField) => {
-  if (colorField === 'male') {
+pointStyle: (x, y, color) => {
+  if (color === 'male') {
     return {
       fill: 'green',
       stroke: 'yellow',

--- a/examples/dual-axes/dual-line/API.zh.md
+++ b/examples/dual-axes/dual-line/API.zh.md
@@ -139,12 +139,9 @@ TODO
 | 细分配置项名称 | 类型 | 功能描述 | 默认值 | 
 | ----- | ----- | ----- | ----- |
 | geometry | _string_ | 图形类型，`'column'`|
-| colorField | _string_ | 颜色字段，同柱状图|
 | seriesField | _string_ | 拆分字段，同柱状图 |
 | isGroup | _boolean_ | 是否分组柱形图，同柱状图 | 
-| groupField | _string_ | 分组拆分字段，同柱状图 |
 | isStack | _boolean_ | 是否堆积柱状图，同柱状图 | 
-| stackField | _boolean_ | 是否堆积柱状图，同柱状图 | 
 | size | _number_ | 宽度，同柱状图 | 
 | interval | _IntervalConfig | 柱子样式设置，同柱状图 |
  
@@ -247,8 +244,8 @@ pointStyle: {
   opacity: 0.8
 }
 // 回调
-pointStyle: (x, y, colorField) => {
-  if (colorField === 'male') {
+pointStyle: (x, y, color) => {
+  if (color === 'male') {
     return {
       fill: 'green',
       stroke: 'yellow',

--- a/examples/dual-axes/grouped-column-line/demo/custom-grouped-column-line.ts
+++ b/examples/dual-axes/grouped-column-line/demo/custom-grouped-column-line.ts
@@ -29,7 +29,7 @@ const dualAxesChart = new DualAxes('container', {
     {
       geometry: 'column',
       isGroup: true,
-      groupField: 'type',
+      seriesField: 'type',
       columnWidthRatio: 0.4,
       label: {},
     },

--- a/examples/dual-axes/grouped-column-line/demo/grouped-column-line.ts
+++ b/examples/dual-axes/grouped-column-line/demo/grouped-column-line.ts
@@ -29,7 +29,7 @@ const dualAxesChart = new DualAxes('container', {
     {
       geometry: 'column',
       isGroup: true,
-      groupField: 'type',
+      seriesField: 'type',
     },
     {
       geometry: 'line',

--- a/examples/dual-axes/grouped-column-line/demo/grouped-column-multi-line.ts
+++ b/examples/dual-axes/grouped-column-line/demo/grouped-column-multi-line.ts
@@ -39,7 +39,7 @@ const dualAxesChart = new DualAxes('container', {
     {
       geometry: 'column',
       isGroup: true,
-      groupField: 'type',
+      seriesField: 'type',
       columnWidthRatio: 0.4,
     },
     {

--- a/examples/dual-axes/stacked-column-line/demo/custom-stacked-column-line.ts
+++ b/examples/dual-axes/stacked-column-line/demo/custom-stacked-column-line.ts
@@ -29,7 +29,7 @@ const dualAxesChart = new DualAxes('container', {
     {
       geometry: 'column',
       isStack: true,
-      stackField: 'type',
+      seriesField: 'type',
       columnWidthRatio: 0.4,
       label: {},
     },

--- a/examples/dual-axes/stacked-column-line/demo/stacked-column-line.ts
+++ b/examples/dual-axes/stacked-column-line/demo/stacked-column-line.ts
@@ -29,7 +29,7 @@ const dualAxesChart = new DualAxes('container', {
     {
       geometry: 'column',
       isStack: true,
-      stackField: 'type',
+      seriesField: 'type',
     },
     {
       geometry: 'line',

--- a/examples/dual-axes/stacked-column-line/demo/stacked-column-multi-line.ts
+++ b/examples/dual-axes/stacked-column-line/demo/stacked-column-multi-line.ts
@@ -39,7 +39,7 @@ const dualAxesChart = new DualAxes('container', {
     {
       geometry: 'column',
       isStack: true,
-      stackField: 'type',
+      seriesField: 'type',
       columnWidthRatio: 0.4,
     },
     {

--- a/src/adaptor/geometries/interval.ts
+++ b/src/adaptor/geometries/interval.ts
@@ -17,63 +17,39 @@ export interface IntervalGeometryOptions extends Options {
   readonly xField: string;
   /** y 轴字段 */
   readonly yField: string;
-  /** 颜色字段，可选 */
-  readonly colorField?: string;
   /** 拆分字段，在分组柱状图下同 groupField、colorField，在堆积柱状图下同 stackField、colorField  */
   readonly seriesField?: string;
   /** 是否分组柱形图 */
   readonly isGroup?: boolean;
-  /** 分组拆分字段 */
-  readonly groupField?: string;
   /** 是否堆积柱状图 */
   readonly isStack?: boolean;
-  /** 堆积拆分字段 */
-  readonly stackField?: string;
   /** 柱子样式配置 */
   readonly interval?: IntervalOption;
 }
 
-function getGroupField(params: Params<IntervalGeometryOptions>): string {
-  const { options } = params;
-  const { groupField, seriesField, colorField } = options;
-
-  return groupField || seriesField || colorField;
-}
-
-function getStackField(params: Params<IntervalGeometryOptions>): string {
-  const { options } = params;
-  const { stackField, seriesField, colorField } = options;
-
-  return stackField || seriesField || colorField;
-}
-
 export function interval<O extends IntervalGeometryOptions>(params: Params<O>): Params<O> {
   const { chart, options } = params;
-  const { xField, yField, colorField, color, isGroup, isStack, interval } = options;
-  let realColorField = colorField;
+  const { xField, yField, seriesField, color, isGroup, isStack, interval } = options;
 
   if (interval) {
     const { marginRatio, widthRatio, style } = interval;
     const geometry = chart.interval().position(`${xField}*${yField}`);
 
     // field
-    if (isGroup) {
-      realColorField = getGroupField(params);
-      geometry.color(realColorField, color);
-      geometry.adjust({
-        type: 'dodge',
-        marginRatio,
-      });
-    } else if (isStack) {
-      realColorField = getStackField(params);
-      geometry.color(getStackField(params), color);
-      geometry.adjust({
-        type: 'stack',
-        marginRatio,
-      });
-    } else {
-      if (colorField) {
-        geometry.color(colorField, color);
+    if (seriesField) {
+      geometry.color(seriesField, color);
+      // group
+      if (isGroup) {
+        geometry.adjust({
+          type: 'dodge',
+          marginRatio,
+        });
+      } else if (isStack) {
+        // stack
+        geometry.adjust({
+          type: 'stack',
+          marginRatio,
+        });
       }
     }
 
@@ -87,7 +63,7 @@ export function interval<O extends IntervalGeometryOptions>(params: Params<O>): 
     // style
     if (style) {
       if (isFunction(style)) {
-        geometry.style(`${xField}*${yField}*${realColorField}`, style);
+        geometry.style(`${xField}*${yField}*${seriesField}`, style);
       } else {
         geometry.style(style);
       }

--- a/src/plots/box/types.ts
+++ b/src/plots/box/types.ts
@@ -7,7 +7,7 @@ export interface BoxOptions extends Options {
   /** y 轴映射 box range [low, q1, median, q3, high] 五个字段 or 一个数组字段 */
   readonly yField: string | [string?, string?, string?, string?, string?];
   /** 箱型样式配置，可选 */
-  readonly boxStyle?: ShapeStyle | ((x: string, _range: string) => ShapeStyle);
+  readonly boxStyle?: ShapeStyle | ((x: string, range: string) => ShapeStyle);
   /** 分组拆分字段，默认是分组情况，颜色作为视觉通道 */
   readonly groupField?: string;
   /** 异常值字段 */

--- a/src/plots/column/types.ts
+++ b/src/plots/column/types.ts
@@ -6,18 +6,12 @@ export interface ColumnOptions extends Options {
   readonly xField: string;
   /** y 轴字段 */
   readonly yField: string;
-  /** 颜色字段，可选 */
-  readonly colorField?: string;
   /** 拆分字段，在分组柱状图下同 groupField、colorField，在堆积柱状图下同 stackField、colorField  */
   readonly seriesField?: string;
   /** 是否分组柱形图 */
   readonly isGroup?: boolean;
-  /** 分组拆分字段 */
-  readonly groupField?: string;
   /** 是否堆积柱状图 */
   readonly isStack?: boolean;
-  /** 堆积拆分字段 */
-  readonly stackField?: string;
   /** 柱状图宽度占比 [0-1] */
   readonly columnWidthRatio?: number;
   /** 分组中柱子之间的间距 [0-1]，仅对分组柱状图适用 */

--- a/src/plots/dual-axes/types.ts
+++ b/src/plots/dual-axes/types.ts
@@ -35,14 +35,7 @@ export type LineConfig = Pick<LineOptions, 'seriesField' | 'smooth' | 'connectNu
 // 柱设置接口
 export type ColumnConfig = Pick<
   ColumnOptions,
-  | 'colorField'
-  | 'isGroup'
-  | 'groupField'
-  | 'isStack'
-  | 'stackField'
-  | 'columnWidthRatio'
-  | 'marginRatio'
-  | 'columnStyle'
+  'seriesField' | 'isGroup' | 'isStack' | 'columnWidthRatio' | 'marginRatio' | 'columnStyle'
 > &
   CommonGeometryConfig;
 

--- a/src/plots/dual-axes/util/geometry.ts
+++ b/src/plots/dual-axes/util/geometry.ts
@@ -47,7 +47,7 @@ export function drawSingleGeometry<O extends { xField: string; yField: string; g
       deepMix({}, params, {
         options: {
           ...pick(options, FIELD_KEY),
-          ...pick(geometryConfig, ['color', 'colorField', 'isGroup', 'groupField', 'isStack', 'stackField']),
+          ...pick(geometryConfig, ['color', 'seriesField', 'isGroup', 'isStack']),
           interval: {
             marginRatio: geometryConfig.marginRatio,
             widthRatio: geometryConfig.columnWidthRatio,


### PR DESCRIPTION
如 https://github.com/antvis/G2Plot/pull/1454#issuecomment-683244868 的讨论，收敛条、柱关于字段的的配置。

 - [x] remove groupField, colorField, stackField，统一使用 seriesField + isStack + isGroup 标识
 - [x] 修改单测
 - [x] 修改 demo，已经验证