### PR TITLE
fix(1761): 辅助 geometry 的 color 样式跟随主元素的 color 配置

### DIFF
--- a/__tests__/bugs/issue-1758-spec.ts
+++ b/__tests__/bugs/issue-1758-spec.ts
@@ -2,7 +2,7 @@ import { TinyArea } from '../../src';
 import { createDiv } from '../utils/dom';
 
 describe('#1758', () => {
-  it('area line.color', () => {
+  it('tiny-area line.color', () => {
     const tinyArea = new TinyArea(createDiv('mini 面积图 color 配置不生效'), {
       height: 60,
       width: 300,

--- a/__tests__/bugs/issue-1761-spec.ts
+++ b/__tests__/bugs/issue-1761-spec.ts
@@ -1,0 +1,85 @@
+import { Line, Area } from '../../src';
+import { createDiv } from '../utils/dom';
+import { partySupport } from '../data/party-support';
+
+describe('#1761', () => {
+  it('Line: point color should be same with line color', () => {
+    const line = new Line(createDiv('point color should be same with line color'), {
+      height: 300,
+      width: 400,
+      autoFit: false,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      smooth: true,
+      color: ['red', 'green'],
+    });
+
+    line.render();
+
+    expect(line.chart.geometries.length).toBe(1);
+
+    line.update({
+      ...line.options,
+      point: {},
+    });
+
+    // @ts-ignore
+    expect(line.chart.geometries[1].attributeOption.color.values).toEqual(['red', 'green']);
+
+    line.update({
+      ...line.options,
+      point: {
+        color: ['blue', 'black'],
+      },
+    });
+
+    // @ts-ignore
+    expect(line.chart.geometries[1].attributeOption.color.values).toEqual(['blue', 'black']);
+  });
+
+  it('Area: point, line color should be same with area color', () => {
+    const area = new Area(createDiv('point/line color should be same with area color'), {
+      height: 300,
+      width: 400,
+      autoFit: false,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      smooth: true,
+      color: ['red', 'green'],
+    });
+
+    area.render();
+
+    expect(area.chart.geometries.length).toBe(1);
+
+    area.update({
+      ...area.options,
+      line: {},
+      point: {},
+    });
+
+    // @ts-ignore
+    expect(area.chart.geometries[1].attributeOption.color.values).toEqual(['red', 'green']);
+    // @ts-ignore
+    expect(area.chart.geometries[2].attributeOption.color.values).toEqual(['red', 'green']);
+
+    area.update({
+      ...area.options,
+      line: {
+        color: ['yellow', 'grey'],
+      },
+      point: {
+        color: ['blue', 'black'],
+      },
+    });
+
+    // @ts-ignore
+    expect(area.chart.geometries[1].attributeOption.color.values).toEqual(['yellow', 'grey']);
+    // @ts-ignore
+    expect(area.chart.geometries[2].attributeOption.color.values).toEqual(['blue', 'black']);
+  });
+});

--- a/src/plots/area/adaptor.ts
+++ b/src/plots/area/adaptor.ts
@@ -13,7 +13,7 @@ import { AreaOptions } from './types';
  */
 function geometry(params: Params<AreaOptions>): Params<AreaOptions> {
   const { chart, options } = params;
-  const { data, areaStyle, color, point: pointOptions, line: lineOptions } = options;
+  const { data, areaStyle, color, point: pointMapping, line: lineMapping } = options;
 
   chart.data(data);
 
@@ -22,13 +22,13 @@ function geometry(params: Params<AreaOptions>): Params<AreaOptions> {
       area: { color, style: areaStyle },
       // 颜色保持一致，因为如果颜色不一致，会导致 tooltip 中元素重复。
       // 如果存在，才设置，否则为空
-      line: lineOptions && {
+      line: lineMapping && {
         color,
-        ...lineOptions,
+        ...lineMapping,
       },
-      point: pointOptions && {
+      point: pointMapping && {
         color,
-        ...pointOptions,
+        ...pointMapping,
       },
     },
   });

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -24,7 +24,12 @@ function geometry(params: Params<LineOptions>): Params<LineOptions> {
         color,
         style: lineStyle,
       },
-      point: pointMapping,
+      // 颜色保持一致，因为如果颜色不一致，会导致 tooltip 中元素重复。
+      // 如果存在，才设置，否则为空
+      point: pointMapping && {
+        color,
+        ...pointMapping,
+      },
     },
   });
 


### PR DESCRIPTION
fixed #1761 

 - [x] 修复问题
 - [x] 面积图折线图 先关变量命名保持一致
 - [x] 单测折线图、面积图