### PR TITLE
Fix/dual axes

### DIFF
--- a/__tests__/unit/core/index-spec.ts
+++ b/__tests__/unit/core/index-spec.ts
@@ -96,7 +96,7 @@ describe('core', () => {
     line.render();
 
     function click(): Promise<Event> {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         line.on('element:click', (e) => {
           resolve(e);
         });

--- a/__tests__/unit/plots/tiny-column/index-spec.ts
+++ b/__tests__/unit/plots/tiny-column/index-spec.ts
@@ -59,7 +59,7 @@ describe('tiny-column', () => {
 
     tinyColumn.update({
       ...tinyColumn.options,
-      columnStyle: (x, y) => {
+      columnStyle: (x) => {
         return x > 10 ? { fill: '#222222' } : { fill: '#444444' };
       },
     });

--- a/__tests__/unit/plots/tiny-column/theme-spec.ts
+++ b/__tests__/unit/plots/tiny-column/theme-spec.ts
@@ -25,7 +25,7 @@ describe('tiny-column', () => {
     });
 
     tinyColumn.render();
-    const elements = tinyColumn.chart.geometries[0].elements;
+    // const elements = tinyColumn.chart.geometries[0].elements;
     expect(tinyColumn.chart.getTheme().colors10).toEqual(['blue', 'red', 'yellow', 'lightgreen', 'lightblue', 'pink']);
   });
 });

--- a/examples/dual-axes/column-line/demo/column-line.ts
+++ b/examples/dual-axes/column-line/demo/column-line.ts
@@ -18,6 +18,10 @@ const dualAxesChart = new DualAxes('container', {
     },
     {
       geometry: 'line',
+      lineStyle: {
+        lineWidth: 2,
+        stroke: '#29cae4',
+      },
     },
   ],
 });

--- a/examples/dual-axes/grouped-column-line/demo/grouped-column-line.ts
+++ b/examples/dual-axes/grouped-column-line/demo/grouped-column-line.ts
@@ -33,6 +33,10 @@ const dualAxesChart = new DualAxes('container', {
     },
     {
       geometry: 'line',
+      lineStyle: {
+        lineWidth: 2,
+        stroke: '#FAA219',
+      },
     },
   ],
 });

--- a/src/adaptor/geometries/interval.ts
+++ b/src/adaptor/geometries/interval.ts
@@ -51,6 +51,8 @@ export function interval<O extends IntervalGeometryOptions>(params: Params<O>): 
           marginRatio,
         });
       }
+    } else if (typeof color === 'string') {
+      geometry.color(color);
     }
 
     // widthRatio

--- a/src/adaptor/geometries/line.ts
+++ b/src/adaptor/geometries/line.ts
@@ -42,6 +42,9 @@ export function line<O extends LineGeometryOptions>(params: Params<O>): Params<O
     if (seriesField) {
       const lineColor = isFunction(line.color) ? line.color : line.color || color;
       lineGeometry.color(seriesField, lineColor);
+    } else if (typeof color === 'string') {
+      // 单折线图的颜色赋值
+      lineGeometry.color(color);
     }
 
     // size

--- a/src/adaptor/geometries/point.ts
+++ b/src/adaptor/geometries/point.ts
@@ -1,4 +1,4 @@
-import { isFunction, isObject, isString, uniq } from '@antv/util';
+import { isFunction, isObject, isString } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { Options } from '../../types';
 import { ShapeStyle } from '../../types/style';
@@ -40,6 +40,8 @@ export function point<O extends PointGeometryOptions>(params: Params<O>): Params
     if (seriesField) {
       const pointColor = isFunction(point.color) ? point.color : point.color || color;
       pointGeometry.color(seriesField, pointColor);
+    } else if (typeof color === 'string') {
+      pointGeometry.color(color);
     }
 
     // size

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -3,7 +3,7 @@ import Element from '@antv/g2/lib/geometry/element';
 import { deepMix, each } from '@antv/util';
 import EE from '@antv/event-emitter';
 import { bind } from 'size-sensor';
-import { Options, Data, StateName, StateCondition, Size, StateObject } from '../types';
+import { Options, StateName, StateCondition, Size, StateObject } from '../types';
 import { getContainerSize, getAllElements } from '../utils';
 import { Adaptor } from './adaptor';
 

--- a/src/plots/dual-axes/adaptor.ts
+++ b/src/plots/dual-axes/adaptor.ts
@@ -1,5 +1,6 @@
-import { deepMix } from '@antv/util';
-import { theme, tooltip, interaction, animation, scale } from '../../adaptor/common';
+import { each, deepMix } from '@antv/util';
+import { theme, animation, scale } from '../../adaptor/common';
+import { Interaction } from '../../types/interaction';
 import { Params } from '../../core/adaptor';
 import { flow } from '../../utils';
 import { getOption } from './util/option';
