### PR TITLE
fix(word-cloud): 修复this指向问题

### DIFF
--- a/src/plots/word-cloud/index.ts
+++ b/src/plots/word-cloud/index.ts
@@ -48,17 +48,17 @@ export class WordCloud extends Plot<WordCloudOptions> {
       return;
     }
 
-    processImageMask(imageMask)
-      .then((img) => {
-        this.options = {
-          ...this.options,
-          imageMask: img || null,
-        };
+    const handler = (img: HTMLImageElement) => {
+      this.options = {
+        ...this.options,
+        imageMask: img || null,
+      };
 
-        // 调用父类渲染函数
-        super.render();
-      })
-      .catch(super.render);
+      // 调用父类渲染函数
+      super.render();
+    };
+
+    processImageMask(imageMask).then(handler).catch(handler);
   }
 
   /**


### PR DESCRIPTION
在把`processImageMask`有`callback`形式改为`Promise`时，不小心改出的一个bug。