### PR TITLE
fix: correct spelling

### DIFF
--- a/examples/general/annotation/index.en.md
+++ b/examples/general/annotation/index.en.md
@@ -1,4 +1,4 @@
 ---
-title: Annotaiton setting
+title: Annotation setting
 order: 0
 ---


### PR DESCRIPTION
Fix a typo in the headline.