### PR TITLE
fix: fix api-extractor does not support the export * as syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "site:develop": "cross-env PORT=8080 gatsby develop --open -H 0.0.0.0",
     "site:build": "npm run site:clean && gatsby build --prefix-paths",
     "site:clean": "gatsby clean",
-    "site:deploy": "npm run site:build && gh-pages -d public",
+    "site:deploy": "npm run build && npm run site:build && gh-pages -d public",
     "fix": "eslint --ext .ts ./src ./__tests__ --fix && prettier --write ./src ./__tests__ && lint-md --fix ./examples",
     "build": "run-s clean lib dist size",
     "size": "limit-size",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 export const version = '2.0.0-beta.4';
 
 // G2 自定义能力透出
-export * as G2 from '@antv/g2';
+import * as G2 from '@antv/g2';
+export { G2 };
 
 /** G2Plot 的 Plot 基类 */
 export { Plot } from './core/plot';


### PR DESCRIPTION
add smart tips for G2Plot examples