@@ -8,8 +9,9 @@ import { DualAxesOption } from './types';
 
 /**
  * 获取默认参数设置
- * 双轴图无法使用公共的 getDefaultOption, 因为双轴图存在[lineConfig, lineConfig] 这样的数据，需要根据传入的 option，生成不同的 defaultOption
- * 主要针对 yAxis 和 geometryOptions
+ * 双轴图无法使用公共的 getDefaultOption, 因为双轴图存在[lineConfig, lineConfig] 这样的数据，需要根据传入的 option，生成不同的 defaultOption,
+ * 并且 deepmix 无法 mix 数组类型数据，因此需要做一次参数的后转换
+ * 这个函数针对 yAxis 和 geometryOptions
  * @param params
  */
 export function transformOptions(params: Params<DualAxesOption>): Params<DualAxesOption> {
@@ -62,6 +64,7 @@ function geometry(params: Params<DualAxesOption>): Params<DualAxesOption> {
       geometryConfig: geometryOptions[1],
     },
   });
+
   return params;
 }
 
@@ -106,6 +109,15 @@ export function axis(params: Params<DualAxesOption>): Params<DualAxesOption> {
     yAxis[1] = deepMix({}, yAxis[1], { position: 'right', grid: null });
   }
 
+  chart.scale({
+    [yField[0]]: {
+      sync: 'value',
+    },
+    [yField[1]]: {
+      sync: 'value',
+    },
+  });
+
   chart.axis(xField, false);
   chart.axis(yField[0], false);
   chart.axis(yField[1], false);
@@ -124,15 +136,67 @@ export function axis(params: Params<DualAxesOption>): Params<DualAxesOption> {
 }
 
 /**
+ * tooltip 配置
+ * @param params
+ */
+export function tooltip(params: Params<DualAxesOption>): Params<DualAxesOption> {
+  const { chart, options } = params;
+  const { tooltip } = options;
+  const [leftView, rightView] = chart.views;
+  if (tooltip !== undefined) {
+    chart.tooltip(tooltip);
+    // 在 view 上添加 tooltip，使得 shared 和 interaction active-region 起作用
+    // view 应该继承 chart 里的 shared，但是从表现看来，继承有点问题
+    leftView.tooltip({
+      shared: true,
+    });
+    rightView.tooltip({
+      shared: true,
+    });
+  }
+  return params;
+}
+
+/**
+ * interaction 配置
+ * @param params
+ */
+export function interaction(params: Params<DualAxesOption>): Params<DualAxesOption> {
+  const { chart, options } = params;
+  const { interactions } = options;
+  const [leftView, rightView] = chart.views;
+  each(interactions, (i: Interaction) => {
+    if (i.enable === false) {
+      leftView.removeInteraction(i.type);
+      rightView.removeInteraction(i.type);
+    } else {
+      leftView.interaction(i.type, i.cfg || {});
+      rightView.interaction(i.type, i.cfg || {});
+    }
+  });
+  return params;
+}
+
+/**
  * legend 配置
  * @param params
  */
 export function legend(params: Params<DualAxesOption>): Params<DualAxesOption> {
   const { chart, options } = params;
-  const { legend, yField } = options;
+  const { legend, geometryOptions } = options;
+  const [leftGeometryOption, rightGeometryOption] = geometryOptions;
   if (legend) {
-    chart.legend(yField[0], legend);
-    chart.legend(yField[1], legend);
+    if (leftGeometryOption.seriesField) {
+      // TOFIX: G2 中图例无法绑定在子 view 中，但绑定在 chart 上回换行。暂时先放在下方
+      chart.legend(leftGeometryOption.seriesField, {
+        position: 'bottom',
+      });
+    }
+    if (rightGeometryOption.seriesField) {
+      chart.legend(rightGeometryOption.seriesField, {
+        position: 'bottom',
+      });
+    }
   }
   return params;
 }
@@ -144,5 +208,5 @@ export function legend(params: Params<DualAxesOption>): Params<DualAxesOption> {
  */
 export function adaptor(params: Params<DualAxesOption>): Params<DualAxesOption> {
   // flow 的方式处理所有的配置到 G2 API
-  return flow(transformOptions, geometry, meta, axis, legend, tooltip, theme, interaction, animation)(params);
+  return flow(transformOptions, geometry, meta, axis, tooltip, interaction, theme, animation, legend)(params);
 }

--- a/src/plots/dual-axes/adaptor.ts
+++ b/src/plots/dual-axes/adaptor.ts
@@ -64,7 +64,6 @@ function geometry(params: Params<DualAxesOption>): Params<DualAxesOption> {
       geometryConfig: geometryOptions[1],
     },
   });
