### PR TITLE
fix: update & getDefaultOptions bugs

### DIFF
--- a/__tests__/unit/plots/area/index-spec.ts
+++ b/__tests__/unit/plots/area/index-spec.ts
@@ -36,7 +36,7 @@ describe('area', () => {
 
     area.render();
 
-    expect(area.options.meta.x.type).toBe('cat');
+    expect(area.chart.getScaleByField('x').type).toBe('cat');
     expect(area.chart.getScaleByField('x').range).toEqual([0, 1]);
     area.update({
       ...area.options,

--- a/__tests__/unit/plots/area/y-meta-min-max-spec.ts
+++ b/__tests__/unit/plots/area/y-meta-min-max-spec.ts
@@ -1,9 +1,9 @@
-import { Line } from '../../../../src';
+import { Area } from '../../../../src';
 import { createDiv } from '../../../utils/dom';
 
-describe('line', () => {
+describe('area', () => {
   it('y min, max meta', () => {
-    const line = new Line(createDiv(), {
+    const area = new Area(createDiv(), {
       width: 400,
       height: 300,
       xField: 'date',
@@ -14,11 +14,11 @@ describe('line', () => {
       ],
     });
 
-    line.render();
-    expect(line.chart.getScaleByField('value').min).toBe(0);
-    expect(line.chart.getScaleByField('value').max).toBe(20);
+    area.render();
+    expect(area.chart.getScaleByField('value').min).toBe(0);
+    expect(area.chart.getScaleByField('value').max).toBe(20);
 
-    line.update({
+    area.update({
       width: 400,
       height: 300,
       xField: 'date',
@@ -29,7 +29,7 @@ describe('line', () => {
       ],
     });
 
-    expect(line.chart.getScaleByField('value').min).toBe(-20);
-    expect(line.chart.getScaleByField('value').max).toBe(0);
+    expect(area.chart.getScaleByField('value').min).toBe(-20);
+    expect(area.chart.getScaleByField('value').max).toBe(0);
   });
 });

--- a/__tests__/unit/plots/bidirectional-bar/update-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/update-spec.ts
@@ -1,0 +1,39 @@
+import { BidirectionalBar } from '../../../../src';
+import { data } from '../../../data/bi-directional';
+import { createDiv } from '../../../utils/dom';
+
+describe('Bidirectional layout', () => {
+  it('update layout', () => {
+    const bidirectional = new BidirectionalBar(createDiv('update layout'), {
+      width: 400,
+      height: 400,
+      data,
+      xField: 'country',
+      yField: ['2016年耕地总面积', '2016年转基因种植面积'],
+    });
+    bidirectional.render();
+
+    let firstView = bidirectional.chart.views[0];
+    let secondView = bidirectional.chart.views[1];
+    expect(firstView.getCoordinate().isTransposed).toBe(true);
+    expect(secondView.getCoordinate().isTransposed).toBe(true);
+    //@ts-ignore
+    expect(firstView.getCoordinate().isReflectX).toBe(true);
+    //@ts-ignore
+    expect(firstView.getOptions().axes.country.position).toBe('top');
+
+    bidirectional.update({
+      layout: 'vertical',
+    });
+
+    firstView = bidirectional.chart.views[0];
+    secondView = bidirectional.chart.views[1];
+
+    expect(firstView.getCoordinate().isTransposed).toBe(false);
+    expect(secondView.getCoordinate().isTransposed).toBe(false);
+    //@ts-ignore
+    expect(secondView.getCoordinate().isReflectY).toBe(true);
+    //@ts-ignore
+    expect(firstView.getOptions().axes.country.position).toBe('bottom');
+  });
+});

--- a/__tests__/unit/plots/bidirectional-bar/utils-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/utils-spec.ts
@@ -1,0 +1,25 @@
+import { isHorizontal, transformData } from '../../../../src/plots/bidirectional-bar/utils';
+
+describe('util', () => {
+  it('isHorizontal', () => {
+    // @ts-ignore
+    expect(isHorizontal('a')).toBe(true);
+    expect(isHorizontal(undefined)).toBe(true);
+    expect(isHorizontal('vertical')).toBe(false);
+    expect(isHorizontal('horizontal')).toBe(true);
+  });
+
+  it('transformData', () => {
+    const data = [
+      { x: 'a', y1: 10, y2: 20, y3: 30 },
+      { x: 'b', y1: 11, y2: 21, y3: 31 },
+    ];
+
+    expect(transformData('x', ['y1', 'y2'], data)).toEqual([
+      { type: 'y1', x: 'a', y1: 10 },
+      { type: 'y1', x: 'b', y1: 11 },
+      { type: 'y2', x: 'a', y2: 20 },
+      { type: 'y2', x: 'b', y2: 21 },
+    ]);
+  });
+});

--- a/__tests__/unit/plots/column/update-spec.ts
+++ b/__tests__/unit/plots/column/update-spec.ts
@@ -1,0 +1,89 @@
+import { Column } from '../../../../src';
+import { salesByArea } from '../../../data/sales';
+import { createDiv } from '../../../utils/dom';
+
+describe('column update', () => {
+  it('meta', () => {
+    const column = new Column(createDiv(), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      xField: 'area',
+      yField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+        },
+      },
+    });
+
+    column.render();
+
+    expect(column.chart.getXScale().type).toBe('cat'); // 默认值
+
+    column.update({
+      meta: {
+        area: {
+          type: 'timeCat',
+        },
+      },
+    });
+    expect(column.chart.getXScale().type).toBe('timeCat');
+
+    column.update({
+      meta: {
+        area: {
+          type: 'cat',
+        },
+      },
+    });
+    expect(column.chart.getXScale().type).toBe('cat');
+  });
+
+  it('legend', () => {
+    const column = new Column(createDiv(), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      xField: 'area',
+      yField: 'sales',
+    });
+
+    column.render();
+
+    expect(column.chart.getOptions().legends).toBe(false);
+
+    column.update({
+      seriesField: 'area',
+      isStack: true,
+      legend: {},
+    });
+
+    // @ts-ignore
+    expect(column.chart.getOptions().legends.area).toEqual({ position: 'right-top' });
+
+    column.update({
+      seriesField: 'area',
+      isStack: false,
+      legend: {},
+    });
+
+    // @ts-ignore
+    expect(column.chart.getOptions().legends.area).toEqual({ position: 'right-top' });
+
+    column.update({
+      seriesField: 'area',
+      isStack: false,
+      legend: false,
+    });
+
+    expect(column.chart.getOptions().legends).toBe(false);
+
+    column.update({
+      seriesField: undefined,
+      legend: {},
+    });
+
+    expect(column.chart.getOptions().legends).toBe(false);
+  });
+});

--- a/__tests__/unit/plots/dual-axes/default-options-spec.ts
+++ b/__tests__/unit/plots/dual-axes/default-options-spec.ts
@@ -12,13 +12,13 @@ describe('default options', () => {
     });
 
     dualAxes.render();
-
-    expect(dualAxes.options.meta.date.sync).toBe(true);
-    expect(dualAxes.options.meta.date.range).toEqual([0, 1]);
     // @ts-ignore
-    expect(dualAxes.options.tooltip.showCrosshairs).toEqual(true);
+    expect(dualAxes.chart.getScaleByField('date').sync).toBeTruthy();
+    expect(dualAxes.chart.getScaleByField('date').range).toEqual([0, 1]);
     // @ts-ignore
-    expect(dualAxes.options.tooltip.showMarkers).toEqual(true);
+    expect(dualAxes.chart.options.tooltip.showCrosshairs).toEqual(true);
+    // @ts-ignore
+    expect(dualAxes.chart.options.tooltip.showMarkers).toEqual(true);
   });
 
   it('line column', () => {
@@ -40,14 +40,13 @@ describe('default options', () => {
     });
 
     dualAxes.render();
-
-    expect(dualAxes.options.meta.date.sync).toBe(true);
-    expect(dualAxes.options.meta.date.range).toEqual(undefined);
+    console.log(dualAxes.chart.getComponents());
     // @ts-ignore
-    expect(dualAxes.options.tooltip.showCrosshairs).toEqual(false);
+    expect(dualAxes.chart.getScaleByField('date').sync).toBeTruthy();
+    expect(dualAxes.chart.getScaleByField('date').range.length).toBe(2);
     // @ts-ignore
-    expect(dualAxes.options.tooltip.showMarkers).toEqual(false);
-
-    expect(dualAxes.options.interactions.some((i) => i.type === 'active-region'));
+    expect(dualAxes.chart.getOptions().tooltip.showCrosshairs).toEqual(false);
+    // @ts-ignore
+    expect(dualAxes.chart.getOptions().tooltip.showMarkers).toEqual(false);
   });
 });

--- a/__tests__/unit/plots/dual-axes/default-options-spec.ts
+++ b/__tests__/unit/plots/dual-axes/default-options-spec.ts
@@ -40,7 +40,6 @@ describe('default options', () => {
     });
 
     dualAxes.render();
-    console.log(dualAxes.chart.getComponents());
     // @ts-ignore
     expect(dualAxes.chart.getScaleByField('date').sync).toBeTruthy();
     expect(dualAxes.chart.getScaleByField('date').range.length).toBe(2);

--- a/__tests__/unit/plots/dual-axes/util/option-spec.ts
+++ b/__tests__/unit/plots/dual-axes/util/option-spec.ts
@@ -18,6 +18,20 @@ describe('DualAxes option', () => {
     ).toEqual({
       xField: 'test',
       yField: ['test1', 'test2'],
+      meta: {
+        test: {
+          sync: true,
+          range: [0, 1],
+        },
+      },
+      tooltip: {
+        showMarkers: true,
+        showCrosshairs: true,
+        shared: true,
+        crosshairs: {
+          type: 'x',
+        },
+      },
       yAxis: [
         {
           nice: true,
@@ -39,6 +53,7 @@ describe('DualAxes option', () => {
           color: '#E76C5E',
         },
       ],
+      interactions: [{ type: 'legend-visible-filter' }],
     });
 
     expect(

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -111,8 +111,9 @@ describe('gauge', () => {
     });
 
     gauge.render();
-
-    expect(gauge.options.range.ticks).toEqual([0, 0.65, 1]);
+    console.log(gauge.chart.views[1].getYScales());
+    // @ts-ignore
+    expect(gauge.chart.views[1].getYScales()[0].ticks).toEqual([0, 0.25, 0.5, 0.75, 1]);
     expect(gauge.chart.views.length).toBe(2);
     expect(pick(gauge.chart.views[1].getYScales()[0], ['min', 'max', 'minLimit', 'maxLimit'])).toEqual({
       min: 0,
@@ -172,17 +173,13 @@ describe('gauge', () => {
       height: 300,
       autoFit: false,
       percent: 0.75,
-      range: {
-        color: ['l(0) 0:#5d7cef 1:#e35767'],
-      },
     });
 
     gauge.render();
-
     expect(gauge.chart.views[0].getData()).toEqual([{ percent: 0.75 }]);
-    expect(gauge.options.range.ticks).toEqual([0, 0.75, 1]);
+    expect(gauge.chart.views[1].getYScales()[0].values).toEqual([0.75, 0.25]);
     gauge.changeData(0.2);
     expect(gauge.chart.views[0].getData()).toEqual([{ percent: 0.2 }]);
-    expect(gauge.options.range.ticks).toEqual([0, 0.2, 1]);
+    expect(gauge.chart.views[1].getYScales()[0].values).toEqual([0.2, 0.8]);
   });
 });

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -111,7 +111,6 @@ describe('gauge', () => {
     });
 
     gauge.render();
-    console.log(gauge.chart.views[1].getYScales());
     // @ts-ignore
     expect(gauge.chart.views[1].getYScales()[0].ticks).toEqual([0, 0.25, 0.5, 0.75, 1]);
     expect(gauge.chart.views.length).toBe(2);

--- a/__tests__/unit/plots/line/index-spec.ts
+++ b/__tests__/unit/plots/line/index-spec.ts
@@ -50,4 +50,37 @@ describe('line', () => {
     expect(geometry.scales.value.min).toBe(0);
     expect(geometry.scales.value.max).toBe(5000);
   });
+
+  it('x cat scale', () => {
+    const data = [
+      { x: 1, y: 1 },
+      { x: 2, y: 4 },
+      { x: 3, y: 5 },
+      { x: 4, y: 2 },
+    ];
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      appendPadding: 10,
+      data: data,
+      xField: 'x',
+      yField: 'y',
+    });
+
+    line.render();
+
+    expect(line.chart.getScaleByField('x').type).toBe('cat');
+    expect(line.chart.getScaleByField('x').range).toEqual([0, 1]);
+    line.update({
+      meta: {
+        x: {
+          type: 'linear',
+          range: [0.1, 0.9],
+        },
+      },
+    });
+
+    expect(line.chart.getScaleByField('x').type).toBe('linear');
+    expect(line.chart.getScaleByField('x').range).toEqual([0.1, 0.9]);
+  });
 });

--- a/__tests__/unit/plots/scatter/tooltip-spec.ts
+++ b/__tests__/unit/plots/scatter/tooltip-spec.ts
@@ -27,8 +27,8 @@ describe('scatter', () => {
       ...scatter.options,
       tooltip: false,
     });
-    // @ts-ignore
-    expect(scatter.chart.options.tooltip).toBe(false);
+
+    expect(scatter.chart.getOptions().tooltip).toBe(undefined);
     expect(scatter.chart.getComponents().find((co) => co.type === 'tooltip')).toBe(undefined);
   });
 

