### PR TITLE
feat(api): changeData & update

### DIFF
--- a/__tests__/bugs/issue-1757-spec.ts
+++ b/__tests__/bugs/issue-1757-spec.ts
@@ -45,5 +45,6 @@ describe('#1757', () => {
     // @ts-ignore
     expect(document.getElementsByClassName('g2-tooltip-title')[0].style['margin-top']).toBe('12px');
     expect(line.chart.geometries[1].elements[0].container.getChildByIndex(0).attr('stroke')).toBe('#2593fc');
+    line.destroy();
   });
 });

--- a/__tests__/unit/plots/column/percent-spec.ts
+++ b/__tests__/unit/plots/column/percent-spec.ts
@@ -21,8 +21,8 @@ const data = [
 ];
 
 describe('column percent', () => {
-  it('percent: render', async () => {
-    const column = new Column(createDiv('percent'), {
+  it('percent: render', () => {
+    const column = new Column(createDiv('percent', document.body, 'culumn-percent-render'), {
       width: 400,
       height: 300,
       data,
@@ -50,7 +50,8 @@ describe('column percent', () => {
     const elements = geometry.elements;
     const bbox = elements[elements.length - 1].getBBox();
     column.chart.showTooltip({ x: bbox.maxX, y: bbox.maxY });
-    expect(document.getElementsByClassName('g2-tooltip-title')[0].innerHTML).toBe('2100');
+    const box = document.getElementById('culumn-percent-render');
+    expect(box.getElementsByClassName('g2-tooltip-title')[0].innerHTML).toBe('2100');
     const {
       // @ts-ignore
       labelOption: { cfg },
@@ -61,9 +62,10 @@ describe('column percent', () => {
     });
     expect(cfg.position).toBe('middle');
     expect(cfg.content).not.toBeUndefined();
+    column.destroy();
   });
-  it('percent: custom content', async () => {
-    const column = new Column(createDiv('percent'), {
+  it('percent: custom content', () => {
+    const column = new Column(createDiv('percent', document.body, 'culumn-percent'), {
       width: 400,
       height: 300,
       data,
@@ -94,8 +96,10 @@ describe('column percent', () => {
     const elements = geometry.elements;
     const bbox = elements[elements.length - 1].getBBox();
     column.chart.showTooltip({ x: bbox.maxX, y: bbox.maxY });
-    expect(document.getElementsByClassName('g2-tooltip-title')[1]).toBeUndefined();
-    expect(document.getElementsByClassName('tooltip-class')[0].innerHTML).toBe('123');
+    const box = document.getElementById('culumn-percent');
+    expect(box.getElementsByClassName('g2-tooltip-title')[1]).toBeUndefined();
+    expect(box.getElementsByClassName('tooltip-class')[0].innerHTML).toBe('123');
+    column.destroy();
   });
   it('percent: custom tooltip formatter', () => {
     const column = new Column(createDiv('percent', undefined, 'percent'), {

--- a/__tests__/unit/plots/column/percent-spec.ts
+++ b/__tests__/unit/plots/column/percent-spec.ts
@@ -21,7 +21,7 @@ const data = [
 ];
 
 describe('column percent', () => {
-  it('percent: render', () => {
+  it('percent: render', async () => {
     const column = new Column(createDiv('percent', document.body, 'culumn-percent-render'), {
       width: 400,
       height: 300,
@@ -64,7 +64,7 @@ describe('column percent', () => {
     expect(cfg.content).not.toBeUndefined();
     column.destroy();
   });
-  it('percent: custom content', () => {
+  it('percent: custom content', async () => {
     const column = new Column(createDiv('percent', document.body, 'culumn-percent'), {
       width: 400,
       height: 300,

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -180,7 +180,9 @@ describe('gauge', () => {
     gauge.render();
 
     expect(gauge.chart.views[0].getData()).toEqual([{ percent: 0.75 }]);
+    expect(gauge.options.range.ticks).toEqual([0, 0.75, 1]);
     gauge.changeData(0.2);
     expect(gauge.chart.views[0].getData()).toEqual([{ percent: 0.2 }]);
+    expect(gauge.options.range.ticks).toEqual([0, 0.2, 1]);
   });
 });

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -165,4 +165,22 @@ describe('gauge', () => {
     // 多 view 的时候，防止 update 的时候 view 泄露
     expect(gauge.chart.views.length).toBe(2);
   });
+
+  it('change data', () => {
+    const gauge = new Gauge(createDiv(), {
+      width: 600,
+      height: 300,
+      autoFit: false,
+      percent: 0.75,
+      range: {
+        color: ['l(0) 0:#5d7cef 1:#e35767'],
+      },
+    });
+
+    gauge.render();
+
+    expect(gauge.chart.views[0].getData()).toEqual([{ percent: 0.75 }]);
+    gauge.changeData(0.2);
+    expect(gauge.chart.views[0].getData()).toEqual([{ percent: 0.2 }]);
+  });
 });

--- a/__tests__/unit/plots/liquid/index-spec.ts
+++ b/__tests__/unit/plots/liquid/index-spec.ts
@@ -24,4 +24,17 @@ describe('liquid', () => {
     // @ts-ignore
     expect(liquid.chart.middleGroup.getChildren()[0].getChildren()[1].attr('r')).toBe(135); // circle
   });
+  it('change data', () => {
+    const liquid = new Liquid(createDiv(), {
+      width: 600,
+      height: 300,
+      autoFit: false,
+      percent: 0.75,
+    });
+
+    liquid.render();
+    expect(liquid.chart.geometries[0].elements[0].getData().percent).toBe(0.75);
+    liquid.changeData(0.5);
+    expect(liquid.chart.geometries[0].elements[0].getData().percent).toBe(0.5);
+  });
 });

--- a/__tests__/unit/plots/progress/index-spec.ts
+++ b/__tests__/unit/plots/progress/index-spec.ts
@@ -236,4 +236,17 @@ describe('progress', () => {
       },
     ]);
   });
+  it('change data', () => {
+    const progress = new Progress(createDiv(), {
+      width: 200,
+      height: 100,
+      percent: 0.6,
+      autoFit: false,
+    });
+
+    progress.render();
+    expect(progress.chart.geometries[0].elements[0].getData().percent).toBe(0.6);
+    progress.changeData(0.8);
+    expect(progress.chart.geometries[0].elements[0].getData().percent).toBe(0.8);
+  });
 });

--- a/__tests__/unit/plots/ring-progress/index-spec.ts
+++ b/__tests__/unit/plots/ring-progress/index-spec.ts
@@ -284,4 +284,19 @@ describe('ring-progress', () => {
 
     expect(ring.chart.getController('annotation').getComponents()[0].component.get('style').fontSize).toBe(20 * 0.6);
   });
+  it('change data', () => {
+    const ringProgress = new RingProgress(createDiv(), {
+      radius: 1,
+      innerRadius: 0.5,
+      width: 200,
+      height: 100,
+      percent: 0.6,
+      autoFit: false,
+    });
+
+    ringProgress.render();
+    expect(ringProgress.chart.geometries[0].elements[0].getData().percent).toBe(0.6);
+    ringProgress.changeData(0.7);
+    expect(ringProgress.chart.geometries[0].elements[0].getData().percent).toBe(0.7);
+  });
 });

--- a/__tests__/unit/utils/deep-assign-spec.ts
+++ b/__tests__/unit/utils/deep-assign-spec.ts
@@ -200,5 +200,100 @@ describe('deepAssign', () => {
         ],
       },
     });
+    // MAX_MIX_LEVEL
+    expect(
+      deepAssign(
+        {},
+        {
+          value: null,
+          callback: fn,
+          data: {
+            list: [
+              {
+                age: 19,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        },
+        {
+          value: undefined,
+          callback: fn,
+          data: {
+            list: [
+              {
+                age: 18,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        }
+      )
+    ).toEqual({
+      value: undefined,
+      callback: fn,
+      data: {
+        list: [
+          {
+            age: 18,
+            name: 'xiaoming',
+          },
+        ],
+      },
+    });
+
+    expect(
+      deepAssign(
+        {},
+        {
+          value: null,
+          deep1: {
+            deep2: {
+              deep3: {
+                deep4: {
+                  deep5: {
+                    deep6: {
+                      name: 'kevin',
+                      age: 18,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          value: undefined,
+          deep1: {
+            deep2: {
+              deep3: {
+                deep4: {
+                  deep5: {
+                    deep6: {
+                      age: 19,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      )
+    ).toEqual({
+      value: undefined,
+      deep1: {
+        deep2: {
+          deep3: {
+            deep4: {
+              deep5: {
+                deep6: {
+                  age: 19,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
   });
 });

--- a/__tests__/unit/utils/deep-assign-spec.ts
+++ b/__tests__/unit/utils/deep-assign-spec.ts
@@ -1,66 +1,94 @@
-import { deepMix } from '../../../src/utils';
+import { deepAssign } from '../../../src/utils';
 
-describe('deepMix', () => {
-  it('deepMix', () => {
+describe('deepAssign', () => {
+  it('deepAssign', () => {
     const fn = jest.fn();
     // undefined -> number
-    expect(deepMix({}, { value: 0 }, { value: undefined })).toEqual({ value: undefined });
-    expect(deepMix({}, { value: undefined }, { value: 0 })).toEqual({ value: 0 });
+    expect(deepAssign({}, { value: 0 }, { value: undefined })).toEqual({ value: undefined });
+    expect(deepAssign({}, { value: undefined }, { value: 0 })).toEqual({ value: 0 });
     // boolean -> boolean
-    expect(deepMix({}, { value: false }, { value: true })).toEqual({
+    expect(deepAssign({}, { value: false }, { value: true })).toEqual({
       value: true,
     });
-    expect(deepMix({}, { value: true }, { value: false })).toEqual({
+    expect(deepAssign({}, { value: true }, { value: false })).toEqual({
       value: false,
     });
     // null -> boolean
-    expect(deepMix({}, { value: true }, { value: null })).toEqual({
+    expect(deepAssign({}, { value: true }, { value: null })).toEqual({
       value: null,
     });
-    expect(deepMix({}, { value: false }, { value: null })).toEqual({
+    expect(deepAssign({}, { value: false }, { value: null })).toEqual({
       value: null,
     });
     // boolean => ''
-    expect(deepMix({}, { value: true }, { value: '' })).toEqual({
+    expect(deepAssign({}, { value: true }, { value: '' })).toEqual({
       value: '',
     });
-    expect(deepMix({}, { value: '' }, { value: false })).toEqual({
+    expect(deepAssign({}, { value: '' }, { value: false })).toEqual({
       value: false,
     });
-    expect(deepMix({}, { value: '' }, { value: true })).toEqual({
+    expect(deepAssign({}, { value: '' }, { value: true })).toEqual({
       value: true,
     });
     // string => string
-    expect(deepMix({}, { value: 'a' }, { value: 'b' })).toEqual({
+    expect(deepAssign({}, { value: 'a' }, { value: 'b' })).toEqual({
       value: 'b',
     });
     // string => NaN
-    expect(deepMix({}, { value: NaN }, { value: 'NaN' })).toEqual({
+    expect(deepAssign({}, { value: NaN }, { value: 'NaN' })).toEqual({
       value: 'NaN',
     });
     // boolean => NaN
-    expect(deepMix({}, { value: true }, { value: NaN })).toEqual({
+    expect(deepAssign({}, { value: true }, { value: NaN })).toEqual({
       value: NaN,
     });
     // fn
-    expect(deepMix({}, { value: 0 }, { value: undefined, callback: fn })).toEqual({
+    expect(deepAssign({}, { value: 0 }, { value: undefined, callback: fn })).toEqual({
       value: undefined,
       callback: fn,
     });
     // Array
-    expect(deepMix({}, { value: 0, callback: fn }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
+    expect(deepAssign({}, { value: 0, callback: fn }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
       value: 1,
       callback: fn,
       list: [0, 2, 1],
     });
-    expect(deepMix({}, { value: 0, callback: fn, list: [1] }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
+    expect(deepAssign({}, { value: 0, callback: fn, list: [1] }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
+      value: 1,
+      callback: fn,
+      list: [0, 2, 1],
+    });
+    // Date
+    const targetDate = new Date();
+    expect(deepAssign({}, { value: 1, callback: fn }, { value: targetDate, callback: fn, list: [0, 2, 1] })).toEqual({
+      value: targetDate,
+      callback: fn,
+      list: [0, 2, 1],
+    });
+    const sourceDate = new Date();
+    expect(deepAssign({}, { value: sourceDate, callback: fn }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
+      value: 1,
+      callback: fn,
+      list: [0, 2, 1],
+    });
+    // RegExp
+    expect(
+      deepAssign({}, { value: 1, callback: fn }, { value: new RegExp('a', 'g'), callback: fn, list: [0, 2, 1] })
+    ).toEqual({
+      value: new RegExp('a', 'g'),
+      callback: fn,
+      list: [0, 2, 1],
+    });
+    expect(
+      deepAssign({}, { value: new RegExp('a', 'g'), callback: fn }, { value: 1, callback: fn, list: [0, 2, 1] })
+    ).toEqual({
       value: 1,
       callback: fn,
       list: [0, 2, 1],
     });
     // object
     expect(
-      deepMix(
+      deepAssign(
         {},
         {
           value: null,
@@ -90,7 +118,7 @@ describe('deepMix', () => {
     });
 
     expect(
-      deepMix(
+      deepAssign(
         {},
         {
           value: null,
@@ -131,7 +159,7 @@ describe('deepMix', () => {
     });
 
     expect(
-      deepMix(
+      deepAssign(
         {},
         {
           value: null,

--- a/__tests__/unit/utils/deep-mix-spec.ts
+++ b/__tests__/unit/utils/deep-mix-spec.ts
@@ -1,0 +1,176 @@
+import { deepMix } from '../../../src/utils';
+
+describe('deepMix', () => {
+  it('deepMix', () => {
+    const fn = jest.fn();
+    // undefined -> number
+    expect(deepMix({}, { value: 0 }, { value: undefined })).toEqual({ value: undefined });
+    expect(deepMix({}, { value: undefined }, { value: 0 })).toEqual({ value: 0 });
+    // boolean -> boolean
+    expect(deepMix({}, { value: false }, { value: true })).toEqual({
+      value: true,
+    });
+    expect(deepMix({}, { value: true }, { value: false })).toEqual({
+      value: false,
+    });
+    // null -> boolean
+    expect(deepMix({}, { value: true }, { value: null })).toEqual({
+      value: null,
+    });
+    expect(deepMix({}, { value: false }, { value: null })).toEqual({
+      value: null,
+    });
+    // boolean => ''
+    expect(deepMix({}, { value: true }, { value: '' })).toEqual({
+      value: '',
+    });
+    expect(deepMix({}, { value: '' }, { value: false })).toEqual({
+      value: false,
+    });
+    expect(deepMix({}, { value: '' }, { value: true })).toEqual({
+      value: true,
+    });
+    // string => string
+    expect(deepMix({}, { value: 'a' }, { value: 'b' })).toEqual({
+      value: 'b',
+    });
+    // string => NaN
+    expect(deepMix({}, { value: NaN }, { value: 'NaN' })).toEqual({
+      value: 'NaN',
+    });
+    // boolean => NaN
+    expect(deepMix({}, { value: true }, { value: NaN })).toEqual({
+      value: NaN,
+    });
+    // fn
+    expect(deepMix({}, { value: 0 }, { value: undefined, callback: fn })).toEqual({
+      value: undefined,
+      callback: fn,
+    });
+    // Array
+    expect(deepMix({}, { value: 0, callback: fn }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
+      value: 1,
+      callback: fn,
+      list: [0, 2, 1],
+    });
+    expect(deepMix({}, { value: 0, callback: fn, list: [1] }, { value: 1, callback: fn, list: [0, 2, 1] })).toEqual({
+      value: 1,
+      callback: fn,
+      list: [0, 2, 1],
+    });
+    // object
+    expect(
+      deepMix(
+        {},
+        {
+          value: null,
+          callback: fn,
+          data: {
+            list: [
+              {
+                age: 19,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        },
+        { value: undefined, callback: fn }
+      )
+    ).toEqual({
+      value: undefined,
+      callback: fn,
+      data: {
+        list: [
+          {
+            age: 19,
+            name: 'xiaoming',
+          },
+        ],
+      },
+    });
+
+    expect(
+      deepMix(
+        {},
+        {
+          value: null,
+          callback: fn,
+          data: {
+            list: [
+              {
+                age: 19,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        },
+        {
+          value: undefined,
+          callback: fn,
+          data: {
+            list: [
+              {
+                age: 18,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        }
+      )
+    ).toEqual({
+      value: undefined,
+      callback: fn,
+      data: {
+        list: [
+          {
+            age: 18,
+            name: 'xiaoming',
+          },
+        ],
+      },
+    });
+
+    expect(
+      deepMix(
+        {},
+        {
+          value: null,
+          callback: fn,
+          data: {
+            list: [
+              {
+                age: 19,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        },
+        {
+          value: undefined,
+          callback: fn,
+          status: 200,
+          data: {
+            list: [
+              {
+                age: 18,
+                name: 'xiaoming',
+              },
+            ],
+          },
+        }
+      )
+    ).toEqual({
+      value: undefined,
+      callback: fn,
+      status: 200,
+      data: {
+        list: [
+          {
+            age: 18,
+            name: 'xiaoming',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/__tests__/utils/dom.ts
+++ b/__tests__/utils/dom.ts
@@ -5,7 +5,9 @@
  */
 export function createDiv(title: string = '', container: HTMLElement = document.body, id?: string): HTMLElement {
   const div = document.createElement('div');
-
+  if (id) {
+    div.id = id;
+  }
   if (title) {
     const titleDiv = document.createElement('div').appendChild(document.createTextNode(title));
     container.appendChild(titleDiv);

--- a/src/adaptor/common.ts
+++ b/src/adaptor/common.ts
@@ -5,7 +5,7 @@ import { Options } from '../types';
 import { Interaction } from '../types/interaction';
 import { Axis } from '../types/axis';
 import { AXIS_META_CONFIG_KEYS } from '../constant';
-import { pick, deepMix } from '../utils';
+import { pick, deepAssign } from '../utils';
 
 /**
  * 通用 legend 配置, 适用于带 colorField 或 seriesField 的图表
@@ -156,7 +156,7 @@ export function scale(axes: Record<string, Axis>, meta?: Options['meta']) {
     });
 
     // 2. meta 直接是 scale 的信息
-    scales = deepMix({}, meta, options.meta, scales);
+    scales = deepAssign({}, meta, options.meta, scales);
 
     chart.scale(scales);
 

--- a/src/adaptor/common.ts
+++ b/src/adaptor/common.ts
@@ -1,11 +1,11 @@
 import { Geometry } from '@antv/g2';
-import { each, deepMix } from '@antv/util';
+import { each } from '@antv/util';
 import { Params } from '../core/adaptor';
 import { Options } from '../types';
 import { Interaction } from '../types/interaction';
 import { Axis } from '../types/axis';
 import { AXIS_META_CONFIG_KEYS } from '../constant';
-import { pick } from '../utils';
+import { pick, deepMix } from '../utils';
 
 /**
  * 通用 legend 配置, 适用于带 colorField 或 seriesField 的图表

--- a/src/adaptor/conversion-tag.ts
+++ b/src/adaptor/conversion-tag.ts
@@ -3,7 +3,7 @@ import { Coordinate, IGroup, ShapeAttrs } from '@antv/g2/lib/dependents';
 import { Geometry, View } from '@antv/g2';
 import Element from '@antv/g2/lib/geometry/element';
 import { Params } from '../core/adaptor';
-import { deepMix } from '../utils';
+import { deepAssign } from '../utils';
 
 /** 转化率组件配置选项 */
 export interface ConversionTagOptions {
@@ -54,7 +54,7 @@ type TagRenderConfig = {
 };
 
 function getConversionTagOptionsWithDefaults(options: ConversionTagOptions, horizontal: boolean): ConversionTagOptions {
-  return deepMix(
+  return deepAssign(
     {
       size: horizontal ? 32 : 80,
       spacing: horizontal ? 8 : 12,

--- a/src/adaptor/conversion-tag.ts
+++ b/src/adaptor/conversion-tag.ts
@@ -1,8 +1,9 @@
-import { map, find, each, deepMix } from '@antv/util';
+import { map, find, each } from '@antv/util';
 import { Coordinate, IGroup, ShapeAttrs } from '@antv/g2/lib/dependents';
 import { Geometry, View } from '@antv/g2';
 import Element from '@antv/g2/lib/geometry/element';
 import { Params } from '../core/adaptor';
+import { deepMix } from '../utils';
 
 /** 转化率组件配置选项 */
 export interface ConversionTagOptions {

--- a/src/adaptor/geometries/area.ts
+++ b/src/adaptor/geometries/area.ts
@@ -1,6 +1,6 @@
 import { Params } from '../../core/adaptor';
 import { getTooltipMapping } from '../../utils/tooltip';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { GeometryOptions, geometry, MappingOptions } from './base';
 
 export interface AreaGeometryOptions extends GeometryOptions {
@@ -29,7 +29,7 @@ export function area<O extends AreaGeometryOptions>(params: Params<O>): Params<O
   // 如果存在才处理
   return area
     ? geometry(
-        deepMix({}, params, {
+        deepAssign({}, params, {
           options: {
             type: 'area',
             colorField: seriesField,

--- a/src/adaptor/geometries/area.ts
+++ b/src/adaptor/geometries/area.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { getTooltipMapping } from '../../utils/tooltip';
+import { deepMix } from '../../utils';
 import { GeometryOptions, geometry, MappingOptions } from './base';
 
 export interface AreaGeometryOptions extends GeometryOptions {

--- a/src/adaptor/geometries/interval.ts
+++ b/src/adaptor/geometries/interval.ts
@@ -1,6 +1,7 @@
 import { Geometry } from '@antv/g2';
-import { deepMix, isNil } from '@antv/util';
+import { isNil } from '@antv/util';
 import { Params } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { getTooltipMapping } from '../../utils/tooltip';
 import { GeometryOptions, MappingOptions, geometry } from './base';
 

--- a/src/adaptor/geometries/interval.ts
+++ b/src/adaptor/geometries/interval.ts
@@ -1,7 +1,7 @@
 import { Geometry } from '@antv/g2';
 import { isNil } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { getTooltipMapping } from '../../utils/tooltip';
 import { GeometryOptions, MappingOptions, geometry } from './base';
 
@@ -71,7 +71,7 @@ export function interval<O extends IntervalGeometryOptions>(params: Params<O>): 
   // 保障一定要存在 interval 映射
   const { ext } = interval
     ? geometry(
-        deepMix({}, params, {
+        deepAssign({}, params, {
           options: {
             type: 'interval',
             colorField: seriesField,

--- a/src/adaptor/geometries/line.ts
+++ b/src/adaptor/geometries/line.ts
@@ -1,7 +1,7 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { ColorAttr, StyleAttr, SizeAttr } from '../../types';
 import { getTooltipMapping } from '../../utils/tooltip';
+import { deepMix } from '../../utils';
 import { GeometryOptions, geometry } from './base';
 
 type LineOption = {

--- a/src/adaptor/geometries/line.ts
+++ b/src/adaptor/geometries/line.ts
@@ -1,7 +1,7 @@
 import { Params } from '../../core/adaptor';
 import { ColorAttr, StyleAttr, SizeAttr } from '../../types';
 import { getTooltipMapping } from '../../utils/tooltip';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { GeometryOptions, geometry } from './base';
 
 type LineOption = {
@@ -43,7 +43,7 @@ export function line<O extends LineGeometryOptions>(params: Params<O>): Params<O
   // 如果存在才处理
   return line
     ? geometry(
-        deepMix({}, params, {
+        deepAssign({}, params, {
           options: {
             type: 'line',
             colorField: seriesField,

--- a/src/adaptor/geometries/point.ts
+++ b/src/adaptor/geometries/point.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { getTooltipMapping } from '../../utils/tooltip';
+import { deepMix } from '../../utils';
 import { geometry, MappingOptions, GeometryOptions } from './base';
 
 export interface PointGeometryOptions extends GeometryOptions {

--- a/src/adaptor/geometries/point.ts
+++ b/src/adaptor/geometries/point.ts
@@ -1,6 +1,6 @@
 import { Params } from '../../core/adaptor';
 import { getTooltipMapping } from '../../utils/tooltip';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { geometry, MappingOptions, GeometryOptions } from './base';
 
 export interface PointGeometryOptions extends GeometryOptions {
@@ -30,7 +30,7 @@ export function point<O extends PointGeometryOptions>(params: Params<O>): Params
 
   return point
     ? geometry(
-        deepMix({}, params, {
+        deepAssign({}, params, {
           options: {
             type: 'point',
             colorField: seriesField,

--- a/src/adaptor/geometries/polygon.ts
+++ b/src/adaptor/geometries/polygon.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { getTooltipMapping } from '../../utils/tooltip';
+import { deepMix } from '../../utils';
 import { geometry, MappingOptions, GeometryOptions } from './base';
 
 export interface PolygonGeometryOptions extends GeometryOptions {

--- a/src/adaptor/geometries/polygon.ts
+++ b/src/adaptor/geometries/polygon.ts
@@ -1,6 +1,6 @@
 import { Params } from '../../core/adaptor';
 import { getTooltipMapping } from '../../utils/tooltip';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { geometry, MappingOptions, GeometryOptions } from './base';
 
 export interface PolygonGeometryOptions extends GeometryOptions {
@@ -26,7 +26,7 @@ export function polygon<O extends PolygonGeometryOptions>(params: Params<O>): Pa
 
   return polygon
     ? geometry(
-        deepMix({}, params, {
+        deepAssign({}, params, {
           options: {
             type: 'polygon',
             colorField: seriesField,

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -4,7 +4,7 @@ import { each } from '@antv/util';
 import EE from '@antv/event-emitter';
 import { bind } from 'size-sensor';
 import { Options, StateName, StateCondition, Size, StateObject } from '../types';
-import { getContainerSize, getAllElements, deepMix } from '../utils';
+import { getContainerSize, getAllElements, deepAssign } from '../utils';
 import { Adaptor } from './adaptor';
 
 /** 单独 pick 出来的用于基类的类型定义 */
@@ -40,7 +40,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
     super();
     this.container = typeof container === 'string' ? document.getElementById(container) : container;
 
-    this.options = deepMix({}, this.getDefaultOptions(options), options);
+    this.options = deepAssign({}, this.getDefaultOptions(options), options);
 
     this.createG2();
 
@@ -162,9 +162,9 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * 更新配置
    * @param options
    */
-  public update(options: any) {
+  public update(options: O) {
     // options 更新是全量更新，这里和构造函数中一会加上图表的默认选项
-    this.options = deepMix({}, this.options, this.getDefaultOptions({ ...this.options, ...options }), options);
+    this.options = deepAssign({}, this.options, this.getDefaultOptions({ ...this.options, ...options }), options);
     this.render();
   }
 
@@ -208,6 +208,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
    */
   public changeData(data: any) {
     // 临时方案，会在 G2 做处理
+    // @ts-ignore
     this.update({
       data,
     });

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -1,10 +1,10 @@
 import { Chart, Event } from '@antv/g2';
 import Element from '@antv/g2/lib/geometry/element';
-import { deepMix, each } from '@antv/util';
+import { each } from '@antv/util';
 import EE from '@antv/event-emitter';
 import { bind } from 'size-sensor';
 import { Options, StateName, StateCondition, Size, StateObject } from '../types';
-import { getContainerSize, getAllElements } from '../utils';
+import { getContainerSize, getAllElements, deepMix } from '../utils';
 import { Adaptor } from './adaptor';
 
 /** 单独 pick 出来的用于基类的类型定义 */
@@ -162,10 +162,9 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * 更新配置
    * @param options
    */
-  public update(options: O) {
+  public update(options: any) {
     // options 更新是全量更新，这里和构造函数中一会加上图表的默认选项
-    this.options = deepMix({}, this.getDefaultOptions(options), options);
-
+    this.options = deepMix({}, this.options, this.getDefaultOptions({ ...this.options, ...options }), options);
     this.render();
   }
 
@@ -210,7 +209,6 @@ export abstract class Plot<O extends PickOptions> extends EE {
   public changeData(data: any) {
     // 临时方案，会在 G2 做处理
     this.update({
-      ...this.options,
       data,
     });
     // this.chart.changeData(data);

--- a/src/plots/area/adaptor.ts
+++ b/src/plots/area/adaptor.ts
@@ -2,7 +2,7 @@ import { tooltip, slider, interaction, animation, theme, annotation } from '../.
 import { findGeometry } from '../../utils';
 import { Params } from '../../core/adaptor';
 import { area, point, line } from '../../adaptor/geometries';
-import { flow, transformLabel, deepMix } from '../../utils';
+import { flow, transformLabel, deepAssign } from '../../utils';
 import { meta, legend, axis, adjust } from '../line/adaptor';
 import { AreaOptions } from './types';
 
@@ -16,7 +16,7 @@ function geometry(params: Params<AreaOptions>): Params<AreaOptions> {
 
   chart.data(data);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       area: { color, style: areaStyle },
       // 颜色保持一致，因为如果颜色不一致，会导致 tooltip 中元素重复。

--- a/src/plots/area/adaptor.ts
+++ b/src/plots/area/adaptor.ts
@@ -1,9 +1,8 @@
-import { deepMix } from '@antv/util';
 import { tooltip, slider, interaction, animation, theme, annotation } from '../../adaptor/common';
 import { findGeometry } from '../../utils';
 import { Params } from '../../core/adaptor';
 import { area, point, line } from '../../adaptor/geometries';
-import { flow, transformLabel } from '../../utils';
+import { flow, transformLabel, deepMix } from '../../utils';
 import { meta, legend, axis, adjust } from '../line/adaptor';
 import { AreaOptions } from './types';
 

--- a/src/plots/area/index.ts
+++ b/src/plots/area/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { AreaOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/area/index.ts
+++ b/src/plots/area/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { AreaOptions } from './types';
 import { adaptor } from './adaptor';
@@ -15,7 +15,7 @@ export class Area extends Plot<AreaOptions> {
    */
   protected getDefaultOptions(options: AreaOptions) {
     const { xField } = options;
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       tooltip: {
         showMarkers: true,
         showCrosshairs: true,

--- a/src/plots/bar/index.ts
+++ b/src/plots/bar/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BarOptions } from './types';
 import { adaptor } from './adaptor';
@@ -18,7 +18,7 @@ export class Bar extends Plot<BarOptions> {
    */
   protected getDefaultOptions(options: BarOptions) {
     const { isRange, label, xField, yField, isGroup, isStack } = options;
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       barWidthRatio: 0.6,
       marginRatio: 1 / 32,
       label:

--- a/src/plots/bar/index.ts
+++ b/src/plots/bar/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BarOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/bidirectional-bar/adaptor.ts
+++ b/src/plots/bidirectional-bar/adaptor.ts
@@ -3,7 +3,7 @@ import { groupBy } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
-import { flow, findViewById, findGeometry, transformLabel, deepMix } from '../../utils';
+import { flow, findViewById, findGeometry, transformLabel, deepAssign } from '../../utils';
 import { BidirectionalBarOptions } from './types';
 import { FIRST_AXES_VIEW, SECOND_AXES_VIEW } from './constant';
 import { transformData } from './utils';
@@ -80,7 +80,7 @@ function geometry(params: Params<BidirectionalBarOptions>): Params<Bidirectional
   }
 
   firstView.data(groupData[0]);
-  const left = deepMix({}, params, {
+  const left = deepAssign({}, params, {
     chart: firstView,
     options: {
       widthRatio,
@@ -96,7 +96,7 @@ function geometry(params: Params<BidirectionalBarOptions>): Params<Bidirectional
   interval(left);
 
   secondView.data(groupData[1]);
-  const right = deepMix({}, params, {
+  const right = deepAssign({}, params, {
     chart: secondView,
     options: {
       xField,
@@ -127,12 +127,12 @@ function meta(params: Params<BidirectionalBarOptions>): Params<BidirectionalBarO
   scale({
     [xField]: xAxis,
     [yField[0]]: yAxis[yField[0]],
-  })(deepMix({}, params, { chart: firstView }));
+  })(deepAssign({}, params, { chart: firstView }));
 
   scale({
     [xField]: xAxis,
     [yField[1]]: yAxis[yField[1]],
-  })(deepMix({}, params, { chart: secondView }));
+  })(deepAssign({}, params, { chart: secondView }));
 
   return params;
 }

--- a/src/plots/bidirectional-bar/adaptor.ts
+++ b/src/plots/bidirectional-bar/adaptor.ts
@@ -1,9 +1,9 @@
 import { View } from '@antv/g2';
-import { deepMix, groupBy } from '@antv/util';
+import { groupBy } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
-import { flow, findViewById, findGeometry, transformLabel } from '../../utils';
+import { flow, findViewById, findGeometry, transformLabel, deepMix } from '../../utils';
 import { BidirectionalBarOptions } from './types';
 import { FIRST_AXES_VIEW, SECOND_AXES_VIEW } from './constant';
 import { transformData } from './utils';

--- a/src/plots/bidirectional-bar/index.ts
+++ b/src/plots/bidirectional-bar/index.ts
@@ -1,6 +1,6 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { BidirectionalBarOptions } from './types';
 import { adaptor } from './adaptor';
 
@@ -19,7 +19,7 @@ export class BidirectionalBar extends Plot<BidirectionalBarOptions> {
 
   protected getDefaultOptions(options: BidirectionalBarOptions) {
     const { layout = 'horizontal' } = options;
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       xAxis: {
         // 不同布局 firstView 的坐标轴显示位置
         position: layout === 'vertical' ? 'bottom' : 'top',

--- a/src/plots/bidirectional-bar/index.ts
+++ b/src/plots/bidirectional-bar/index.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { BidirectionalBarOptions } from './types';
 import { adaptor } from './adaptor';
 

--- a/src/plots/box/adaptor.ts
+++ b/src/plots/box/adaptor.ts
@@ -2,7 +2,7 @@ import { isFunction, map, isObject } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, animation, theme } from '../../adaptor/common';
 import { findGeometry } from '../../utils';
-import { flow, pick, deepMix } from '../../utils';
+import { flow, pick, deepAssign } from '../../utils';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 import { BoxOptions } from './types';
 import { BOX_RANGE, BOX_SYNC_NAME } from './constant';
@@ -89,7 +89,7 @@ function meta(params: Params<BoxOptions>): Params<BoxOptions> {
     };
   }
 
-  const scales = deepMix(baseMeta, meta, {
+  const scales = deepAssign(baseMeta, meta, {
     [xField]: pick(xAxis, AXIS_META_CONFIG_KEYS),
     [yFieldName]: pick(yAxis, AXIS_META_CONFIG_KEYS),
   });

--- a/src/plots/box/adaptor.ts
+++ b/src/plots/box/adaptor.ts
@@ -1,8 +1,8 @@
-import { deepMix, isFunction, map, isObject } from '@antv/util';
+import { isFunction, map, isObject } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, animation, theme } from '../../adaptor/common';
 import { findGeometry } from '../../utils';
-import { flow, pick } from '../../utils';
+import { flow, pick, deepMix } from '../../utils';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 import { BoxOptions } from './types';
 import { BOX_RANGE, BOX_SYNC_NAME } from './constant';

--- a/src/plots/box/index.ts
+++ b/src/plots/box/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BoxOptions } from './types';
 import { adaptor } from './adaptor';
@@ -14,7 +14,7 @@ export class Box extends Plot<BoxOptions> {
    * 获取 箱型图 默认配置项
    */
   protected getDefaultOptions(): Partial<BoxOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       meta: {
         [BOX_RANGE]: { min: 0, alias: BOX_RANGE_ALIAS },
       },

--- a/src/plots/bullet/adaptor.ts
+++ b/src/plots/bullet/adaptor.ts
@@ -1,7 +1,7 @@
-import { deepMix, isNumber } from '@antv/util';
+import { isNumber } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, animation, theme, tooltip } from '../../adaptor/common';
-import { flow, pick, transformLabel } from '../../utils';
+import { flow, pick, transformLabel, deepMix } from '../../utils';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 import { interval, point } from '../../adaptor/geometries';
 import { BulletOptions } from './types';

--- a/src/plots/bullet/adaptor.ts
+++ b/src/plots/bullet/adaptor.ts
@@ -1,7 +1,7 @@
 import { isNumber } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, animation, theme, tooltip } from '../../adaptor/common';
-import { flow, pick, transformLabel, deepMix } from '../../utils';
+import { flow, pick, transformLabel, deepAssign } from '../../utils';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 import { interval, point } from '../../adaptor/geometries';
 import { BulletOptions } from './types';
@@ -35,7 +35,7 @@ function geometry(params: Params<BulletOptions>): Params<BulletOptions> {
   chart.axis(`${targetField}`, false);
 
   // rangeGeometry
-  const r = deepMix({}, params, {
+  const r = deepAssign({}, params, {
     options: {
       xField: xField,
       yField: rangeField,
@@ -53,7 +53,7 @@ function geometry(params: Params<BulletOptions>): Params<BulletOptions> {
   chart.geometries[0].tooltip(false);
 
   // measureGeometry
-  const m = deepMix({}, params, {
+  const m = deepAssign({}, params, {
     options: {
       xField: xField,
       yField: measureField,
@@ -69,7 +69,7 @@ function geometry(params: Params<BulletOptions>): Params<BulletOptions> {
   interval(m);
 
   // targetGeometry
-  const t = deepMix({}, params, {
+  const t = deepAssign({}, params, {
     options: {
       xField: xField,
       yField: targetField,
@@ -101,7 +101,7 @@ function meta(params: Params<BulletOptions>): Params<BulletOptions> {
   const { xAxis, yAxis, meta, targetField, rangeField, measureField, xField } = options;
 
   if (meta) {
-    const scales = deepMix({}, meta, {
+    const scales = deepAssign({}, meta, {
       [xField]: pick(xAxis, AXIS_META_CONFIG_KEYS),
       [measureField]: pick(yAxis, AXIS_META_CONFIG_KEYS),
       [targetField]: {

--- a/src/plots/bullet/index.ts
+++ b/src/plots/bullet/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BulletOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/bullet/index.ts
+++ b/src/plots/bullet/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BulletOptions } from './types';
 import { adaptor } from './adaptor';
@@ -18,7 +18,7 @@ export class Bullet extends Plot<BulletOptions> {
   }
 
   protected getDefaultOptions() {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       layout: 'horizontal',
       size: {
         range: 30,

--- a/src/plots/column/adaptor.ts
+++ b/src/plots/column/adaptor.ts
@@ -3,7 +3,7 @@ import { findGeometry } from '../../utils';
 import { tooltip, slider, interaction, animation, theme, scale, annotation, scrollbar } from '../../adaptor/common';
 import { conversionTag } from '../../adaptor/conversion-tag';
 import { interval } from '../../adaptor/geometries';
-import { flow, transformLabel, deepMix } from '../../utils';
+import { flow, transformLabel, deepAssign } from '../../utils';
 import { percent } from '../../utils/transform/percent';
 import { Datum } from '../../types';
 import { ColumnOptions } from './types';
@@ -30,7 +30,7 @@ function geometry(params: Params<ColumnOptions>): Params<ColumnOptions> {
       }
     : tooltip;
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       widthRatio: columnWidthRatio,
       tooltip: tooltipOptions,

--- a/src/plots/column/adaptor.ts
+++ b/src/plots/column/adaptor.ts
@@ -1,10 +1,9 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { findGeometry } from '../../utils';
 import { tooltip, slider, interaction, animation, theme, scale, annotation, scrollbar } from '../../adaptor/common';
 import { conversionTag } from '../../adaptor/conversion-tag';
 import { interval } from '../../adaptor/geometries';
-import { flow, transformLabel } from '../../utils';
+import { flow, transformLabel, deepMix } from '../../utils';
 import { percent } from '../../utils/transform/percent';
 import { Datum } from '../../types';
 import { ColumnOptions } from './types';

--- a/src/plots/column/index.ts
+++ b/src/plots/column/index.ts
@@ -1,6 +1,6 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { ColumnOptions } from './types';
 import { adaptor } from './adaptor';
 
@@ -18,7 +18,7 @@ export class Column extends Plot<ColumnOptions> {
    */
   protected getDefaultOptions(options: ColumnOptions) {
     const { isRange, label, yField, xField, isGroup, isStack } = options;
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       columnWidthRatio: 0.6,
       marginRatio: 1 / 32,
       label:

--- a/src/plots/column/index.ts
+++ b/src/plots/column/index.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { ColumnOptions } from './types';
 import { adaptor } from './adaptor';
 

--- a/src/plots/dual-axes/adaptor.ts
+++ b/src/plots/dual-axes/adaptor.ts
@@ -8,7 +8,7 @@ import {
 } from '../../adaptor/common';
 import { percent } from '../../utils/transform/percent';
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { findViewById } from '../../utils/view';
 import { Datum } from '../../types';
 import { getOption, isColumn } from './util/option';
@@ -20,12 +20,12 @@ import { LEFT_AXES_VIEW, RIGHT_AXES_VIEW } from './constant';
 /**
  * 获取默认参数设置
  * 双轴图无法使用公共的 getDefaultOption, 因为双轴图存在[lineConfig, lineConfig] 这样的数据，需要根据传入的 option，生成不同的 defaultOption,
- * 并且 deepmix 无法 mix 数组类型数据，因此需要做一次参数的后转换
+ * 并且 deepAssign 无法 mix 数组类型数据，因此需要做一次参数的后转换
  * 这个函数针对 yAxis 和 geometryOptions
  * @param params
  */
 export function transformOptions(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
-  return deepMix({}, params, {
+  return deepAssign({}, params, {
     options: getOption(params.options),
   });
 }
@@ -56,7 +56,7 @@ function geometry(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
       const formatData = isPercent ? percent(data, yField, xField, yField) : data;
       const view = chart.createView({ id }).data(formatData);
 
-      const tooltipOptions = deepMix(
+      const tooltipOptions = deepAssign(
         {},
         {
           formatter: isPercent
@@ -94,12 +94,12 @@ export function meta(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
   scale({
     [xField]: xAxis,
     [yField[0]]: yAxis[0],
-  })(deepMix({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
+  })(deepAssign({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
 
   scale({
     [xField]: xAxis,
     [yField[1]]: yAxis[1],
-  })(deepMix({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
+  })(deepAssign({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
 
   return params;
 }
@@ -116,16 +116,16 @@ export function axis(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
 
   // 固定位置
   if (xAxis) {
-    deepMix(xAxis, { position: 'bottom' }); // 直接修改到 xAxis 中
+    deepAssign(xAxis, { position: 'bottom' }); // 直接修改到 xAxis 中
   }
 
   if (yAxis[0]) {
-    yAxis[0] = deepMix({}, yAxis[0], { position: 'left' });
+    yAxis[0] = deepAssign({}, yAxis[0], { position: 'left' });
   }
 
   // 隐藏右轴 grid，留到 g2 解决
   if (yAxis[1]) {
-    yAxis[1] = deepMix({}, yAxis[1], { position: 'right', grid: null });
+    yAxis[1] = deepAssign({}, yAxis[1], { position: 'right', grid: null });
   }
 
   chart.axis(xField, false);
@@ -173,8 +173,8 @@ export function tooltip(params: Params<DualAxesOptions>): Params<DualAxesOptions
 export function interaction(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
   const { chart } = params;
 
-  commonInteraction(deepMix({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
-  commonInteraction(deepMix({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
+  commonInteraction(deepAssign({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
+  commonInteraction(deepAssign({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
 
   return params;
 }
@@ -186,8 +186,8 @@ export function interaction(params: Params<DualAxesOptions>): Params<DualAxesOpt
 export function theme(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
   const { chart } = params;
 
-  commonTheme(deepMix({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
-  commonTheme(deepMix({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
+  commonTheme(deepAssign({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
+  commonTheme(deepAssign({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
 
   return params;
 }
@@ -195,8 +195,8 @@ export function theme(params: Params<DualAxesOptions>): Params<DualAxesOptions> 
 export function animation(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
   const { chart } = params;
 
-  commonAnimation(deepMix({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
-  commonAnimation(deepMix({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
+  commonAnimation(deepAssign({}, params, { chart: findViewById(chart, LEFT_AXES_VIEW) }));
+  commonAnimation(deepAssign({}, params, { chart: findViewById(chart, RIGHT_AXES_VIEW) }));
 
   return params;
 }
@@ -234,7 +234,7 @@ export function legend(params: Params<DualAxesOptions>): Params<DualAxesOptions>
       });
 
       chart.legend(
-        deepMix({}, legend, {
+        deepAssign({}, legend, {
           custom: true,
           // todo 修改类型定义
           // @ts-ignore

--- a/src/plots/dual-axes/adaptor.ts
+++ b/src/plots/dual-axes/adaptor.ts
@@ -1,4 +1,4 @@
-import { deepMix, each, findIndex, get, isObject } from '@antv/util';
+import { each, findIndex, get, isObject } from '@antv/util';
 import { Scale } from '@antv/g2/lib/dependents';
 import {
   theme as commonTheme,
@@ -8,7 +8,7 @@ import {
 } from '../../adaptor/common';
 import { percent } from '../../utils/transform/percent';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { findViewById } from '../../utils/view';
 import { Datum } from '../../types';
 import { getOption, isColumn } from './util/option';

--- a/src/plots/dual-axes/index.ts
+++ b/src/plots/dual-axes/index.ts
@@ -1,7 +1,7 @@
-import { every, some } from '@antv/util';
+import { every } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { DualAxesOptions, DualAxesGeometry } from './types';
 import { adaptor } from './adaptor';
 
@@ -21,7 +21,7 @@ export class DualAxes extends Plot<DualAxesOptions> {
       ({ geometry }) => geometry === DualAxesGeometry.Line || geometry === undefined
     );
 
-    return deepMix({}, super.getDefaultOptions(options), {
+    return deepAssign({}, super.getDefaultOptions(options), {
       yAxis: [],
       geometryOptions: [],
       meta: {

--- a/src/plots/dual-axes/index.ts
+++ b/src/plots/dual-axes/index.ts
@@ -1,6 +1,7 @@
-import { deepMix, every, some } from '@antv/util';
+import { every, some } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { DualAxesOptions, DualAxesGeometry } from './types';
 import { adaptor } from './adaptor';
 

--- a/src/plots/dual-axes/util/geometry.ts
+++ b/src/plots/dual-axes/util/geometry.ts
@@ -1,8 +1,8 @@
-import { deepMix, each } from '@antv/util';
+import { each } from '@antv/util';
 import { Geometry } from '@antv/g2';
 import { Params } from '../../../core/adaptor';
 import { point, line, interval } from '../../../adaptor/geometries';
-import { pick, findGeometry } from '../../../utils';
+import { pick, findGeometry, deepMix } from '../../../utils';
 import { GeometryOption } from '../types';
 import { isLine, isColumn } from './option';
 

--- a/src/plots/dual-axes/util/geometry.ts
+++ b/src/plots/dual-axes/util/geometry.ts
@@ -2,7 +2,7 @@ import { each } from '@antv/util';
 import { Geometry } from '@antv/g2';
 import { Params } from '../../../core/adaptor';
 import { point, line, interval } from '../../../adaptor/geometries';
-import { pick, findGeometry, deepMix } from '../../../utils';
+import { pick, findGeometry, deepAssign } from '../../../utils';
 import { GeometryOption } from '../types';
 import { isLine, isColumn } from './option';
 
@@ -21,7 +21,7 @@ export function drawSingleGeometry<O extends { xField: string; yField: string; g
   if (isLine(geometryOption)) {
     // 绘制线
     line(
-      deepMix({}, params, {
+      deepAssign({}, params, {
         options: {
           ...pick(options, FIELD_KEY),
           ...geometryOption,
@@ -34,7 +34,7 @@ export function drawSingleGeometry<O extends { xField: string; yField: string; g
     );
     // 绘制点
     point(
-      deepMix({}, params, {
+      deepAssign({}, params, {
         options: {
           ...pick(options, FIELD_KEY),
           ...geometryOption,
@@ -57,7 +57,7 @@ export function drawSingleGeometry<O extends { xField: string; yField: string; g
 
   if (isColumn(geometryOption)) {
     interval(
-      deepMix({}, params, {
+      deepAssign({}, params, {
         options: {
           ...pick(options, FIELD_KEY),
           ...geometryOption,

--- a/src/plots/dual-axes/util/option.ts
+++ b/src/plots/dual-axes/util/option.ts
@@ -1,4 +1,5 @@
-import { deepMix, get } from '@antv/util';
+import { get } from '@antv/util';
+import { deepMix } from '../../../utils';
 import {
   DualAxesOptions,
   GeometryOption,

--- a/src/plots/dual-axes/util/option.ts
+++ b/src/plots/dual-axes/util/option.ts
@@ -1,5 +1,5 @@
 import { get } from '@antv/util';
-import { deepMix } from '../../../utils';
+import { deepAssign } from '../../../utils';
 import {
   DualAxesOptions,
   GeometryOption,
@@ -36,7 +36,7 @@ export function getGeometryOption(
 ): GeometryOption {
   // 空默认为线
   return isColumn(geometryOption)
-    ? deepMix(
+    ? deepAssign(
         {},
         {
           geometry: DualAxesGeometry.Column,
@@ -76,11 +76,11 @@ export function getOption(options: DualAxesOptions): DualAxesOptions {
     },
   };
 
-  const formatOptions = deepMix({}, options, {
+  const formatOptions = deepAssign({}, options, {
     // yAxis
     yAxis: [
-      yAxis[0] !== false ? deepMix({}, DEFAULT_YAXIS_CONFIG, yAxis[0]) : false,
-      yAxis[1] !== false ? deepMix({}, DEFAULT_YAXIS_CONFIG, yAxis[1]) : false,
+      yAxis[0] !== false ? deepAssign({}, DEFAULT_YAXIS_CONFIG, yAxis[0]) : false,
+      yAxis[1] !== false ? deepAssign({}, DEFAULT_YAXIS_CONFIG, yAxis[1]) : false,
     ],
     // geometryOptions
     geometryOptions: [

--- a/src/plots/funnel/geometries/common.ts
+++ b/src/plots/funnel/geometries/common.ts
@@ -1,7 +1,8 @@
 import { Geometry } from '@antv/g2';
 import { LineOption } from '@antv/g2/lib/interface';
-import { isFunction, deepMix } from '@antv/util';
+import { isFunction } from '@antv/util';
 import { Datum, Data } from '../../../types/common';
+import { deepMix } from '../../../utils';
 import { FUNNEL_PERCENT } from '../constant';
 import { Params } from '../../../core/adaptor';
 import { FunnelOptions } from '../types';
@@ -46,25 +47,22 @@ export function conversionTagComponent(
       data.forEach((obj, index) => {
         if (index <= 0) return;
         const lineCoordinateOption = getLineCoordinate(obj, index, data);
-        const lineOption = deepMix(
-          {},
-          {
-            top: true,
-            text: {
-              content: isFunction(formatter) ? formatter(obj, data) : formatter,
-              offsetX: conversionTag.offsetX,
-              offsetY: conversionTag.offsetY,
-              position: 'end',
-              autoRotate: false,
-              style: {
-                ...conversionTag.style,
-                textAlign: 'start',
-                textBaseline: 'middle',
-              },
+
+        const lineOption = deepMix({}, lineCoordinateOption, {
+          top: true,
+          text: {
+            content: isFunction(formatter) ? formatter(obj, data) : formatter,
+            offsetX: conversionTag.offsetX,
+            offsetY: conversionTag.offsetY,
+            position: 'end',
+            autoRotate: false,
+            style: {
+              ...conversionTag.style,
+              textAlign: 'start',
+              textBaseline: 'middle',
             },
           },
-          lineCoordinateOption
-        );
+        });
         chart.annotation().line(lineOption);
       });
     }

--- a/src/plots/funnel/geometries/common.ts
+++ b/src/plots/funnel/geometries/common.ts
@@ -2,7 +2,7 @@ import { Geometry } from '@antv/g2';
 import { LineOption } from '@antv/g2/lib/interface';
 import { isFunction } from '@antv/util';
 import { Datum, Data } from '../../../types/common';
-import { deepMix } from '../../../utils';
+import { deepAssign } from '../../../utils';
 import { FUNNEL_PERCENT } from '../constant';
 import { Params } from '../../../core/adaptor';
 import { FunnelOptions } from '../types';
@@ -48,7 +48,7 @@ export function conversionTagComponent(
         if (index <= 0) return;
         const lineCoordinateOption = getLineCoordinate(obj, index, data);
 
-        const lineOption = deepMix({}, lineCoordinateOption, {
+        const lineOption = deepAssign({}, lineCoordinateOption, {
           top: true,
           text: {
             content: isFunction(formatter) ? formatter(obj, data) : formatter,

--- a/src/plots/funnel/geometries/compare.ts
+++ b/src/plots/funnel/geometries/compare.ts
@@ -1,6 +1,6 @@
-import { deepMix, map } from '@antv/util';
+import { map } from '@antv/util';
 import { LineOption } from '@antv/g2/lib/interface';
-import { flow, findGeometry } from '../../../utils';
+import { flow, findGeometry, deepMix } from '../../../utils';
 import { Params } from '../../../core/adaptor';
 import { Datum, Data } from '../../../types/common';
 import { FunnelOptions } from '../types';

--- a/src/plots/funnel/geometries/compare.ts
+++ b/src/plots/funnel/geometries/compare.ts
@@ -1,6 +1,6 @@
 import { map } from '@antv/util';
 import { LineOption } from '@antv/g2/lib/interface';
-import { flow, findGeometry, deepMix } from '../../../utils';
+import { flow, findGeometry, deepAssign } from '../../../utils';
 import { Params } from '../../../core/adaptor';
 import { Datum, Data } from '../../../types/common';
 import { FunnelOptions } from '../types';
@@ -84,7 +84,7 @@ function label(params: Params<FunnelOptions>): Params<FunnelOptions> {
       const geometry = findGeometry(view, 'interval');
       geometryLabel(geometry)(
         label
-          ? deepMix({}, params, {
+          ? deepAssign({}, params, {
               options: {
                 label: {
                   offset: 10,
@@ -128,7 +128,7 @@ function conversionTag(params: Params<FunnelOptions>): Params<FunnelOptions> {
       };
 
       conversionTagComponent(getLineCoordinate)(
-        deepMix(
+        deepAssign(
           {},
           {
             chart: view,

--- a/src/plots/funnel/index.ts
+++ b/src/plots/funnel/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { FunnelOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/funnel/index.ts
+++ b/src/plots/funnel/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { FunnelOptions } from './types';
 import { adaptor } from './adaptor';
@@ -39,7 +39,7 @@ export class Funnel extends Plot<FunnelOptions> {
       };
     }
 
-    return deepMix(
+    return deepAssign(
       {},
       super.getDefaultOptions(),
       {

--- a/src/plots/gauge/index.ts
+++ b/src/plots/gauge/index.ts
@@ -88,6 +88,16 @@ export class Gauge extends Plot<GaugeOptions> {
   }
 
   /**
+   * 更新数据
+   * @param percent
+   */
+  public changeData(percent: number) {
+    this.update({
+      percent,
+    });
+  }
+
+  /**
    * 获取适配器
    */
   protected getSchemaAdaptor(): Adaptor<GaugeOptions> {

--- a/src/plots/heatmap/index.ts
+++ b/src/plots/heatmap/index.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { HeatmapOptions } from './types';
 import { adaptor } from './adaptor';
 // registered shapes

--- a/src/plots/heatmap/index.ts
+++ b/src/plots/heatmap/index.ts
@@ -1,6 +1,6 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { HeatmapOptions } from './types';
 import { adaptor } from './adaptor';
 // registered shapes
@@ -21,7 +21,7 @@ export class Heatmap extends Plot<HeatmapOptions> {
   }
 
   protected getDefaultOptions() {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       type: 'polygon',
       legend: false,
       xAxis: {

--- a/src/plots/histogram/adaptor.ts
+++ b/src/plots/histogram/adaptor.ts
@@ -1,7 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale } from '../../adaptor/common';
-import { findGeometry } from '../../utils';
+import { findGeometry, deepMix } from '../../utils';
 import { flow, transformLabel } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { binHistogram } from '../../utils/transform/histogram';

--- a/src/plots/histogram/adaptor.ts
+++ b/src/plots/histogram/adaptor.ts
@@ -1,6 +1,6 @@
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale } from '../../adaptor/common';
-import { findGeometry, deepMix } from '../../utils';
+import { findGeometry, deepAssign } from '../../utils';
 import { flow, transformLabel } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { binHistogram } from '../../utils/transform/histogram';
@@ -19,7 +19,7 @@ function geometry(params: Params<HistogramOptions>): Params<HistogramOptions> {
 
   chart.data(plotData);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: 'range',
       yField: 'count',

--- a/src/plots/histogram/index.ts
+++ b/src/plots/histogram/index.ts
@@ -1,5 +1,6 @@
-import { deepMix, isNil } from '@antv/util';
+import { isNil } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { HistogramOptions } from './types';
 import { adaptor } from './adaptor';
@@ -15,7 +16,7 @@ export class Histogram extends Plot<HistogramOptions> {
    * @param options
    */
   protected getDefaultOptions(options: HistogramOptions) {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       // @ts-ignore
       columnStyle: isNil(options.columnStyle?.stroke)
         ? {

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -1,8 +1,8 @@
 import { Geometry } from '@antv/g2';
-import { deepMix, each } from '@antv/util';
+import { each } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, slider, interaction, animation, theme, scale, annotation } from '../../adaptor/common';
-import { findGeometry, transformLabel } from '../../utils';
+import { findGeometry, transformLabel, deepMix } from '../../utils';
 import { point, line } from '../../adaptor/geometries';
 import { flow } from '../../utils';
 import { LineOptions } from './types';

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -2,7 +2,7 @@ import { Geometry } from '@antv/g2';
 import { each } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, slider, interaction, animation, theme, scale, annotation } from '../../adaptor/common';
-import { findGeometry, transformLabel, deepMix } from '../../utils';
+import { findGeometry, transformLabel, deepAssign } from '../../utils';
 import { point, line } from '../../adaptor/geometries';
 import { flow } from '../../utils';
 import { LineOptions } from './types';
@@ -18,7 +18,7 @@ function geometry(params: Params<LineOptions>): Params<LineOptions> {
   chart.data(data);
 
   // line geometry 处理
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       shapeField: seriesField,
       line: {

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -1,6 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { adjustYMetaByZero } from '../../utils/data';
 import { LineOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -1,6 +1,6 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { adjustYMetaByZero } from '../../utils/data';
 import { LineOptions } from './types';
 import { adaptor } from './adaptor';
@@ -19,7 +19,7 @@ export class Line extends Plot<LineOptions> {
   protected getDefaultOptions(options: LineOptions) {
     const { xField, yField, data } = options;
 
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       tooltip: {
         showMarkers: true,
         showCrosshairs: true,

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -1,8 +1,8 @@
 import { Geometry } from '@antv/g2';
-import { deepMix, isFunction } from '@antv/util';
+import { isFunction } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { LiquidOptions } from './types';
 

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -2,7 +2,7 @@ import { Geometry } from '@antv/g2';
 import { isFunction } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { LiquidOptions } from './types';
 
@@ -27,7 +27,7 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
 
   chart.data(data);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: 'type',
       yField: 'percent',

--- a/src/plots/liquid/index.ts
+++ b/src/plots/liquid/index.ts
@@ -33,6 +33,16 @@ export class Liquid extends Plot<LiquidOptions> {
   }
 
   /**
+   * 更新数据
+   * @param percent
+   */
+  public changeData(percent: number) {
+    this.update({
+      percent,
+    });
+  }
+
+  /**
    * 获取适配器
    */
   protected getSchemaAdaptor(): Adaptor<LiquidOptions> {

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -1,9 +1,9 @@
 import { Datum } from '@antv/g2/lib/interface';
-import { deepMix, every, filter, get, isFunction, isString, isNil } from '@antv/util';
+import { every, filter, get, isFunction, isString, isNil } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { Data } from '../../types';
-import { flow, LEVEL, log, template, transformLabel } from '../../utils';
+import { flow, LEVEL, log, template, transformLabel, deepAssign } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { PieOptions } from './types';
 import { getTotalValue } from './utils';
@@ -29,7 +29,7 @@ function geometry(params: Params<PieOptions>): Params<PieOptions> {
     processData = processData.map((d) => ({ ...d, [percentageField]: 1 / processData.length }));
     chart.data(processData);
 
-    const p = deepMix({}, params, {
+    const p = deepAssign({}, params, {
       options: {
         xField: '1',
         yField: percentageField,
@@ -49,7 +49,7 @@ function geometry(params: Params<PieOptions>): Params<PieOptions> {
   } else {
     chart.data(processData);
 
-    const p = deepMix({}, params, {
+    const p = deepAssign({}, params, {
       options: {
         xField: '1',
         yField: angleField,
@@ -77,7 +77,7 @@ function meta(params: Params<PieOptions>): Params<PieOptions> {
   const { meta, colorField } = options;
 
   // meta 直接是 scale 的信息
-  const scales = deepMix({}, meta);
+  const scales = deepAssign({}, meta);
   chart.scale(scales, {
     [colorField]: { type: 'cat' },
   });
@@ -157,7 +157,7 @@ function label(params: Params<PieOptions>): Params<PieOptions> {
     const labelType = LABEL_TYPE_MAP[labelCfg.type] || 'pie';
     const labelLayoutType = LABEL_LAYOUT_TYPE_MAP[labelCfg.type] || 'pie-outer';
     labelCfg.type = labelType;
-    labelCfg.layout = deepMix({}, labelCfg.layout, { type: labelLayoutType });
+    labelCfg.layout = deepAssign({}, labelCfg.layout, { type: labelLayoutType });
 
     geometry.label({
       // fix: could not create scale, when field is undefined（attributes 中的 fields 定义都会被用来创建 scale）
@@ -197,7 +197,7 @@ function statistic(params: Params<PieOptions>): Params<PieOptions> {
         return datum ? datum[angleField] : getTotalValue(data, angleField);
       };
       chart.annotation().text(
-        deepMix(
+        deepAssign(
           {},
           {
             style: {

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { PieOptions } from './types';
 import { adaptor } from './adaptor';
@@ -16,7 +16,7 @@ export class Pie extends Plot<PieOptions> {
    * 获取 饼图 默认配置项
    */
   protected getDefaultOptions(): Partial<PieOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       legend: {
         position: 'right',
       },

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { PieOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/pie/label/inner-label.ts
+++ b/src/plots/pie/label/inner-label.ts
@@ -1,5 +1,6 @@
 import { getGeometryLabel } from '@antv/g2';
-import { deepMix, isNil, isString } from '@antv/util';
+import { isNil, isString } from '@antv/util';
+import { deepMix } from '../../../utils';
 import { parsePercentageToNumber } from '../utils';
 
 const PieLabel = getGeometryLabel('pie');

--- a/src/plots/pie/label/inner-label.ts
+++ b/src/plots/pie/label/inner-label.ts
@@ -1,6 +1,6 @@
 import { getGeometryLabel } from '@antv/g2';
 import { isNil, isString } from '@antv/util';
-import { deepMix } from '../../../utils';
+import { deepAssign } from '../../../utils';
 import { parsePercentageToNumber } from '../utils';
 
 const PieLabel = getGeometryLabel('pie');
@@ -14,7 +14,7 @@ export class PieInnerLabel extends PieLabel {
    */
   protected getDefaultLabelCfg() {
     const cfg = super.getDefaultLabelCfg();
-    return deepMix({}, cfg, { labelLine: false });
+    return deepAssign({}, cfg, { labelLine: false });
   }
 
   /**

--- a/src/plots/progress/adaptor.ts
+++ b/src/plots/progress/adaptor.ts
@@ -1,6 +1,6 @@
 import { isString, clamp } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { scale, animation, theme, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { ProgressOptions } from './types';
@@ -28,7 +28,7 @@ export function geometry(params: Params<ProgressOptions>): Params<ProgressOption
 
   chart.data(data);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: '1',
       yField: 'percent',

--- a/src/plots/progress/adaptor.ts
+++ b/src/plots/progress/adaptor.ts
@@ -1,6 +1,6 @@
-import { deepMix, isString, clamp } from '@antv/util';
+import { isString, clamp } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { scale, animation, theme, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { ProgressOptions } from './types';

--- a/src/plots/progress/index.ts
+++ b/src/plots/progress/index.ts
@@ -18,6 +18,16 @@ export class Progress extends Plot<ProgressOptions> {
   }
 
   /**
+   * 更新数据
+   * @param percent
+   */
+  public changeData(percent: number) {
+    this.update({
+      percent,
+    });
+  }
+
+  /**
    * 获取 进度图 的适配器
    */
   protected getSchemaAdaptor(): Adaptor<ProgressOptions> {

--- a/src/plots/radar/adaptor.ts
+++ b/src/plots/radar/adaptor.ts
@@ -1,8 +1,7 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale, annotation, legend } from '../../adaptor/common';
 import { area, point, line } from '../../adaptor/geometries';
-import { findGeometry, flow, transformLabel } from '../../utils';
+import { findGeometry, flow, transformLabel, deepMix } from '../../utils';
 import { RadarOptions } from './types';
 
 /**

--- a/src/plots/radar/adaptor.ts
+++ b/src/plots/radar/adaptor.ts
@@ -1,7 +1,7 @@
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale, annotation, legend } from '../../adaptor/common';
 import { area, point, line } from '../../adaptor/geometries';
-import { findGeometry, flow, transformLabel, deepMix } from '../../utils';
+import { findGeometry, flow, transformLabel, deepAssign } from '../../utils';
 import { RadarOptions } from './types';
 
 /**
@@ -15,7 +15,7 @@ function geometry(params: Params<RadarOptions>): Params<RadarOptions> {
   chart.data(data);
 
   // 雷达图 geometry
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       line: {
         style: lineStyle,

--- a/src/plots/radar/index.ts
+++ b/src/plots/radar/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RadarOptions } from './types';
 import { adaptor } from './adaptor';
@@ -15,7 +15,7 @@ export class Radar extends Plot<RadarOptions> {
    * 获取 雷达图 默认配置
    */
   protected getDefaultOptions(): Partial<RadarOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       xAxis: {
         label: {
           offset: 15,

--- a/src/plots/radar/index.ts
+++ b/src/plots/radar/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RadarOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/radial-bar/adaptor.ts
+++ b/src/plots/radial-bar/adaptor.ts
@@ -1,7 +1,6 @@
-import { deepMix } from '@antv/util';
 import { interaction, animation, theme, scale, tooltip, legend } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { RadialBarOptions } from './types';
 import { getScaleMax } from './utils';
@@ -14,7 +13,7 @@ function geometry(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
   const { chart, options } = params;
   const { data, barStyle: style, color, tooltip } = options;
   chart.data(data);
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       tooltip,
       interval: {

--- a/src/plots/radial-bar/index.ts
+++ b/src/plots/radial-bar/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RadialBarOptions } from './types';
 import { adaptor } from './adaptor';
@@ -17,7 +17,7 @@ export class RadialBar extends Plot<RadialBarOptions> {
    * 获取默认配置
    */
   protected getDefaultOptions(): Partial<RadialBarOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       interactions: [{ type: 'element-active' }],
       legend: false,
       tooltip: {

--- a/src/plots/ring-progress/index.ts
+++ b/src/plots/ring-progress/index.ts
@@ -31,6 +31,16 @@ export class RingProgress extends Plot<RingProgressOptions> {
   }
 
   /**
+   * 更新数据
+   * @param percent
+   */
+  public changeData(percent: number) {
+    this.update({
+      percent,
+    });
+  }
+
+  /**
    * 获取 环形进度图 的适配器
    */
   protected getSchemaAdaptor(): Adaptor<RingProgressOptions> {

--- a/src/plots/rose/adaptor.ts
+++ b/src/plots/rose/adaptor.ts
@@ -1,6 +1,6 @@
 import { filter, isObject, isArray } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow, findGeometry, log, LEVEL, transformLabel, deepMix } from '../../utils';
+import { flow, findGeometry, log, LEVEL, transformLabel, deepAssign } from '../../utils';
 import { tooltip, interaction, animation, theme, scale, annotation, state } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { RoseOptions } from './types';
@@ -17,7 +17,7 @@ function geometry(params: Params<RoseOptions>): Params<RoseOptions> {
   chart.data(data);
 
   flow(interval)(
-    deepMix({}, params, {
+    deepAssign({}, params, {
       options: {
         marginRatio: 1,
         interval: {

--- a/src/plots/rose/adaptor.ts
+++ b/src/plots/rose/adaptor.ts
@@ -1,6 +1,6 @@
-import { deepMix, filter, isObject, isArray } from '@antv/util';
+import { filter, isObject, isArray } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow, findGeometry, log, LEVEL, transformLabel } from '../../utils';
+import { flow, findGeometry, log, LEVEL, transformLabel, deepMix } from '../../utils';
 import { tooltip, interaction, animation, theme, scale, annotation, state } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { RoseOptions } from './types';

--- a/src/plots/rose/index.ts
+++ b/src/plots/rose/index.ts
@@ -1,5 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
+import { deepMix } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RoseOptions } from './types';
 import { adaptor } from './adaptor';

--- a/src/plots/rose/index.ts
+++ b/src/plots/rose/index.ts
@@ -1,5 +1,5 @@
 import { Plot } from '../../core/plot';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RoseOptions } from './types';
 import { adaptor } from './adaptor';
@@ -14,7 +14,7 @@ export class Rose extends Plot<RoseOptions> {
    * 获取默认的 options 配置项
    */
   protected getDefaultOptions(): Partial<RoseOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       xAxis: false,
       yAxis: false,
       legend: {

--- a/src/plots/scatter/adaptor.ts
+++ b/src/plots/scatter/adaptor.ts
@@ -1,6 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { point } from '../../adaptor/geometries';
 import { tooltip, interaction, animation, theme, scale, annotation } from '../../adaptor/common';
 import { findGeometry, transformLabel } from '../../utils';

--- a/src/plots/scatter/adaptor.ts
+++ b/src/plots/scatter/adaptor.ts
@@ -1,5 +1,5 @@
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { point } from '../../adaptor/geometries';
 import { tooltip, interaction, animation, theme, scale, annotation } from '../../adaptor/common';
 import { findGeometry, transformLabel } from '../../utils';
@@ -20,7 +20,7 @@ function geometry(params: Params<ScatterOptions>): Params<ScatterOptions> {
 
   // geometry
   point(
-    deepMix({}, params, {
+    deepAssign({}, params, {
       options: {
         seriesField: colorField,
         point: {
@@ -142,12 +142,12 @@ function scatterAnnotation(params: Params<ScatterOptions>): Params<ScatterOption
           type: 'region',
           top: false,
           ...defaultConfig.regionStyle[index].position,
-          style: deepMix({}, defaultConfig.regionStyle[index].style, regionStyle?.[index]),
+          style: deepAssign({}, defaultConfig.regionStyle[index].style, regionStyle?.[index]),
         },
         {
           type: 'text',
           top: true,
-          ...deepMix({}, defaultConfig.labelStyle[index], labels?.[index]),
+          ...deepAssign({}, defaultConfig.labelStyle[index], labels?.[index]),
         }
       );
     });
@@ -158,14 +158,14 @@ function scatterAnnotation(params: Params<ScatterOptions>): Params<ScatterOption
         top: false,
         start: ['min', yBaseline],
         end: ['max', yBaseline],
-        style: deepMix({}, defaultConfig.lineStyle, lineStyle),
+        style: deepAssign({}, defaultConfig.lineStyle, lineStyle),
       },
       {
         type: 'line',
         top: false,
         start: [xBaseline, 'min'],
         end: [xBaseline, 'max'],
-        style: deepMix({}, defaultConfig.lineStyle, lineStyle),
+        style: deepAssign({}, defaultConfig.lineStyle, lineStyle),
       }
     );
   }

--- a/src/plots/scatter/index.ts
+++ b/src/plots/scatter/index.ts
@@ -1,6 +1,7 @@
-import { deepMix, isBoolean } from '@antv/util';
+import { isBoolean } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { deepMix } from '../../utils';
 import { ScatterOptions } from './types';
 import { adaptor } from './adaptor';
 import './interaction';

--- a/src/plots/scatter/index.ts
+++ b/src/plots/scatter/index.ts
@@ -1,7 +1,7 @@
 import { isBoolean } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { ScatterOptions } from './types';
 import { adaptor } from './adaptor';
 import './interaction';
@@ -21,7 +21,7 @@ export class Scatter extends Plot<ScatterOptions> {
 
   protected getDefaultOptions(options: ScatterOptions) {
     const { shapeField, colorField, legend, xField, yField, sizeField } = options;
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       size: 4,
       /** pointStyle 跟随主题默认样式 */
       tooltip: {

--- a/src/plots/stock/adaptor.ts
+++ b/src/plots/stock/adaptor.ts
@@ -1,7 +1,7 @@
 import { isArray, isObject, map } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, animation, theme } from '../../adaptor/common';
-import { findGeometry, flow, pick, deepMix } from '../../utils';
+import { findGeometry, flow, pick, deepAssign } from '../../utils';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 
 import { StockOptions } from './types';
@@ -54,7 +54,7 @@ export function meta(params: Params<StockOptions>): Params<StockOptions> {
     },
   };
 
-  const scales = deepMix(baseMeta, meta, {
+  const scales = deepAssign(baseMeta, meta, {
     [xField]: pick(xAxis, AXIS_META_CONFIG_KEYS),
     [Y_FIELD]: pick(yAxis, AXIS_META_CONFIG_KEYS),
   });

--- a/src/plots/stock/adaptor.ts
+++ b/src/plots/stock/adaptor.ts
@@ -1,7 +1,7 @@
-import { deepMix, isArray, isObject, map } from '@antv/util';
+import { isArray, isObject, map } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, animation, theme } from '../../adaptor/common';
-import { findGeometry, flow, pick } from '../../utils';
+import { findGeometry, flow, pick, deepMix } from '../../utils';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 
 import { StockOptions } from './types';

--- a/src/plots/stock/index.ts
+++ b/src/plots/stock/index.ts
@@ -1,4 +1,4 @@
-import { deepMix } from '@antv/util';
+import { deepAssign } from '../../utils';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { StockOptions } from './types';
@@ -16,7 +16,7 @@ export class Stock extends Plot<StockOptions> {
    *  g2/g2plot默 认 配 置 -->  图 表 默 认 配 置  --> 开 发 者 自 定 义 配 置  --> 最 终 绘 图 配 置
    */
   protected getDefaultOptions(): Partial<StockOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       // 设置默认图表 tooltips
       tooltip: DEFAULT_TOOLTIP_OPTIONS,
       interactions: [{ type: 'tooltip' }],

--- a/src/plots/sunburst/adaptor.ts
+++ b/src/plots/sunburst/adaptor.ts
@@ -1,8 +1,7 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { polygon as polygonAdaptor } from '../../adaptor/geometries';
 import { tooltip, interaction, animation, theme, annotation } from '../../adaptor/common';
-import { flow, findGeometry, transformLabel } from '../../utils';
+import { flow, findGeometry, transformLabel, deepMix } from '../../utils';
 import { transformData } from './utils';
 import { SunburstOptions } from './types';
 

--- a/src/plots/sunburst/adaptor.ts
+++ b/src/plots/sunburst/adaptor.ts
@@ -1,7 +1,7 @@
 import { Params } from '../../core/adaptor';
 import { polygon as polygonAdaptor } from '../../adaptor/geometries';
 import { tooltip, interaction, animation, theme, annotation } from '../../adaptor/common';
-import { flow, findGeometry, transformLabel, deepMix } from '../../utils';
+import { flow, findGeometry, transformLabel, deepAssign } from '../../utils';
 import { transformData } from './utils';
 import { SunburstOptions } from './types';
 
@@ -17,7 +17,7 @@ function geometry(params: Params<SunburstOptions>): Params<SunburstOptions> {
 
   // geometry
   polygonAdaptor(
-    deepMix({}, params, {
+    deepAssign({}, params, {
       options: {
         xField: 'x',
         yField: 'y',

--- a/src/plots/sunburst/index.ts
+++ b/src/plots/sunburst/index.ts
@@ -1,4 +1,4 @@
-import { deepMix } from '@antv/util';
+import { deepAssign } from '../../utils';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { SunburstOptions } from './types';
@@ -16,7 +16,7 @@ export class Sunburst extends Plot<SunburstOptions> {
    */
   protected getDefaultOptions(options: SunburstOptions) {
     const { tooltip, seriesField, colorField } = options;
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       type: 'partition',
       innerRadius: 0,
       seriesField: 'value',

--- a/src/plots/tiny-area/adaptor.ts
+++ b/src/plots/tiny-area/adaptor.ts
@@ -1,7 +1,6 @@
-import { deepMix } from '@antv/util';
 import { theme, scale, animation, annotation, tooltip } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { area, line, point } from '../../adaptor/geometries';
 import { TinyAreaOptions } from './types';
 

--- a/src/plots/tiny-area/adaptor.ts
+++ b/src/plots/tiny-area/adaptor.ts
@@ -1,6 +1,6 @@
 import { theme, scale, animation, annotation, tooltip } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { area, line, point } from '../../adaptor/geometries';
 import { TinyAreaOptions } from './types';
 
@@ -18,7 +18,7 @@ function geometry(params: Params<TinyAreaOptions>): Params<TinyAreaOptions> {
 
   chart.data(seriesData);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: 'x',
       yField: 'y',

--- a/src/plots/tiny-column/adaptor.ts
+++ b/src/plots/tiny-column/adaptor.ts
@@ -1,7 +1,6 @@
-import { deepMix } from '@antv/util';
 import { theme, scale, animation, annotation, tooltip } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { TinyColumnOptions } from './types';
 /**

--- a/src/plots/tiny-column/adaptor.ts
+++ b/src/plots/tiny-column/adaptor.ts
@@ -1,6 +1,6 @@
 import { theme, scale, animation, annotation, tooltip } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { TinyColumnOptions } from './types';
 /**
@@ -17,7 +17,7 @@ function geometry(params: Params<TinyColumnOptions>): Params<TinyColumnOptions> 
 
   chart.data(seriesData);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: 'x',
       yField: 'y',

--- a/src/plots/tiny-line/adaptor.ts
+++ b/src/plots/tiny-line/adaptor.ts
@@ -1,6 +1,5 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { scale, theme, animation, annotation, tooltip } from '../../adaptor/common';
 import { line, point } from '../../adaptor/geometries';
 import { TinyLineOptions } from './types';

--- a/src/plots/tiny-line/adaptor.ts
+++ b/src/plots/tiny-line/adaptor.ts
@@ -1,5 +1,5 @@
 import { Params } from '../../core/adaptor';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { scale, theme, animation, annotation, tooltip } from '../../adaptor/common';
 import { line, point } from '../../adaptor/geometries';
 import { TinyLineOptions } from './types';
@@ -19,7 +19,7 @@ function geometry(params: Params<TinyLineOptions>): Params<TinyLineOptions> {
   chart.data(seriesData);
 
   // line geometry 处理
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: 'x',
       yField: 'y',

--- a/src/plots/waterfall/adaptor.ts
+++ b/src/plots/waterfall/adaptor.ts
@@ -1,10 +1,10 @@
 import { Geometry } from '@antv/g2';
-import { deepMix, get } from '@antv/util';
+import { get } from '@antv/util';
 import { Datum } from '@antv/g2/lib/interface';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, state, scale, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
-import { findGeometry, flow, transformLabel } from '../../utils';
+import { findGeometry, flow, transformLabel, deepMix } from '../../utils';
 import { Y_FIELD, ABSOLUTE_FIELD, DIFF_FIELD, IS_TOTAL } from './constants';
 import { WaterfallOptions } from './types';
 import { transformData } from './utils';

--- a/src/plots/waterfall/adaptor.ts
+++ b/src/plots/waterfall/adaptor.ts
@@ -4,7 +4,7 @@ import { Datum } from '@antv/g2/lib/interface';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, state, scale, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
-import { findGeometry, flow, transformLabel, deepMix } from '../../utils';
+import { findGeometry, flow, transformLabel, deepAssign } from '../../utils';
 import { Y_FIELD, ABSOLUTE_FIELD, DIFF_FIELD, IS_TOTAL } from './constants';
 import { WaterfallOptions } from './types';
 import { transformData } from './utils';
@@ -42,7 +42,7 @@ function geometry(params: Params<WaterfallOptions>): Params<WaterfallOptions> {
       return get(datum, [Y_FIELD, 1]) - get(datum, [Y_FIELD, 0]) > 0 ? risingFill : fallingFill;
     };
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: xField,
       yField: Y_FIELD,
@@ -73,7 +73,7 @@ function meta(params: Params<WaterfallOptions>): Params<WaterfallOptions> {
   const { options } = params;
   const { xAxis, yAxis, xField, yField, meta } = options;
 
-  const Y_FIELD_META = deepMix({}, { alias: yField }, get(meta, yField));
+  const Y_FIELD_META = deepAssign({}, { alias: yField }, get(meta, yField));
 
   return flow(
     scale(
@@ -82,7 +82,7 @@ function meta(params: Params<WaterfallOptions>): Params<WaterfallOptions> {
         [yField]: yAxis,
         [Y_FIELD]: yAxis,
       },
-      deepMix({}, meta, { [Y_FIELD]: Y_FIELD_META, [DIFF_FIELD]: Y_FIELD_META, [ABSOLUTE_FIELD]: Y_FIELD_META })
+      deepAssign({}, meta, { [Y_FIELD]: Y_FIELD_META, [DIFF_FIELD]: Y_FIELD_META, [ABSOLUTE_FIELD]: Y_FIELD_META })
     )
   )(params);
 }
@@ -140,12 +140,12 @@ function legend(params: Params<WaterfallOptions>): Params<WaterfallOptions> {
         value: 'total',
         marker: {
           symbol: 'square',
-          style: deepMix({}, { r: 5 }, get(total, 'style')),
+          style: deepAssign({}, { r: 5 }, get(total, 'style')),
         },
       });
     }
     chart.legend(
-      deepMix(
+      deepAssign(
         {},
         {
           custom: true,

--- a/src/plots/waterfall/shape.ts
+++ b/src/plots/waterfall/shape.ts
@@ -2,7 +2,7 @@ import { IGroup } from '@antv/g-base';
 import { registerShape } from '@antv/g2';
 import { ShapeInfo } from '@antv/g2/lib/interface';
 import { get } from '@antv/util';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { Point } from '../../types';
 
 /**
@@ -31,7 +31,7 @@ function getRectPath(points: Point[]) {
  * @param cfg 图形绘制数据
  */
 function getFillAttrs(cfg: ShapeInfo) {
-  return deepMix({}, cfg.defaultStyle, cfg.style, { fill: cfg.color });
+  return deepAssign({}, cfg.defaultStyle, cfg.style, { fill: cfg.color });
 }
 
 registerShape('interval', 'waterfall', {

--- a/src/plots/waterfall/shape.ts
+++ b/src/plots/waterfall/shape.ts
@@ -1,7 +1,8 @@
 import { IGroup } from '@antv/g-base';
 import { registerShape } from '@antv/g2';
 import { ShapeInfo } from '@antv/g2/lib/interface';
-import { deepMix, get } from '@antv/util';
+import { get } from '@antv/util';
+import { deepMix } from '../../utils';
 import { Point } from '../../types';
 
 /**

--- a/src/plots/word-cloud/adaptor.ts
+++ b/src/plots/word-cloud/adaptor.ts
@@ -1,7 +1,6 @@
-import { deepMix } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale, state } from '../../adaptor/common';
-import { flow } from '../../utils';
+import { flow, deepMix } from '../../utils';
 import { point } from '../../adaptor/geometries';
 import { WordCloudOptions } from './types';
 import { transform } from './utils';

--- a/src/plots/word-cloud/adaptor.ts
+++ b/src/plots/word-cloud/adaptor.ts
@@ -1,6 +1,6 @@
 import { Params } from '../../core/adaptor';
 import { tooltip, interaction, animation, theme, scale, state } from '../../adaptor/common';
-import { flow, deepMix } from '../../utils';
+import { flow, deepAssign } from '../../utils';
 import { point } from '../../adaptor/geometries';
 import { WordCloudOptions } from './types';
 import { transform } from './utils';
@@ -16,7 +16,7 @@ function geometry(params: Params<WordCloudOptions>): Params<WordCloudOptions> {
 
   chart.data(data);
 
-  const p = deepMix({}, params, {
+  const p = deepAssign({}, params, {
     options: {
       xField: 'x',
       yField: 'y',

--- a/src/plots/word-cloud/index.ts
+++ b/src/plots/word-cloud/index.ts
@@ -1,7 +1,7 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { Datum } from '../../types';
-import { deepMix } from '../../utils';
+import { deepAssign } from '../../utils';
 import { WordCloudOptions } from './types';
 import { adaptor } from './adaptor';
 import { processImageMask } from './utils';
@@ -18,7 +18,7 @@ export class WordCloud extends Plot<WordCloudOptions> {
    * 获取默认的 options 配置项
    */
   protected getDefaultOptions(): Partial<WordCloudOptions> {
-    return deepMix({}, super.getDefaultOptions(), {
+    return deepAssign({}, super.getDefaultOptions(), {
       timeInterval: 2000,
       tooltip: {
         showTitle: false,

--- a/src/plots/word-cloud/index.ts
+++ b/src/plots/word-cloud/index.ts
@@ -1,7 +1,7 @@
-import { deepMix } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { Datum } from '../../types';
+import { deepMix } from '../../utils';
 import { WordCloudOptions } from './types';
 import { adaptor } from './adaptor';
 import { processImageMask } from './utils';

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,4 +1,4 @@
-import { deepMix } from '../utils';
+import { deepAssign } from '../utils';
 import { Plot, PickOptions } from '../core/plot';
 import { Adaptor } from '../core/adaptor';
 /**
@@ -38,7 +38,7 @@ export class P<O extends PickOptions> extends Plot<O> {
    * @param defaultOptions
    */
   constructor(container: string | HTMLElement, options: O, adaptor: Adaptor<O>, defaultOptions?: Partial<O>) {
-    super(container, deepMix({}, defaultOptions, options));
+    super(container, deepAssign({}, defaultOptions, options));
 
     this.adaptor = adaptor;
   }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,4 +1,4 @@
-import { deepMix } from '@antv/util';
+import { deepMix } from '../utils';
 import { Plot, PickOptions } from '../core/plot';
 import { Adaptor } from '../core/adaptor';
 /**

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -11,10 +11,10 @@ export function adjustYMetaByZero(data: Data, field: string): Meta {
   const ltZero = data.every((datum: Datum) => get(datum, [field]) < 0);
 
   if (gtZero) {
-    return { min: 0 };
+    return { min: 0, max: undefined };
   }
   if (ltZero) {
-    return { max: 0 };
+    return { max: 0, min: undefined };
   }
   return {};
 }

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -10,6 +10,8 @@ export function adjustYMetaByZero(data: Data, field: string): Meta {
   const gtZero = data.every((datum: Datum) => get(datum, [field]) > 0);
   const ltZero = data.every((datum: Datum) => get(datum, [field]) < 0);
 
+  // 目前是增量更新，对 { min: 0, max: undefined } 进行 update({ max: 0 }) 会得到 { min: 0, max: 0 }
+  // 需要添加 undefined 进行覆盖
   if (gtZero) {
     return { min: 0, max: undefined };
   }

--- a/src/utils/deep-assign.ts
+++ b/src/utils/deep-assign.ts
@@ -76,7 +76,11 @@ const deep = (dist, src, level?, maxLevel?) => {
   }
 };
 
-// todo 重写
+/**
+ * deepAssign 功能类似 deepMix
+ * 不同点在于 deepAssign 会将 null undefined 等类型直接覆盖给 source
+ * 详细参考： __tests__/unit/utils/deep-assign-spec.ts
+ */
 export const deepAssign = (rst: any, ...args: any[]) => {
   for (let i = 0; i < args.length; i += 1) {
     deep(rst, args[i]);

--- a/src/utils/deep-assign.ts
+++ b/src/utils/deep-assign.ts
@@ -1,7 +1,8 @@
-const MAX_MIX_LEVEL = 5;
+const MAX_MIX_LEVEL = 5; // 最大比对层级
 
 const toString = {}.toString;
 
+// 类型检测
 const isType = (value: any, type: string): boolean => toString.call(value) === '[object ' + type + ']';
 
 const isArray = (value: any): value is Array<any> => {
@@ -38,6 +39,12 @@ const isPlainObject = (value: any): value is object => {
   return Object.getPrototypeOf(value) === proto;
 };
 
+/***
+ * @param {any} dist
+ * @param {any} src
+ * @param {number} level 当前层级
+ * @param {number} maxLevel 最大层级
+ */
 const deep = (dist, src, level?, maxLevel?) => {
   level = level || 0;
   maxLevel = maxLevel || MAX_MIX_LEVEL;
@@ -45,6 +52,7 @@ const deep = (dist, src, level?, maxLevel?) => {
     if (Object.prototype.hasOwnProperty.call(src, key)) {
       const value = src[key];
       if (!value) {
+        // null 、 undefined 等情况直接赋值
         dist[key] = value;
       } else {
         if (isPlainObject(value)) {
@@ -54,12 +62,13 @@ const deep = (dist, src, level?, maxLevel?) => {
           if (level < maxLevel) {
             deep(dist[key], value, level + 1, maxLevel);
           } else {
+            // 层级过深直接赋值，性能问题
             dist[key] = src[key];
           }
         } else if (isArray(value)) {
           dist[key] = [];
           dist[key] = dist[key].concat(value);
-        } else if (value !== undefined) {
+        } else {
           dist[key] = value;
         }
       }

--- a/src/utils/deep-assign.ts
+++ b/src/utils/deep-assign.ts
@@ -68,7 +68,7 @@ const deep = (dist, src, level?, maxLevel?) => {
 };
 
 // todo 重写
-export const deepMix = (rst: any, ...args: any[]) => {
+export const deepAssign = (rst: any, ...args: any[]) => {
   for (let i = 0; i < args.length; i += 1) {
     deep(rst, args[i]);
   }

--- a/src/utils/deep-assign.ts
+++ b/src/utils/deep-assign.ts
@@ -6,7 +6,7 @@ const toString = {}.toString;
 const isType = (value: any, type: string): boolean => toString.call(value) === '[object ' + type + ']';
 
 const isArray = (value: any): value is Array<any> => {
-  return Array.isArray ? Array.isArray(value) : isType(value, 'Array');
+  return isType(value, 'Array');
 };
 
 const isObjectLike = (value: any): value is object => {
@@ -14,7 +14,6 @@ const isObjectLike = (value: any): value is object => {
    * isObjectLike({}) => true
    * isObjectLike([1, 2, 3]) => true
    * isObjectLike(Function) => false
-   * isObjectLike(null) => false
    */
   return typeof value === 'object' && value !== null;
 };
@@ -24,13 +23,9 @@ const isPlainObject = (value: any): value is object => {
    * isObjectLike(new Foo) => false
    * isObjectLike([1, 2, 3]) => false
    * isObjectLike({ x: 0, y: 0 }) => true
-   * isObjectLike(Object.create(null)) => true
    */
   if (!isObjectLike(value) || !isType(value, 'Object')) {
     return false;
-  }
-  if (Object.getPrototypeOf(value) === null) {
-    return true;
   }
   let proto = value;
   while (Object.getPrototypeOf(proto) !== null) {

--- a/src/utils/deep-mix.ts
+++ b/src/utils/deep-mix.ts
@@ -1,0 +1,76 @@
+const MAX_MIX_LEVEL = 5;
+
+const toString = {}.toString;
+
+const isType = (value: any, type: string): boolean => toString.call(value) === '[object ' + type + ']';
+
+const isArray = (value: any): value is Array<any> => {
+  return Array.isArray ? Array.isArray(value) : isType(value, 'Array');
+};
+
+const isObjectLike = (value: any): value is object => {
+  /**
+   * isObjectLike({}) => true
+   * isObjectLike([1, 2, 3]) => true
+   * isObjectLike(Function) => false
+   * isObjectLike(null) => false
+   */
+  return typeof value === 'object' && value !== null;
+};
+
+const isPlainObject = (value: any): value is object => {
+  /**
+   * isObjectLike(new Foo) => false
+   * isObjectLike([1, 2, 3]) => false
+   * isObjectLike({ x: 0, y: 0 }) => true
+   * isObjectLike(Object.create(null)) => true
+   */
+  if (!isObjectLike(value) || !isType(value, 'Object')) {
+    return false;
+  }
+  if (Object.getPrototypeOf(value) === null) {
+    return true;
+  }
+  let proto = value;
+  while (Object.getPrototypeOf(proto) !== null) {
+    proto = Object.getPrototypeOf(proto);
+  }
+  return Object.getPrototypeOf(value) === proto;
+};
+
+const deep = (dist, src, level?, maxLevel?) => {
+  level = level || 0;
+  maxLevel = maxLevel || MAX_MIX_LEVEL;
+  for (const key in src) {
+    if (Object.prototype.hasOwnProperty.call(src, key)) {
+      const value = src[key];
+      if (!value) {
+        dist[key] = value;
+      } else {
+        if (isPlainObject(value)) {
+          if (!isPlainObject(dist[key])) {
+            dist[key] = {};
+          }
+          if (level < maxLevel) {
+            deep(dist[key], value, level + 1, maxLevel);
+          } else {
+            dist[key] = src[key];
+          }
+        } else if (isArray(value)) {
+          dist[key] = [];
+          dist[key] = dist[key].concat(value);
+        } else if (value !== undefined) {
+          dist[key] = value;
+        }
+      }
+    }
+  }
+};
+
+// todo 重写
+export const deepMix = (rst: any, ...args: any[]) => {
+  for (let i = 0; i < args.length; i += 1) {
+    deep(rst, args[i]);
+  }
+  return rst;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export { findGeometry, getAllElements } from './geometry';
 export { findViewById } from './view';
 export { transformLabel } from './label';
 export { getSplinePath } from './path';
+export { deepMix } from './deep-mix';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,4 +7,4 @@ export { findGeometry, getAllElements } from './geometry';
 export { findViewById } from './view';
 export { transformLabel } from './label';
 export { getSplinePath } from './path';
-export { deepMix } from './deep-mix';
+export { deepAssign } from './deep-assign';


### PR DESCRIPTION
@lxfu1 

> G2Plot v2 暂时没有开放 changeData API，所有的数据更新都是重新走画布渲染，所以无法进行增量数据的更新。但是在 charts 中文档透出，所以导致一些 bug 和答疑问题。

所以需要在 G2Plot 完善 changeData API，并做到文档透出。在开发过程中遇到 update 的另外的问题。分别描述

## changeData API

目前的 changeData 仅仅是对 data key 生效，而对于 percent 类型，双轴图的双 data 类型，直方图等经过数据 transform 的均不生效。

解决方案：

1. 终极方案

实现使用 g2 的 changeData，结果 g2 的 update 能力，可以实现动画，但是需要解决不同图表的 transform 逻辑。目前来看开发成本，回滚成本大。

2. 中间方案

依然使用 更新整体配置的方式，只不过只更新 data/percent 等数据相关的 key 值。具体伪代码：

```ts
 // 针对非 data key 类型的图表，子类实现 changeData 处理数据，调用父类 update 方法， 父类 deepMix 增量数据。
 /**
   * 更新数据
   * @param percent
  */
  public changeData(percent: number) {
    this.update({
      percent,
    });
  }

  // 父类 
  public update(options: any) {
    // this.options 用于处理增量数据，或者所有 getDefaultOptions deepMix base getDefaultOptions()
    this.options = deepMix({}, this.options, this.getDefaultOptions({ ...this.options, ...options }), options);
    this.render();
  }

```



## update API 问题

在实现 changeData 中，发现 update 存在的问题。目前实现代码：

```ts
/**
 * 更新配置
 * @param options
 */
public update(options: O) {
  // options 更新是全量更新，这里和构造函数中一会加上图表的默认选项
  this.options = deepMix({}, this.getDefaultOptions(options), options);

  this.render();
}
```

存在的问题：

1. 无法增量 update。比如我只 update color 色板，需要外包传入所有配置项；使用上不方便。而 update 不直接开启内置 deepMix 的原因是 配置传入 updefined 的时候，无法覆盖旧的内容。
2. 如果 getDefaultOptions 中利用 options 生成默认配置的时候，会导致生成的默认配置无法更新

解决办法：

1. 自己实现 deepMix 逻辑，原 deepMix 逻辑是 undefined 无法做覆盖（Object.assign 是可以覆盖的）

> deepMix({},{value: 0}, {value: undefined}) => {value: 0}

因为这个也不算 bug，毕竟 lodash 都是这么做的，所以名字上重命名为： **deepAssign** 以作区分，方式误导开发者。

2. deepAssign 针对 !value 类型 直接赋值。
```ts
if (Object.prototype.hasOwnProperty.call(sourceObj, key)) {
      const value = sourceObj[key];
      if (!value) {
        target[key] = value;
      } else{
      // TODO 
      }
}
```