-
   return params;
 }
 
@@ -108,15 +107,6 @@ export function axis(params: Params<DualAxesOption>): Params<DualAxesOption> {
   if (yAxis[1]) {
     yAxis[1] = deepMix({}, yAxis[1], { position: 'right', grid: null });
   }
-
-  chart.scale({
-    [yField[0]]: {
-      sync: 'value',
-    },
-    [yField[1]]: {
-      sync: 'value',
-    },
-  });
 
   chart.axis(xField, false);
   chart.axis(yField[0], false);

--- a/src/plots/dual-axes/index.ts
+++ b/src/plots/dual-axes/index.ts
@@ -1,7 +1,7 @@
 import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { DualAxesOption } from './types';
+import { DualAxesOption, DualAxesGeometry } from './types';
 import { adaptor } from './adaptor';
 
 export { DualAxesOption };
@@ -13,15 +13,23 @@ export class DualAxes extends Plot<DualAxesOption> {
   /**
    * 获取 双轴图 默认配置
    */
-  protected getDefaultOptions() {
+  protected getDefaultOptions(options) {
+    const { geometryOptions = [] } = options;
+    const hasColumn = geometryOptions.find(
+      (geometryOption) => geometryOption && geometryOption.geometry === DualAxesGeometry.Column
+    );
+    const defaultInteraction = [{ type: 'legend-visible-filter' }];
     return deepMix({}, super.getDefaultOptions(), {
       tooltip: {
-        showMarkers: true,
-        showCrosshairs: true,
+        showMarkers: false,
+        // 存在柱状图，不显示 crosshairs
+        showCrosshairs: !hasColumn,
+        shared: true,
         crosshairs: {
           type: 'x',
         },
       },
+      interactions: hasColumn ? defaultInteraction.concat({ type: 'active-region' }) : defaultInteraction,
     });
   }
 

--- a/src/plots/dual-axes/util/option.ts
+++ b/src/plots/dual-axes/util/option.ts
@@ -61,12 +61,11 @@ export function getOption(options: DualAxesOption): DualAxesOption {
     },
   };
 
-  const mixYAxis = [
-    yAxis[0] !== false ? deepMix({}, DEFAULT_YAXIS_CONFIG, yAxis[0]) : false,
-    yAxis[1] !== false ? deepMix({}, DEFAULT_YAXIS_CONFIG, yAxis[1]) : false,
-  ];
   return deepMix({}, options, {
-    yAxis: mixYAxis,
+    yAxis: [
+      yAxis[0] !== false ? deepMix({}, DEFAULT_YAXIS_CONFIG, yAxis[0]) : false,
+      yAxis[1] !== false ? deepMix({}, DEFAULT_YAXIS_CONFIG, yAxis[1]) : false,
+    ],
     geometryOptions: [
       getGeometryConfig(geometryOptions[0], AxisType.Left),
       getGeometryConfig(geometryOptions[1], AxisType.Right),

--- a/src/plots/pie/interaction/pie-legend-action.ts
+++ b/src/plots/pie/interaction/pie-legend-action.ts
@@ -11,7 +11,7 @@ import { groupTransform } from '../../../utils/g-util';
  */
 export class PieLegendAction extends Action {
   init() {
-    const { view } = this.context;
+    // const { view } = this.context;
   }
   /**
    * 获取激活的图形元素

--- a/src/plots/rose/adaptor.ts
+++ b/src/plots/rose/adaptor.ts
@@ -1,6 +1,6 @@
 import { deepMix, isObject } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow, findGeometry, log, LEVEL, pick } from '../../utils';
+import { flow, findGeometry, log, LEVEL } from '../../utils';
 import { legend, tooltip, interaction, animation, theme, scale } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { RoseOptions } from './types';


### PR DESCRIPTION
1. 为双轴图 column 增加 active-region 效果
2. 为单折柱点 geometry 增加 color 功能
3. 去除不必要的 warning

TODO
1. 双轴图的案例问题，包括 legend-filter 和位置问题，在 plot 层面没有很好的解决方法，接下来看下 g2 层面。
2. 理论上来说子 view 会继承 chart 上设置的 tooltip: {shared: true} 属性，但为双轴图 column 增加 active-region 效果时，发现需要显式在子 view 中声明。