--- a/__tests__/unit/plots/sunburst/change-data-spec.ts
+++ b/__tests__/unit/plots/sunburst/change-data-spec.ts
@@ -1,0 +1,75 @@
+import { Sunburst } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { delay } from '../../../utils/delay';
+
+describe('sunburst', () => {
+  it('init: change data', async () => {
+    const data = await fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/sunburst.json').then((res) =>
+      res.json()
+    );
+    const sunburstPlot = new Sunburst(createDiv(), {
+      width: 400,
+      height: 400,
+      data: [],
+      seriesField: 'sum',
+      colorField: 'value',
+      color: ['#BAE7FF', '#1890FF', '#0050B3'],
+      innerRadius: 0.3,
+      radius: 1,
+      label: {
+        position: 'middle',
+      },
+      interactions: [{ type: 'element-active' }],
+    });
+    sunburstPlot.render();
+    await delay(500);
+    sunburstPlot.changeData(data);
+    const geometry = sunburstPlot.chart.geometries[0];
+    expect(geometry.type).toBe('polygon');
+    const {
+      // @ts-ignore
+      labelOption: { fields, cfg },
+      coordinate,
+    } = geometry;
+    expect(fields).toEqual(['sum']);
+    expect(cfg.position).toBe('middle');
+    const positionFields = geometry.getAttribute('position').getFields();
+    expect(geometry.elements.length).toBe(geometry.data.length);
+    expect(positionFields).toHaveLength(2);
+    expect(positionFields).toEqual(['x', 'y']);
+    expect(coordinate.innerRadius).toBe(0.3);
+    expect(coordinate.radius).toBe(1);
+  });
+  it('init: update', async () => {
+    const data = await fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/sunburst.json').then((res) =>
+      res.json()
+    );
+    const sunburstPlot = new Sunburst(createDiv(), {
+      width: 400,
+      height: 400,
+      data,
+      seriesField: 'sum',
+      innerRadius: 0.3,
+      radius: 1,
+      label: {
+        position: 'middle',
+      },
+      interactions: [{ type: 'element-active' }],
+    });
+    sunburstPlot.render();
+    const geometry = sunburstPlot.chart.geometries[0];
+    expect(geometry.type).toBe('polygon');
+    const {
+      // @ts-ignore
+      labelOption: { fields },
+      coordinate,
+    } = geometry;
+    expect(fields).toEqual(['sum']);
+    expect(coordinate.innerRadius).toBe(0.3);
+    // @ts-ignore
+    sunburstPlot.update({
+      innerRadius: 0.6,
+    });
+    expect(sunburstPlot.chart.geometries[0].coordinate.innerRadius).toBe(0.6);
+  });
+});

