### PR TITLE
feat: add axis base, exponent option to scale

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -12,6 +12,10 @@ export const AXIS_META_CONFIG_KEYS = [
   'minLimit',
   'maxLimit',
   'tickMethod',
+  // type: 'log' 的底
+  'base',
+  // type: 'exp' 的指数
+  'exponent',
 ];
 
 /**


### PR DESCRIPTION
 - [x] 将 axis 的 base，exponent 都放入到 scale 中。使用 yAxis 设置比通过 meta 设置更加方便。