### PR TITLE
fix(word-cloud): 修复tooltip小圆点的颜色不显示

### DIFF
--- a/__tests__/bugs/issue-1754-spec.ts
+++ b/__tests__/bugs/issue-1754-spec.ts
@@ -16,7 +16,7 @@ describe('issue 1754', () => {
     const data = [
       {
         data: { text: 'name', value: 'weight' },
-        mappingData: { color: 'red' },
+        color: 'red',
       },
     ];
     const result =

--- a/examples/word-cloud/basic/demo/custom-tooltip.ts
+++ b/examples/word-cloud/basic/demo/custom-tooltip.ts
@@ -19,7 +19,7 @@ fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/antv-keywords.json')
           if (!data.length) return;
           return `<h4 style="margin-top: 1em;">title</h4>
             <li class="g2-tooltip-list-item" style="margin-bottom:4px;display:flex;align-items:center;">
-            <span style="background-color:${data[0]?.mappingData?.color};" class="g2-tooltip-marker"></span>
+            <span style="background-color:${data[0]?.color};" class="g2-tooltip-marker"></span>
             <span style="display:inline-flex;flex:1;justify-content:space-between">
               <span style="margin-right: 16px;">${data[0]?.data.text}:</span><span>${data[0]?.data.value}</span>
             </span>

--- a/src/plots/word-cloud/index.ts
+++ b/src/plots/word-cloud/index.ts
@@ -23,13 +23,13 @@ export class WordCloud extends Plot<WordCloudOptions> {
         showTitle: false,
         showMarkers: false,
         showCrosshairs: false,
-        customContent(_, data: { data: Tag; mappingData: { color: string } }[]) {
+        customContent(_, data: { data: Tag; color: string }[]) {
           if (!data.length) return;
           // 不完全采用模板字符串，是为了去掉换行符和部分空格，
           // 便于测试。
           return (
             '<li class="g2-tooltip-list-item" style="margin-bottom:4px;display:flex;align-items:center;">' +
-            `<span style="background-color:${data[0]?.mappingData?.color};" class="g2-tooltip-marker"></span>` +
+            `<span style="background-color:${data[0]?.color};" class="g2-tooltip-marker"></span>` +
             '<span style="display:inline-flex;flex:1;justify-content:space-between">' +
             `<span style="margin-right: 16px;">${data[0]?.data.text}:</span><span>${data[0]?.data.value}</span>` +
             '</span>' +


### PR DESCRIPTION
- [x] 当 color 和 colorField 字段为空时，tooltip 中左边的小圆点不显示颜色

![9F5031CA-2909-4152-B6C9-87A3CC5F7EB4](https://user-images.githubusercontent.com/38434641/97004033-fd963e80-156e-11eb-8058-a01f7968d154.png)