--- a/__tests__/unit/plots/sunburst/index-spec.ts
+++ b/__tests__/unit/plots/sunburst/index-spec.ts
@@ -102,7 +102,7 @@ describe('sunburst', () => {
       name: 'root',
       children: fetchData,
     };
-    const sunburstPlot = new Sunburst(createDiv(), {
+    const sunburstPlot = new Sunburst(createDiv('sunburst*config', document.body, 'sunburst-id-one'), {
       width: 400,
       height: 400,
       data,
@@ -147,7 +147,9 @@ describe('sunburst', () => {
     const elements = geometry.elements;
     const bbox = elements[elements.length - 1].getBBox();
     sunburstPlot.chart.showTooltip({ x: bbox.maxX, y: bbox.maxY });
-    expect(document.getElementsByClassName('g2-tooltip-list-item-value')[0].innerHTML).toBe('0.0153');
+    expect(
+      document.getElementById('sunburst-id-one').getElementsByClassName('g2-tooltip-list-item-value')[0].innerHTML
+    ).toBe('0.0153');
     sunburstPlot.chart.hideTooltip();
   });
 });
@@ -164,7 +166,7 @@ describe('sunburst', () => {
       name: 'root',
       children: fetchData,
     };
-    const sunburstPlot = new Sunburst(createDiv(), {
+    const sunburstPlot = new Sunburst(createDiv('sunburset', document.body, 'sunburset-id'), {
       width: 400,
       height: 400,
       data,
@@ -213,7 +215,9 @@ describe('sunburst', () => {
     const elements = geometry.elements;
     const bbox = elements[elements.length - 1].getBBox();
     sunburstPlot.chart.showTooltip({ x: bbox.maxX, y: bbox.maxY });
-    expect(document.getElementsByClassName('g2-tooltip-list-item-value')[2].innerHTML).toBe('123');
+    expect(
+      document.getElementById('sunburset-id').getElementsByClassName('g2-tooltip-list-item-value')[0].innerHTML
+    ).toBe('123');
     sunburstPlot.chart.hideTooltip();
   });
 });

--- a/scripts/manual.ts
+++ b/scripts/manual.ts
@@ -11,7 +11,6 @@ const excludeFilesPath = ['gallery']; // 不处理的路径
 const includeFiles = ['API.zh.md', 'API.en.md'];
 
 const apiGenerator = (sourcePath, targetPath, titlePath) => {
-  console.log(sourcePath, targetPath);
   // 内容不多，同步读取即可
   const titleInfo = fs.readFileSync(titlePath, 'utf-8');
   fs.writeFileSync(targetPath, `${titleInfo}\n`, { encoding: 'utf-8' });

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -162,7 +162,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * 更新配置
    * @param options
    */
-  public update(options: O) {
+  public update(options: Partial<O>) {
     this.options = deepAssign({}, this.options, options);
     this.render();
   }
@@ -206,11 +206,9 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * @param options
    */
   public changeData(data: any) {
-    // 临时方案，会在 G2 做处理
     // @ts-ignore
-    this.update({
-      data,
-    });
+    this.update({ data });
+    // TODO: 临时方案，最好使用下面的方式去更新数据
     // this.chart.changeData(data);
   }
 

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -163,8 +163,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * @param options
    */
   public update(options: O) {
-    // options 更新是全量更新，这里和构造函数中一会加上图表的默认选项
-    this.options = deepAssign({}, this.options, this.getDefaultOptions({ ...this.options, ...options }), options);
+    this.options = deepAssign({}, this.options, options);
     this.render();
   }
 

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -106,11 +106,6 @@ export abstract class Plot<O extends PickOptions> extends EE {
   protected getDefaultOptions(options?: O): any {
     return {
       renderer: 'canvas',
-      tooltip: {
-        shared: true,
-        showMarkers: false,
-        offset: 20,
-      },
       xAxis: {
         nice: true,
         label: {

--- a/src/plots/area/index.ts
+++ b/src/plots/area/index.ts
@@ -13,20 +13,13 @@ export class Area extends Plot<AreaOptions> {
   /**
    * 获取 折线图 默认配置
    */
-  protected getDefaultOptions(options: AreaOptions) {
-    const { xField } = options;
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       tooltip: {
         showMarkers: true,
         showCrosshairs: true,
         crosshairs: {
           type: 'x',
-        },
-      },
-      meta: {
-        [xField]: {
-          type: 'cat',
-          range: [0, 1],
         },
       },
       isStack: true,

--- a/src/plots/bar/adaptor.ts
+++ b/src/plots/bar/adaptor.ts
@@ -9,12 +9,27 @@ import { BarOptions } from './types';
  */
 export function adaptor(params: Params<BarOptions>) {
   const { chart, options } = params;
-  const { xField, yField, xAxis, yAxis, barStyle, barWidthRatio, label, data } = options;
+  const { xField, yField, xAxis, yAxis, barStyle, barWidthRatio, label, data, seriesField, isStack } = options;
 
   // label of bar charts default position is left, if plot has label
   if (label && !label.position) {
     label.position = 'left';
   }
+
+  // 默认 legend 位置
+  let { legend } = options;
+  if (seriesField) {
+    if (legend !== false) {
+      legend = {
+        position: isStack ? 'top-left' : 'right-top',
+        ...legend,
+      };
+    }
+  } else {
+    legend = false;
+  }
+  // @ts-ignore 直接改值
+  params.options.legend = legend;
 
   // transpose column to bar
   chart.coordinate().transpose();

--- a/src/plots/bar/index.ts
+++ b/src/plots/bar/index.ts
@@ -16,37 +16,16 @@ export class Bar extends Plot<BarOptions> {
   /**
    * 获取 条形图 默认配置
    */
-  protected getDefaultOptions(options: BarOptions) {
-    const { isRange, label, xField, yField, isGroup, isStack } = options;
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       barWidthRatio: 0.6,
       marginRatio: 1 / 32,
-      label:
-        label && isRange
-          ? {
-              content: (item: object) => {
-                return item[xField]?.join('-');
-              },
-              ...label,
-            }
-          : label,
       tooltip: {
         shared: true,
         showMarkers: false,
         offset: 20,
       },
-      legend:
-        isGroup || isStack
-          ? {
-              position: isStack ? 'top-left' : 'right-top',
-            }
-          : false,
       interactions: [{ type: 'active-region' }],
-      meta: {
-        [yField]: {
-          type: 'cat',
-        },
-      },
     });
   }
 

--- a/src/plots/bidirectional-bar/adaptor.ts
+++ b/src/plots/bidirectional-bar/adaptor.ts
@@ -6,7 +6,7 @@ import { interval } from '../../adaptor/geometries';
 import { flow, findViewById, findGeometry, transformLabel, deepAssign } from '../../utils';
 import { BidirectionalBarOptions } from './types';
 import { FIRST_AXES_VIEW, SECOND_AXES_VIEW } from './constant';
-import { transformData } from './utils';
+import { isHorizontal, transformData } from './utils';
 
 /**
  * geometry 处理
@@ -36,7 +36,7 @@ function geometry(params: Params<BidirectionalBarOptions>): Params<Bidirectional
   let secondView: View;
 
   // 横向
-  if (layout === 'horizontal') {
+  if (isHorizontal(layout)) {
     firstView = chart.createView({
       region: {
         start: { x: 0, y: 0 },
@@ -54,10 +54,8 @@ function geometry(params: Params<BidirectionalBarOptions>): Params<Bidirectional
       id: SECOND_AXES_VIEW,
     });
     secondView.coordinate().transpose();
-  }
-
-  // 纵向
-  if (layout === 'vertical') {
+  } else {
+    // 纵向
     firstView = chart.createView({
       region: {
         start: { x: 0, y: 0 },
@@ -143,7 +141,7 @@ function meta(params: Params<BidirectionalBarOptions>): Params<BidirectionalBarO
  */
 function axis(params: Params<BidirectionalBarOptions>): Params<BidirectionalBarOptions> {
   const { chart, options } = params;
-  const { xAxis, yAxis, xField, yField } = options;
+  const { xAxis, yAxis, xField, yField, layout } = options;
 
   const firstView = findViewById(chart, FIRST_AXES_VIEW);
   const secondView = findViewById(chart, SECOND_AXES_VIEW);
@@ -154,7 +152,11 @@ function axis(params: Params<BidirectionalBarOptions>): Params<BidirectionalBarO
   if (xAxis === false) {
     firstView.axis(xField, false);
   } else {
-    firstView.axis(xField, xAxis);
+    firstView.axis(xField, {
+      // 不同布局 firstView 的坐标轴显示位置
+      position: isHorizontal(layout) ? 'top' : 'bottom',
+      ...axis,
+    });
   }
 
   if (yAxis === false) {

--- a/src/plots/bidirectional-bar/index.ts
+++ b/src/plots/bidirectional-bar/index.ts
@@ -10,21 +10,14 @@ export class BidirectionalBar extends Plot<BidirectionalBarOptions> {
   /** 图表类型 */
   public type: string = 'bidirectional-bar';
 
+  protected getDefaultOptions() {
+    return deepAssign({}, super.getDefaultOptions());
+  }
+
   /**
    * 获取对称条形图的适配器
    */
   protected getSchemaAdaptor(): Adaptor<BidirectionalBarOptions> {
     return adaptor;
-  }
-
-  protected getDefaultOptions(options: BidirectionalBarOptions) {
-    const { layout = 'horizontal' } = options;
-    return deepAssign({}, super.getDefaultOptions(), {
-      xAxis: {
-        // 不同布局 firstView 的坐标轴显示位置
-        position: layout === 'vertical' ? 'bottom' : 'top',
-      },
-      layout,
-    });
   }
 }

--- a/src/plots/bidirectional-bar/utils.ts
+++ b/src/plots/bidirectional-bar/utils.ts
@@ -1,4 +1,5 @@
 import { Datum } from '../../types';
+import { BidirectionalBarOptions } from '.';
 
 type TransformData = {
   type: string;
@@ -24,4 +25,12 @@ export function transformData(xField: string, yField: string[], data: Datum): Tr
     });
   });
   return hopeData;
+}
+
+/**
+ * 是否横向，默认空为横向
+ * @param layout
+ */
+export function isHorizontal(layout: BidirectionalBarOptions['layout']) {
+  return layout !== 'vertical';
 }

--- a/src/plots/column/index.ts
+++ b/src/plots/column/index.ts
@@ -16,37 +16,16 @@ export class Column extends Plot<ColumnOptions> {
   /**
    * 获取 柱形图 默认配置
    */
-  protected getDefaultOptions(options: ColumnOptions) {
-    const { isRange, label, yField, xField, isGroup, isStack } = options;
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       columnWidthRatio: 0.6,
       marginRatio: 1 / 32,
-      label:
-        label && isRange
-          ? {
-              content: (item: object) => {
-                return item[yField]?.join('-');
-              },
-              ...label,
-            }
-          : label,
       tooltip: {
         shared: true,
         showMarkers: false,
         offset: 20,
       },
-      legend:
-        isGroup || isStack
-          ? {
-              position: isStack ? 'right-top' : 'top-left',
-            }
-          : false,
       interactions: [{ type: 'active-region' }],
-      meta: {
-        [xField]: {
-          type: 'cat',
-        },
-      },
     });
   }
 

--- a/src/plots/dual-axes/index.ts
+++ b/src/plots/dual-axes/index.ts
@@ -1,4 +1,3 @@
-import { every } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { deepAssign } from '../../utils';
@@ -14,35 +13,10 @@ export class DualAxes extends Plot<DualAxesOptions> {
   /**
    * 获取 双轴图 默认配置
    */
-  protected getDefaultOptions(options: DualAxesOptions): Partial<DualAxesOptions> {
-    const { geometryOptions = [], xField } = options;
-    const allLine = every(
-      geometryOptions,
-      ({ geometry }) => geometry === DualAxesGeometry.Line || geometry === undefined
-    );
-    return deepAssign({}, super.getDefaultOptions(options), {
+  protected getDefaultOptions(): Partial<DualAxesOptions> {
+    return deepAssign({}, super.getDefaultOptions(), {
       yAxis: [],
-      geometryOptions,
-      meta: {
-        [xField]: {
-          // x 轴一定是同步 scale 的
-          sync: true,
-          // 如果有没有柱子，则
-          range: allLine ? [0, 1] : undefined,
-        },
-      },
-      tooltip: {
-        showMarkers: allLine,
-        // 存在柱状图，不显示 crosshairs
-        showCrosshairs: allLine,
-        shared: true,
-        crosshairs: {
-          type: 'x',
-        },
-      },
-      interactions: !allLine
-        ? [{ type: 'legend-visible-filter' }, { type: 'active-region' }]
-        : [{ type: 'legend-visible-filter' }],
+      geometryOptions: [],
       syncViewPadding: true,
       legend: {
         position: 'top-left',

--- a/src/plots/funnel/index.ts
+++ b/src/plots/funnel/index.ts
@@ -13,66 +13,36 @@ export class Funnel extends Plot<FunnelOptions> {
   /**
    * 获取 漏斗图 默认配置项
    */
-  protected getDefaultOptions(options: FunnelOptions): Partial<FunnelOptions> {
-    const { xField, yField, dynamicHeight, compareField } = options;
-
-    let additionalOption = {};
-
-    if (dynamicHeight) {
-      additionalOption = {
-        tooltip: {
-          itemTpl:
-            '<li class="g2-tooltip-list-item" data-index={index}>' +
-            '<span style="background-color:{color};" class="g2-tooltip-marker"></span>' +
-            `<span class="g2-tooltip-name">{${xField}}</span>` +
-            `<span class="g2-tooltip-value" style="display: inline-block; float: right; margin-left: 30px;">{${yField}}</span></li>`,
+  protected getDefaultOptions(): Partial<FunnelOptions> {
+    return deepAssign({}, super.getDefaultOptions(), {
+      // annotation 无法自适应 chart，先用 appendPadding hack, 随后看看如何自适应
+      appendPadding: [0, 50],
+      label: {
+        offset: 0,
+        position: 'middle',
+        // layout: {
+        //   type: 'limit-in-shape',
+        // },
+        style: {
+          fill: '#fff',
+          fontSize: 12,
         },
-      };
-    } else if (compareField) {
-      additionalOption = {
-        appendPadding: [50, 50, 0, 50],
-        label: {
-          callback: (xField, yField) => ({
-            content: `${yField}`,
-          }),
-        },
-      };
-    }
-
-    return deepAssign(
-      {},
-      super.getDefaultOptions(),
-      {
-        // annotation 无法自适应 chart，先用 appendPadding hack, 随后看看如何自适应
-        appendPadding: [0, 50],
-        label: {
-          offset: 0,
-          position: 'middle',
-          // layout: {
-          //   type: 'limit-in-shape',
-          // },
-          style: {
-            fill: '#fff',
-            fontSize: 12,
-          },
-          callback: (xField, yField) => ({
-            content: `${xField} ${yField}`,
-          }),
-        },
-        tooltip: {
-          showTitle: false,
-          showMarkers: false,
-          shared: false,
-        },
-        conversionTag: {
-          offsetX: 10,
-          offsetY: 0,
-          style: {},
-          formatter: (datum) => `转化率${(datum.$$percentage$$ * 100).toFixed(2)}%`,
-        },
+        callback: (xField, yField) => ({
+          content: `${xField} ${yField}`,
+        }),
       },
-      additionalOption
-    );
+      tooltip: {
+        showTitle: false,
+        showMarkers: false,
+        shared: false,
+      },
+      conversionTag: {
+        offsetX: 10,
+        offsetY: 0,
+        style: {},
+        formatter: (datum) => `转化率${(datum.$$percentage$$ * 100).toFixed(2)}%`,
+      },
+    });
   }
 
   /**

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -15,6 +15,10 @@ function geometry(params: Params<GaugeOptions>): Params<GaugeOptions> {
   const { chart, options } = params;
   const { percent, range, radius, innerRadius, startAngle, endAngle, axis, indicator } = options;
   const { ticks, color } = range;
+  let clampTicks = ticks;
+  if (!clampTicks?.length) {
+    clampTicks = [0, clamp(percent, 0, 1), 1];
+  }
 
   // 指标 & 指针
   // 如果开启在应用
@@ -43,7 +47,7 @@ function geometry(params: Params<GaugeOptions>): Params<GaugeOptions> {
 
   // 辅助 range
   // [{ range: 1, type: '0' }]
-  const rangeData: Data = processRangeData(ticks as number[]);
+  const rangeData: Data = processRangeData(clampTicks as number[]);
   const v2 = chart.createView();
   v2.data(rangeData);
 
@@ -87,9 +91,22 @@ function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
   const { statistic, percent } = options;
 
   const { title, content } = statistic;
-
+  let transformContent = content;
+  if (content) {
+    transformContent = {
+      formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
+      style: {
+        opacity: 0.75,
+        fontSize: 30,
+        textAlign: 'center',
+        textBaseline: 'bottom',
+      },
+      offsetY: -16,
+      ...content,
+    };
+  }
   // annotation title 和 content 分别使用一个 text
-  [title, content].forEach((annotation) => {
+  [title, transformContent].forEach((annotation) => {
     if (annotation) {
       const { formatter, style, offsetX, offsetY, rotate } = annotation;
       chart.annotation().text({

--- a/src/plots/gauge/index.ts
+++ b/src/plots/gauge/index.ts
@@ -1,4 +1,3 @@
-import { clamp } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { GaugeOptions } from './types';
@@ -16,12 +15,11 @@ export class Gauge extends Plot<GaugeOptions> {
   /** 图表类型 */
   public type: string = 'gauge';
 
-  protected getDefaultOptions(options: GaugeOptions) {
-    const { percent } = options;
+  protected getDefaultOptions() {
     return {
       percent: 0, // 当前指标值
       range: {
-        ticks: [0, clamp(percent, 0, 1), 1],
+        ticks: [],
       }, // 默认的刻度
       innerRadius: 0.9,
       radius: 0.95,
@@ -64,16 +62,6 @@ export class Gauge extends Plot<GaugeOptions> {
       },
       statistic: {
         title: false,
-        content: {
-          formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
-          style: {
-            opacity: 0.75,
-            fontSize: 30,
-            textAlign: 'center',
-            textBaseline: 'bottom',
-          },
-          offsetY: -16,
-        },
       },
       meta: {
         // 两个 view 的 scale 同步到 v 上

--- a/src/plots/histogram/index.ts
+++ b/src/plots/histogram/index.ts
@@ -1,4 +1,3 @@
-import { isNil } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
@@ -11,18 +10,12 @@ export class Histogram extends Plot<HistogramOptions> {
   /** 图表类型 */
   public type: string = 'histogram';
 
-  /**
-   * 获取
-   * @param options
-   */
-  protected getDefaultOptions(options: HistogramOptions) {
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       // @ts-ignore
-      columnStyle: isNil(options.columnStyle?.stroke)
-        ? {
-            stroke: '#FFFFFF',
-          }
-        : {},
+      columnStyle: {
+        stroke: '#FFFFFF',
+      },
     });
   }
 

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -5,6 +5,7 @@ import { tooltip, slider, interaction, animation, theme, scale, annotation } fro
 import { findGeometry, transformLabel, deepAssign } from '../../utils';
 import { point, line } from '../../adaptor/geometries';
 import { flow } from '../../utils';
+import { adjustYMetaByZero } from '../../utils/data';
 import { LineOptions } from './types';
 
 /**
@@ -46,13 +47,22 @@ function geometry(params: Params<LineOptions>): Params<LineOptions> {
  */
 export function meta(params: Params<LineOptions>): Params<LineOptions> {
   const { options } = params;
-  const { xAxis, yAxis, xField, yField } = options;
+  const { xAxis, yAxis, xField, yField, data } = options;
 
   return flow(
-    scale({
-      [xField]: xAxis,
-      [yField]: yAxis,
-    })
+    scale(
+      {
+        [xField]: xAxis,
+        [yField]: yAxis,
+      },
+      {
+        [xField]: {
+          type: 'cat',
+          range: [0, 1],
+        },
+        [yField]: adjustYMetaByZero(data, yField),
+      }
+    )
   )(params);
 }
 

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -1,7 +1,6 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { deepAssign } from '../../utils';
-import { adjustYMetaByZero } from '../../utils/data';
 import { LineOptions } from './types';
 import { adaptor } from './adaptor';
 
@@ -16,9 +15,7 @@ export class Line extends Plot<LineOptions> {
   /**
    * 获取 折线图 默认配置
    */
-  protected getDefaultOptions(options: LineOptions) {
-    const { xField, yField, data } = options;
-
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       tooltip: {
         showMarkers: true,
@@ -29,14 +26,6 @@ export class Line extends Plot<LineOptions> {
       },
       legend: {
         position: 'top-left',
-      },
-      meta: {
-        [xField]: {
-          range: [0, 1],
-        },
-        [yField]: {
-          ...adjustYMetaByZero(data, yField),
-        },
       },
       isStack: false,
     });

--- a/src/plots/scatter/adaptor.ts
+++ b/src/plots/scatter/adaptor.ts
@@ -1,7 +1,8 @@
+import { isBoolean } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { flow, deepAssign } from '../../utils';
 import { point } from '../../adaptor/geometries';
-import { tooltip, interaction, animation, theme, scale, annotation } from '../../adaptor/common';
+import { interaction, animation, theme, scale, annotation } from '../../adaptor/common';
 import { findGeometry, transformLabel } from '../../utils';
 import { getQuadrantDefaultConfig, getPath } from './util';
 import { ScatterOptions } from './types';
@@ -79,8 +80,9 @@ function axis(params: Params<ScatterOptions>): Params<ScatterOptions> {
 function legend(params: Params<ScatterOptions>): Params<ScatterOptions> {
   const { chart, options } = params;
   const { legend, colorField, shapeField, sizeField } = options;
-
-  if (legend) {
+  // legend 没有指定时根据 shapeField 和 colorField 来设置默认值
+  const showLegend = isBoolean(legend) ? legend : legend || !!(shapeField || colorField);
+  if (showLegend) {
     chart.legend(colorField || shapeField, legend);
     // 隐藏连续图例
     if (sizeField) {
@@ -201,6 +203,24 @@ function regressionLine(params: Params<ScatterOptions>): Params<ScatterOptions> 
           },
         });
       },
+    });
+  }
+
+  return params;
+}
+
+/**
+ * tooltip 配置
+ * @param params
+ */
+export function tooltip(params: Params<ScatterOptions>): Params<ScatterOptions> {
+  const { chart, options } = params;
+  const { tooltip, shapeField, colorField, xField, yField, sizeField } = options;
+
+  if (tooltip) {
+    chart.tooltip({
+      fields: [xField, yField, colorField, sizeField, shapeField],
+      ...tooltip,
     });
   }
 

--- a/src/plots/scatter/index.ts
+++ b/src/plots/scatter/index.ts
@@ -1,4 +1,3 @@
-import { isBoolean } from '@antv/util';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { deepAssign } from '../../utils';
@@ -19,20 +18,14 @@ export class Scatter extends Plot<ScatterOptions> {
     return adaptor;
   }
 
-  protected getDefaultOptions(options: ScatterOptions) {
-    const { shapeField, colorField, legend, xField, yField, sizeField } = options;
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       size: 4,
-      /** pointStyle 跟随主题默认样式 */
       tooltip: {
         shared: null,
         showTitle: false,
-        fields: [xField, yField, colorField, sizeField, shapeField],
+        offset: 20,
       },
-      /**
-       * legend 没有指定时根据 shapeField 和 colorField 来设置默认值
-       */
-      legend: isBoolean(legend) ? legend : legend || !!(shapeField || colorField),
     });
   }
 }

--- a/src/plots/sunburst/adaptor.ts
+++ b/src/plots/sunburst/adaptor.ts
@@ -1,8 +1,8 @@
 import { Params } from '../../core/adaptor';
 import { polygon as polygonAdaptor } from '../../adaptor/geometries';
-import { tooltip, interaction, animation, theme, annotation } from '../../adaptor/common';
+import { interaction, animation, theme, annotation } from '../../adaptor/common';
 import { flow, findGeometry, transformLabel, deepAssign } from '../../utils';
-import { transformData } from './utils';
+import { transformData, getTooltipTemplate } from './utils';
 import { SunburstOptions } from './types';
 
 /**
@@ -111,6 +111,34 @@ function scale(params: Params<SunburstOptions>): Params<SunburstOptions> {
   if (meta) {
     // @ts-ignore
     chart.scale(meta);
+  }
+
+  return params;
+}
+
+/**
+ * tooltip 配置
+ * @param params
+ */
+export function tooltip(params: Params<SunburstOptions>): Params<SunburstOptions> {
+  const { chart, options } = params;
+  const { tooltip, seriesField, colorField } = options;
+
+  if (tooltip) {
+    chart.tooltip({
+      ...tooltip,
+      customContent:
+        tooltip && tooltip.customContent
+          ? tooltip.customContent
+          : (value: string, items: any[]) => {
+              return getTooltipTemplate({
+                value,
+                items,
+                formatter: tooltip && tooltip?.formatter,
+                fields: (tooltip && tooltip.fields) || [seriesField, colorField],
+              });
+            },
+    });
   }
 
   return params;

--- a/src/plots/sunburst/index.ts
+++ b/src/plots/sunburst/index.ts
@@ -3,7 +3,6 @@ import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { SunburstOptions } from './types';
 import { adaptor } from './adaptor';
-import { getTooltipTemplate } from './utils';
 
 export { SunburstOptions };
 
@@ -14,26 +13,16 @@ export class Sunburst extends Plot<SunburstOptions> {
   /**
    * 获取旭日图默认配置
    */
-  protected getDefaultOptions(options: SunburstOptions) {
-    const { tooltip, seriesField, colorField } = options;
+  protected getDefaultOptions() {
     return deepAssign({}, super.getDefaultOptions(), {
       type: 'partition',
       innerRadius: 0,
       seriesField: 'value',
       tooltip: {
-        showTitle: false,
+        shared: true,
         showMarkers: false,
-        customContent:
-          tooltip && tooltip.customContent
-            ? tooltip.customContent
-            : (value: string, items: any[]) => {
-                return getTooltipTemplate({
-                  value,
-                  items,
-                  formatter: tooltip && tooltip?.formatter,
-                  fields: (tooltip && tooltip.fields) || [seriesField, colorField],
-                });
-              },
+        offset: 20,
+        showTitle: false,
       },
     });
   }

--- a/src/plots/waterfall/adaptor.ts
+++ b/src/plots/waterfall/adaptor.ts
@@ -2,7 +2,7 @@ import { Geometry } from '@antv/g2';
 import { get } from '@antv/util';
 import { Datum } from '@antv/g2/lib/interface';
 import { Params } from '../../core/adaptor';
-import { tooltip, interaction, animation, theme, state, scale, annotation } from '../../adaptor/common';
+import { interaction, animation, theme, state, scale, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { findGeometry, flow, transformLabel, deepAssign } from '../../utils';
 import { Y_FIELD, ABSOLUTE_FIELD, DIFF_FIELD, IS_TOTAL } from './constants';
@@ -179,6 +179,28 @@ function label(params: Params<WaterfallOptions>): Params<WaterfallOptions> {
       fields: labelMode === 'absolute' ? [ABSOLUTE_FIELD] : [DIFF_FIELD],
       callback,
       cfg: transformLabel(cfg),
+    });
+  }
+
+  return params;
+}
+
+/**
+ * tooltip 配置
+ * @param params
+ */
+export function tooltip(params: Params<WaterfallOptions>): Params<WaterfallOptions> {
+  const { chart, options } = params;
+  const { tooltip, yField } = options;
+
+  if (tooltip) {
+    chart.tooltip({
+      showCrosshairs: false,
+      showMarkers: false,
+      shared: true,
+      // tooltip 默认展示 y 字段值
+      fields: [yField],
+      ...tooltip,
     });
   }
 

--- a/src/plots/waterfall/index.ts
+++ b/src/plots/waterfall/index.ts
@@ -22,16 +22,8 @@ export class Waterfall extends Plot<WaterfallOptions> {
   /**
    * 获取 瀑布图 的默认配置
    */
-  protected getDefaultOptions(options: WaterfallOptions): Partial<WaterfallOptions> {
-    const { yField } = options;
+  protected getDefaultOptions(): Partial<WaterfallOptions> {
     return {
-      tooltip: {
-        showCrosshairs: false,
-        showMarkers: false,
-        shared: true,
-        // tooltip 默认展示 y 字段值
-        fields: [yField],
-      },
       /** default: show label */
       label: {},
       /** default: show leaderLine */

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -9,6 +9,7 @@ import { Data, Datum, Meta } from '../types';
 export function adjustYMetaByZero(data: Data, field: string): Meta {
   const gtZero = data.every((datum: Datum) => get(datum, [field]) > 0);
   const ltZero = data.every((datum: Datum) => get(datum, [field]) < 0);
+  console.log(gtZero);
 
   // 目前是增量更新，对 { min: 0, max: undefined } 进行 update({ max: 0 }) 会得到 { min: 0, max: 0 }
   // 需要添加 undefined 进行覆盖

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -9,7 +9,6 @@ import { Data, Datum, Meta } from '../types';
 export function adjustYMetaByZero(data: Data, field: string): Meta {
   const gtZero = data.every((datum: Datum) => get(datum, [field]) > 0);
   const ltZero = data.every((datum: Datum) => get(datum, [field]) < 0);
-  console.log(gtZero);
 
   // 目前是增量更新，对 { min: 0, max: undefined } 进行 update({ max: 0 }) 会得到 { min: 0, max: 0 }
   // 需要添加 undefined 进行覆盖


### PR DESCRIPTION
#### 问题描述
- 由于当前 getDefaultOptions 依赖于 options ，导致更新的时候需要重复调用  getDefaultOptions，用户是增量更新，调用 getDefaultOptions 时的形参需要 merge 当前 options (this.options)，当前 getDefaultOptions 大多数使用默认值，会存在 bug，修复成本比较高，因此决定 getDefaultOptions 不再依赖 options，在 adaptor 里面处理。

#### 示例
```ts

  /**
   * 更新配置
   * @param options
   */
  public update(options: O) {
    // options 更新是全量更新，这里和构造函数中一会加上图表的默认选项
    // options => {data: []}
    // this.options => { innerRadius: 0.3 }
    this.options = deepAssign({}, this.options, this.getDefaultOptions({ ...this.options, ...options }), options);
    // this.options => {innerRadius: 0, data: []}
    this.render();
  }

  protected getDefaultOptions(options: Options) {
    return deepAssign({}, super.getDefaultOptions(), {
      innerRadius: 0,
    });
  }

```

#### 修复方案

二次更新不再调用 getDefaultOptions
 
```ts
  /**
   * 更新配置
   * @param options
   */
  public update(options: O) {
    this.options = deepAssign({}, this.options, options);
    this.render();
  }
```