### PR TITLE
statistic use html-annotation

### DIFF
--- a/__tests__/bugs/issue-1174-spec.ts
+++ b/__tests__/bugs/issue-1174-spec.ts
@@ -55,17 +55,15 @@ describe('donut plot', () => {
 
     donutPlot.render();
 
-    expect(donutPlot.chart.getController('annotation').getComponents()[1].component.get('content')).toBe(
-      `${reduce(data, (r, d) => r + d.value, 0)}万`
-    );
+    let htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe(`${reduce(data, (r, d) => r + d.value, 0)}万`);
 
     const element = donutPlot.chart.geometries[0].elements[0];
     simulateMouseEvent(element.shape, 'mouseenter');
-    await delay(100);
+    await delay(50);
 
-    expect(donutPlot.chart.getController('annotation').getComponents()[1].component.get('content')).toBe(
-      `${data[0].value} 万`
-    );
+    htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe(`${data[0].value} 万`);
 
     donutPlot.destroy();
   });

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -1,6 +1,5 @@
 import { Gauge } from '../../../../src';
 import { pick } from '../../../../src/utils';
-import { delay } from '../../../utils/delay';
 import { createDiv } from '../../../utils/dom';
 
 describe('gauge', () => {

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -1,9 +1,10 @@
 import { Gauge } from '../../../../src';
 import { pick } from '../../../../src/utils';
+import { delay } from '../../../utils/delay';
 import { createDiv } from '../../../utils/dom';
 
 describe('gauge', () => {
-  it('gauge', () => {
+  it('gauge', async () => {
     const gauge = new Gauge(createDiv(), {
       width: 600,
       height: 300,
@@ -89,7 +90,8 @@ describe('gauge', () => {
     const annotations = gauge.chart.getComponents();
     expect(annotations.length).toBe(1);
     expect(annotations[0].extra.position).toEqual(['50%', '100%']);
-    expect(annotations[0].extra.content).toBe('分数：75');
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('分数：75');
 
     // @ts-ignore
     expect(v2.options.axes).toEqual(undefined);

--- a/__tests__/unit/plots/gauge/statistic-spec.ts
+++ b/__tests__/unit/plots/gauge/statistic-spec.ts
@@ -1,0 +1,50 @@
+import { Gauge } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { delay } from '../../../utils/delay';
+
+describe('gauge statistic', () => {
+  const gauge = new Gauge(createDiv(), {
+    width: 600,
+    height: 300,
+    autoFit: false,
+    percent: 0.65,
+    range: {
+      color: 'l(0) 0:#5d7cef 1:#e35767',
+    },
+  });
+
+  gauge.render();
+
+  it('默认不展示', async () => {
+    await delay(50);
+    const annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(0);
+  });
+
+  it.skip('默认格式化：00.00%', () => {
+    gauge.update({ statistic: { content: {} } });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.00%');
+  });
+
+  it('statistic 配置的格式化方式, 优先级高于 meta', () => {
+    gauge.update({ statistic: { content: { formatter: ({ percent }) => `${percent * 100}.0%` } } });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.0%');
+  });
+
+  it('statistic 配置 title', () => {
+    gauge.update({ statistic: { content: {}, title: {} } });
+    let annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(2);
+    expect((annotations[0] as HTMLElement).innerText).toBe('65.00%');
+
+    gauge.update({ statistic: { content: {}, title: { formatter: () => '测试' } } });
+    annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect((annotations[0] as HTMLElement).innerText).toBe('测试');
+  });
+
+  afterAll(() => {
+    // gauge.destroy();
+  });
+});

--- a/__tests__/unit/plots/gauge/statistic-spec.ts
+++ b/__tests__/unit/plots/gauge/statistic-spec.ts
@@ -21,7 +21,7 @@ describe('gauge statistic', () => {
     expect(annotations.length).toBe(0);
   });
 
-  it.skip('默认格式化：00.00%', () => {
+  it('默认格式化：00.00%', () => {
     gauge.update({ statistic: { content: {} } });
     const annotation = document.body.querySelector('.g2-html-annotation');
     expect((annotation as HTMLElement).innerText).toBe('65.00%');
@@ -37,7 +37,7 @@ describe('gauge statistic', () => {
     gauge.update({ statistic: { content: {}, title: {} } });
     let annotations = document.body.querySelectorAll('.g2-html-annotation');
     expect(annotations.length).toBe(2);
-    expect((annotations[0] as HTMLElement).innerText).toBe('65.00%');
+    expect((annotations[1] as HTMLElement).innerText).toBe('65.0%');
 
     gauge.update({ statistic: { content: {}, title: { formatter: () => '测试' } } });
     annotations = document.body.querySelectorAll('.g2-html-annotation');
@@ -45,6 +45,6 @@ describe('gauge statistic', () => {
   });
 
   afterAll(() => {
-    // gauge.destroy();
+    gauge.destroy();
   });
 });

--- a/__tests__/unit/plots/liquid/statistic-spec.ts
+++ b/__tests__/unit/plots/liquid/statistic-spec.ts
@@ -1,0 +1,65 @@
+import { Liquid } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { delay } from '../../../utils/delay';
+
+describe('liquid statistic', () => {
+  const liquid = new Liquid(createDiv(), {
+    width: 600,
+    height: 300,
+    autoFit: false,
+    percent: 0.65,
+  });
+
+  liquid.render();
+
+  it('默认展示', async () => {
+    await delay(50);
+    const annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(1);
+  });
+
+  it('默认展示当前数值', () => {
+    liquid.update({ statistic: { content: {} } });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.00%');
+  });
+
+  it('使用 meta 格式化', () => {
+    liquid.update({
+      meta: { percent: { formatter: (v) => `${v * 100}.000%` } },
+      statistic: { content: { formatter: null } },
+    });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.000%');
+  });
+
+  it('statistic 配置的格式化方式, 优先级高于 meta', () => {
+    liquid.update({ statistic: { content: { formatter: ({ percent }) => `${percent * 100}.0%` } } });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.0%');
+  });
+
+  it('statistic 配置title', () => {
+    liquid.update({ statistic: { content: {}, title: {} } });
+    let annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(2);
+    expect((annotations[0] as HTMLElement).innerText).toBe('');
+
+    liquid.update({ statistic: { content: {}, title: { formatter: () => '测试' } } });
+    annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect((annotations[0] as HTMLElement).innerText).toBe('测试');
+  });
+
+  it('关闭 statistic', () => {
+    liquid.update({ statistic: { content: null } });
+    let annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(1);
+    liquid.update({ statistic: { content: null, title: null } });
+    annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(0);
+  });
+
+  afterAll(() => {
+    liquid.destroy();
+  });
+});

--- a/__tests__/unit/plots/pie/annotation-spec.ts
+++ b/__tests__/unit/plots/pie/annotation-spec.ts
@@ -29,7 +29,7 @@ describe('annotation', () => {
     });
     expect(pie.chart.getController('annotation').getComponents().length).toBe(3);
     expect(pie.chart.getController('annotation').getComponents()[0].component.get('content')).toBe('辅助文本');
-    expect(pie.chart.getController('annotation').getComponents()[1].component.get('key')).toBe('statistic');
+    expect(pie.chart.getController('annotation').getComponents()[1].component.get('key')).toBe('top-statistic');
   });
 
   it('text annotation and line annotation', () => {

--- a/__tests__/unit/plots/pie/html-statistic-spec.ts
+++ b/__tests__/unit/plots/pie/html-statistic-spec.ts
@@ -1,0 +1,151 @@
+import InteractionContext from '@antv/g2/lib/interaction/context';
+import { Pie } from '../../../../src';
+import { StatisticAction } from '../../../../src/plots/pie/interactions/pie-statistic-action';
+import { POSITIVE_NEGATIVE_DATA } from '../../../data/common';
+import { createDiv } from '../../../utils/dom';
+
+describe('html-statistics', () => {
+  const div = createDiv();
+  const pie = new Pie(div, {
+    data: POSITIVE_NEGATIVE_DATA,
+    width: 400,
+    height: 300,
+    angleField: 'value',
+    colorField: 'type',
+    radius: 0.8,
+    innerRadius: 0.4,
+    statistic: {
+      content: false,
+    },
+  });
+  pie.render();
+
+  it('only title, 居中', () => {
+    const geomCoordinate = pie.chart.geometries[0].coordinate;
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    const box = annotation.getBoundingClientRect();
+    const { top, left } = div.getBoundingClientRect();
+    expect(box.x + box.width / 2).toBeCloseTo(geomCoordinate.getCenter().x + left, 1);
+    expect(box.y + box.height / 2).toBeCloseTo(geomCoordinate.getCenter().y + top, 1);
+  });
+
+  it('only title: 默认居中，设置 offsetY 下移', () => {
+    const offsetY = 8;
+    pie.update({ statistic: { title: { offsetY } } });
+    const geomCoordinate = pie.chart.geometries[0].coordinate;
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    const box = annotation.getBoundingClientRect();
+    const { top, left } = div.getBoundingClientRect();
+    expect(box.x + box.width / 2).toBeCloseTo(geomCoordinate.getCenter().x + left, 1);
+    expect(box.y + box.height / 2).toBeCloseTo(geomCoordinate.getCenter().y + top + offsetY, 1);
+  });
+
+  it('only content, 居中', () => {
+    pie.update({
+      statistic: {
+        title: false,
+        content: {},
+      },
+    });
+    const geomCoordinate = pie.chart.geometries[0].coordinate;
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    const box = annotation.getBoundingClientRect();
+    const { top, left } = div.getBoundingClientRect();
+    expect(box.x + box.width / 2).toBeCloseTo(geomCoordinate.getCenter().x + left, 1);
+    expect(box.y + box.height / 2).toBeCloseTo(geomCoordinate.getCenter().y + top, 1);
+  });
+
+  it('only content: 默认居中，设置 offsetY 下移', () => {
+    const offsetY = -8;
+    pie.update({ statistic: { content: { offsetY } } });
+    const geomCoordinate = pie.chart.geometries[0].coordinate;
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    const box = annotation.getBoundingClientRect();
+    const { top, left } = div.getBoundingClientRect();
+    expect(box.x + box.width / 2).toBeCloseTo(geomCoordinate.getCenter().x + left, 1);
+    expect(box.y + box.height / 2).toBeCloseTo(geomCoordinate.getCenter().y + top + offsetY, 1);
+  });
+
+  it('custom html-statistic', () => {
+    pie.update({
+      statistic: {
+        title: {
+          customHtml: () => {
+            return '测试';
+          },
+        },
+        content: {
+          customHtml: (container, view) => {
+            const data = view.getData();
+            return `${data.reduce((a, b) => a + b.value, 0)}`;
+          },
+        },
+      },
+    });
+    const annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect((annotations[0] as HTMLElement).innerText).toBe('测试');
+    expect((annotations[1] as HTMLElement).innerText).toBe(
+      `${POSITIVE_NEGATIVE_DATA.reduce((a, b) => a + b.value, 0)}`
+    );
+  });
+
+  it('custom html-statistic, 设置 style', () => {
+    let container1;
+    let container2;
+    pie.update({
+      statistic: {
+        title: {
+          style: {
+            whiteSpace: 'pre-wrap',
+          },
+          customHtml: (container, view, datum) => {
+            container1 = container;
+            return datum ? `${datum.type}` : '测试\n测试';
+          },
+        },
+        content: {
+          style: {
+            fontSize: '12px',
+          },
+          customHtml: (container, view, datum, data) => {
+            container2 = container;
+            return datum ? `${datum.value}` : `${data.reduce((a, b) => a + b.value, 0)}\nhello`;
+          },
+        },
+      },
+    });
+    const annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect((annotations[0] as HTMLElement).innerText).toBe('测试\n测试');
+    expect((annotations[1] as HTMLElement).innerText).toBe(
+      `${POSITIVE_NEGATIVE_DATA.reduce((a, b) => a + b.value, 0)} hello`
+    );
+    const coordinate = pie.chart.getCoordinate();
+    const actualInnerRadius = coordinate.getRadius() * pie.options.innerRadius;
+    expect(parseFloat(container1.style.width)).toBe(actualInnerRadius * 2);
+    expect(parseFloat(container2.style.width)).toBe(actualInnerRadius * 2);
+    expect(container1.style['white-space']).toBe('pre-wrap');
+    expect(container2.style['font-size']).toBe('12px');
+  });
+
+  it('custom html-statistic: 触发交互', () => {
+    pie.render();
+    const context = new InteractionContext(pie.chart);
+    const action = new StatisticAction(context);
+    const triggerData = POSITIVE_NEGATIVE_DATA[2];
+
+    context.event = { type: 'custom', data: { data: triggerData } };
+    action.change();
+
+    const annotations = document.querySelectorAll('.g2-html-annotation');
+    expect((annotations[0] as HTMLElement).innerText).toBe(`${triggerData.type}`);
+    expect((annotations[1] as HTMLElement).innerText).toBe(`${triggerData.value}`);
+  });
+
+  afterEach(() => {
+    pie.chart.clear();
+  });
+
+  afterAll(() => {
+    pie.destroy();
+  });
+});

--- a/__tests__/unit/plots/pie/html-statistic-spec.ts
+++ b/__tests__/unit/plots/pie/html-statistic-spec.ts
@@ -36,6 +36,7 @@ describe('html-statistics', () => {
     const annotation = document.body.querySelector('.g2-html-annotation');
     const box = annotation.getBoundingClientRect();
     const { top, left } = div.getBoundingClientRect();
+    expect(box.width).toBeCloseTo(geomCoordinate.getRadius() * pie.options.innerRadius * 2);
     expect(box.x + box.width / 2).toBeCloseTo(geomCoordinate.getCenter().x + left, 1);
     expect(box.y + box.height / 2).toBeCloseTo(geomCoordinate.getCenter().y + top + offsetY, 1);
   });
@@ -67,6 +68,7 @@ describe('html-statistics', () => {
   });
 
   it('custom html-statistic', () => {
+    const offsetY = 8;
     pie.update({
       statistic: {
         title: {
@@ -75,6 +77,7 @@ describe('html-statistics', () => {
           },
         },
         content: {
+          offsetY,
           customHtml: (container, view) => {
             const data = view.getData();
             return `${data.reduce((a, b) => a + b.value, 0)}`;
@@ -87,6 +90,11 @@ describe('html-statistics', () => {
     expect((annotations[1] as HTMLElement).innerText).toBe(
       `${POSITIVE_NEGATIVE_DATA.reduce((a, b) => a + b.value, 0)}`
     );
+    const box0 = annotations[0].getBoundingClientRect();
+    const box = annotations[1].getBoundingClientRect();
+    const geomCoordinate = pie.chart.geometries[0].coordinate;
+    expect(box0.width).toBeCloseTo(geomCoordinate.getRadius() * pie.options.innerRadius * 2);
+    expect(box.width).toBeCloseTo(geomCoordinate.getRadius() * pie.options.innerRadius * 2);
   });
 
   it('custom html-statistic, 设置 style', () => {

--- a/__tests__/unit/plots/pie/html-statistic-spec.ts
+++ b/__tests__/unit/plots/pie/html-statistic-spec.ts
@@ -3,6 +3,7 @@ import { Pie } from '../../../../src';
 import { StatisticAction } from '../../../../src/plots/pie/interactions/pie-statistic-action';
 import { POSITIVE_NEGATIVE_DATA } from '../../../data/common';
 import { createDiv } from '../../../utils/dom';
+import { delay } from '../../../utils/delay';
 
 describe('html-statistics', () => {
   const div = createDiv();

--- a/__tests__/unit/plots/pie/interaction-spec.ts
+++ b/__tests__/unit/plots/pie/interaction-spec.ts
@@ -39,9 +39,11 @@ describe('register interaction', () => {
   const context = new InteractionContext(pie.chart);
   const action = new StatisticAction(context);
 
-  it('触发 pie-statistic:change', () => {
+  it('触发 pie-statistic:change', async () => {
     context.event = { type: 'custom', data: { data: { type: 'item3', value: 13 } } };
     action.change();
+
+    await delay(50);
 
     const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
     expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('item3' /** 中心文本指标卡，默认title */);

--- a/__tests__/unit/plots/pie/interaction-spec.ts
+++ b/__tests__/unit/plots/pie/interaction-spec.ts
@@ -40,20 +40,20 @@ describe('register interaction', () => {
   const action = new StatisticAction(context);
 
   it('触发 pie-statistic:change', () => {
-    context.event = { data: { data: { type: 'item3', value: 13 } } };
+    context.event = { type: 'custom', data: { data: { type: 'item3', value: 13 } } };
     action.change();
 
-    const annotations = context.view.getComponents().filter((co) => co.type === 'annotation');
-    expect(annotations[0].extra.content).toBe('item3');
-    expect(annotations[1].extra.content).toBe(13);
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('item3' /** 中心文本指标卡，默认title */);
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe('13');
   });
 
   it('触发 pie-statistic:reset', async () => {
     action.reset();
 
     delay(500);
-    const annotations = context.view.getComponents().filter((co) => co.type === 'annotation');
-    expect(annotations[0].component.get('content')).toBe('Total');
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('Total' /** 中心文本指标卡，默认title */);
   });
 
   afterAll(() => {

--- a/__tests__/unit/plots/pie/statistic-spec.ts
+++ b/__tests__/unit/plots/pie/statistic-spec.ts
@@ -311,8 +311,8 @@ describe('statistic', () => {
       const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
       expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('总计' /** 中心文本指标卡，默认title */);
       expect((htmlAnnotations[1] as HTMLElement).innerText).toBe(`test\ntest ${totalValue}`);
-    }, 400);
+    }, 50);
 
-    // pie.destroy();
+    pie.destroy();
   });
 });

--- a/__tests__/unit/plots/pie/statistic-spec.ts
+++ b/__tests__/unit/plots/pie/statistic-spec.ts
@@ -26,10 +26,6 @@ describe('中心文本 - 指标卡', () => {
   const pie = new Pie(createDiv(), config);
   pie.render();
 
-  afterAll(() => {
-    pie.destroy();
-  });
-
   it('没有设置 inner radius，不展示中心文本指标卡', () => {
     expect(getAnnotations(pie.chart).length).toBe(0);
   });
@@ -43,7 +39,8 @@ describe('中心文本 - 指标卡', () => {
 
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBeGreaterThan(0);
-    expect(annotations[0].component.get('content')).toBe('总计' /** 中心文本指标卡，默认title */);
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('总计' /** 中心文本指标卡，默认title */);
   });
 
   it('自定义中心文本内容: update statistic title & content', () => {
@@ -64,8 +61,20 @@ describe('中心文本 - 指标卡', () => {
 
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBeGreaterThan(0);
-    expect(annotations[0].component.get('content')).toBe('总计');
-    expect(annotations[1].component.get('content')).toBe('test\ntest');
+    let htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('总计' /** 中心文本指标卡，默认title */);
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe('test test');
+
+    pie.update({
+      statistic: {
+        content: {
+          style: { whiteSpace: 'pre-wrap' },
+          formatter: () => 'test\ntest',
+        },
+      },
+    });
+    htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe('test\ntest');
   });
 
   it('自定义中心文本内容: update statistic title & content, 动态数据', async () => {
@@ -77,6 +86,7 @@ describe('中心文本 - 指标卡', () => {
           formatter: (datum) => (!datum ? '总计' : datum['type']),
         },
         content: {
+          style: { whiteSpace: 'pre-wrap' },
           formatter: (datum) => {
             return !datum ? 'test\ntest' : `${datum.value}`;
           },
@@ -89,20 +99,24 @@ describe('中心文本 - 指标卡', () => {
 
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBeGreaterThan(0);
-    expect(annotations[0].component.get('content')).toBe('总计');
-    expect(annotations[1].component.get('content')).toBe('test\ntest');
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('总计' /** 中心文本指标卡，默认title */);
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe('test\ntest');
+
+    pie.chart.clear();
   });
 
-  it('自定义中心文本样式: update statistic title style & content style', async () => {
-    await delay(300);
+  it('自定义中心文本样式: 兼容 shapeStyle', async () => {
     pie.update({
       ...pie.options,
       statistic: {
         title: {
           formatter: () => '',
+          // @ts-ignore
           style: { fill: 'red' },
         },
         content: {
+          // @ts-ignore
           style: { fill: 'pink' },
         },
       },
@@ -111,22 +125,25 @@ describe('中心文本 - 指标卡', () => {
     pie.render();
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBe(2);
-    expect(annotations[0].component.get('content')).toBe('');
-    expect(annotations[0].extra.key).toBe('statistic');
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('' /** 中心文本指标卡，默认title */);
+    expect(annotations[0].extra.key).toBe('top-statistic');
+    expect(annotations[1].extra.key).toBe('bottom-statistic');
     expect(annotations[0].extra.style).toMatchObject({ fill: 'red' });
     expect(annotations[1].extra.style).toMatchObject({ fill: 'pink' });
   });
 
-  it('自定义中心文本样式: with callback', async () => {
-    await delay(500);
+  it('自定义中心文本样式: 兼容 ShapeStyle with callback', async () => {
     pie.update({
       ...pie.options,
       statistic: {
         title: {
           formatter: () => '',
+          // @ts-ignore
           style: { fill: 'red' },
         },
         content: {
+          // @ts-ignore
           style: { fill: 'pink' },
         },
       },
@@ -135,10 +152,19 @@ describe('中心文本 - 指标卡', () => {
     pie.render();
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBe(2);
-    expect(annotations[0].component.get('content')).toBe('');
-    expect(annotations[0].extra.key).toBe('statistic');
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('' /** 中心文本指标卡，默认title */);
+    expect(annotations[0].extra.key).toBe('top-statistic');
     expect(annotations[0].extra.style).toMatchObject({ fill: 'red' });
     expect(annotations[1].extra.style).toMatchObject({ fill: 'pink' });
+  });
+
+  afterEach(() => {
+    pie.chart.clear();
+  });
+
+  afterAll(() => {
+    pie.destroy();
   });
 });
 
@@ -153,7 +179,9 @@ describe('statistic', () => {
 
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBe(2);
-    expect(annotations[1].component.get('content')).toBe(null);
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[1] as HTMLElement).innerText).not.toBe('null');
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe('');
 
     pie.destroy();
   });
@@ -221,22 +249,25 @@ describe('statistic', () => {
 
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBeGreaterThan(0);
-    expect(annotations[0].component.get('content')).toBe('总计');
-    expect(annotations[1].component.get('content')).toBe('test\ntest');
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('总计' /** 中心文本指标卡，默认title */);
+    expect((htmlAnnotations[1] as HTMLElement).innerText).toBe('test test');
 
     pie.destroy();
   });
 
-  it('自定义中心文本样式: title style & content style', () => {
+  it('自定义中心文本样式: 兼容 shapeStyle', () => {
     const pie = new Pie(createDiv(), {
       ...config,
       innerRadius: 0.64,
       statistic: {
         title: {
           formatter: () => '',
+          // @ts-ignore
           style: { fill: 'red' },
         },
         content: {
+          // @ts-ignore
           style: { fill: 'pink' },
         },
       },
@@ -245,8 +276,9 @@ describe('statistic', () => {
     pie.render();
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBe(2);
-    expect(annotations[0].component.get('content')).toBe('');
-    expect(annotations[0].extra.key).toBe('statistic');
+    const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+    expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('' /** 中心文本指标卡，默认title */);
+    expect(annotations[0].extra.key).toBe('top-statistic');
     expect(annotations[0].extra.style).toMatchObject({ fill: 'red' });
     expect(annotations[1].extra.style).toMatchObject({ fill: 'pink' });
 
@@ -275,9 +307,12 @@ describe('statistic', () => {
 
     const annotations = getAnnotations(pie.chart);
     expect(annotations.length).toBeGreaterThan(0);
-    expect(annotations[0].component.get('content')).toBe('总计');
-    expect(annotations[1].component.get('content')).toBe(`test\ntest ${totalValue}`);
+    setTimeout(() => {
+      const htmlAnnotations = document.querySelectorAll('.g2-html-annotation');
+      expect((htmlAnnotations[0] as HTMLElement).innerText).toBe('总计' /** 中心文本指标卡，默认title */);
+      expect((htmlAnnotations[1] as HTMLElement).innerText).toBe(`test\ntest ${totalValue}`);
+    }, 400);
 
-    pie.destroy();
+    // pie.destroy();
   });
 });

--- a/__tests__/unit/plots/pie/utils/index-spec.ts
+++ b/__tests__/unit/plots/pie/utils/index-spec.ts
@@ -1,4 +1,4 @@
-import { adaptOffset, getTotalValue } from '../../../../src/plots/pie/utils';
+import { adaptOffset, getTotalValue } from '../../../../../src/plots/pie/utils';
 
 describe('utils of pie plot', () => {
   const data = [

--- a/__tests__/unit/plots/pie/utils/statistic-spec.ts
+++ b/__tests__/unit/plots/pie/utils/statistic-spec.ts
@@ -1,0 +1,49 @@
+import { adapteStyle, setStatisticContainerStyle } from '../../../../../src/plots/pie/utils/statistic';
+import { ShapeStyle } from '../../../../../src/types';
+import { createDiv } from '../../../../utils/dom';
+
+describe('饼图 statistics 相关处理函数', () => {
+  it('adapteStyle', () => {
+    const style = {
+      fontSize: '12px',
+      lineHeight: '12px',
+    };
+    expect(adapteStyle(style)).toMatchObject({
+      'font-size': '12px',
+      'line-height': '12px',
+    });
+  });
+
+  it('adapteStyle 兼容 shapeStyle', () => {
+    const style: ShapeStyle = {
+      shadowBlur: 5,
+      shadowOffsetY: 2,
+      shadowColor: 'red',
+    };
+
+    // @ts-ignore
+    expect(adapteStyle(style)).toMatchObject({
+      'text-shadow': 'red 0px 2px 5px',
+    });
+
+    const style1: ShapeStyle = {
+      fill: 'red',
+      lineWidth: 1,
+      stroke: 'green',
+    };
+    // @ts-ignore
+    expect(adapteStyle(style1)).toMatchObject({
+      color: 'red',
+      '-webkit-text-stroke': '1px green',
+    });
+  });
+
+  it('设置statistics容器样式', () => {
+    const container = createDiv();
+    setStatisticContainerStyle(container, { color: '', fontSize: '12px' });
+    // 默认穿透
+    expect(container.style['pointerEvents']).toBe('none');
+    expect(container.style.color).toBe('');
+    expect(container.style.fontSize).toBe('12px');
+  });
+});

--- a/__tests__/unit/plots/pie/utils/statistic-spec.ts
+++ b/__tests__/unit/plots/pie/utils/statistic-spec.ts
@@ -1,4 +1,4 @@
-import { adapteStyle, setStatisticContainerStyle } from '../../../../../src/plots/pie/utils/statistic';
+import { adapteStyle, setStatisticContainerStyle } from '../../../../../src/utils/statistic';
 import { ShapeStyle } from '../../../../../src/types';
 import { createDiv } from '../../../../utils/dom';
 

--- a/__tests__/unit/plots/ring-progress/index-spec.ts
+++ b/__tests__/unit/plots/ring-progress/index-spec.ts
@@ -275,7 +275,8 @@ describe('ring-progress', () => {
   });
 
   it('style callback', () => {
-    const ring = new RingProgress(createDiv(), {
+    const div = createDiv();
+    const ring = new RingProgress(div, {
       width: 200,
       height: 100,
       percent: 0.6,
@@ -285,7 +286,7 @@ describe('ring-progress', () => {
         content: {
           style: ({ percent }) => {
             return {
-              fontSize: 20 * percent,
+              fontSize: `${20 * percent}px`,
               textAlign: 'center',
               textBaseline: 'middle',
             };
@@ -296,7 +297,10 @@ describe('ring-progress', () => {
 
     ring.render();
 
-    expect(ring.chart.getController('annotation').getComponents()[0].component.get('style').fontSize).toBe(20 * 0.6);
+    setTimeout(() => {
+      const annotation = div.querySelector('.g2-html-annotation');
+      expect((annotation as HTMLElement).style['font-size']).toBe(`${20 * 0.6}px`);
+    }, 50);
 
     ring.destroy();
   });

--- a/__tests__/unit/plots/ring-progress/statistic-spec.ts
+++ b/__tests__/unit/plots/ring-progress/statistic-spec.ts
@@ -1,0 +1,58 @@
+import { RingProgress } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { delay } from '../../../utils/delay';
+
+describe('ringProgress statistic', () => {
+  const ringProgress = new RingProgress(createDiv(), {
+    radius: 1,
+    innerRadius: 0.5,
+    width: 200,
+    height: 100,
+    percent: 0.65,
+    autoFit: false,
+  });
+
+  ringProgress.render();
+
+  it('默认展示', async () => {
+    await delay(50);
+    const annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(1);
+  });
+
+  it('默认展示当前数值', () => {
+    ringProgress.update({ statistic: { content: {} } });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.00%');
+  });
+
+  it('使用 meta 格式化', () => {
+    ringProgress.update({
+      meta: { percent: { formatter: (v) => `${v * 100}.000%` } },
+      statistic: { content: { formatter: null } },
+    });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.000%');
+  });
+
+  it('statistic 配置的格式化方式, 优先级高于 meta', () => {
+    ringProgress.update({ statistic: { content: { formatter: ({ percent }) => `${percent * 100}.0%` } } });
+    const annotation = document.body.querySelector('.g2-html-annotation');
+    expect((annotation as HTMLElement).innerText).toBe('65.0%');
+  });
+
+  it('statistic 配置title', () => {
+    ringProgress.update({ statistic: { content: {}, title: {} } });
+    let annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(2);
+    expect((annotations[0] as HTMLElement).innerText).toBe('');
+
+    ringProgress.update({ statistic: { content: {}, title: { formatter: () => '测试' } } });
+    annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect((annotations[0] as HTMLElement).innerText).toBe('测试');
+  });
+
+  afterAll(() => {
+    ringProgress.destroy();
+  });
+});

--- a/__tests__/unit/utils/kebab-case-spec.ts
+++ b/__tests__/unit/utils/kebab-case-spec.ts
@@ -1,0 +1,13 @@
+import { kebabCase } from '../../../src/utils';
+
+describe('kebabCase', () => {
+  it('kebabCase', () => {
+    expect(kebabCase(null)).toEqual(null);
+    expect(kebabCase('')).toEqual('');
+    expect(kebabCase('AAA')).toEqual('a-a-a');
+
+    expect(kebabCase('fontSize')).toEqual('font-size');
+    expect(kebabCase('aBBB')).toEqual('a-b-b-b');
+    expect(kebabCase('aBcDeFggggHHH')).toEqual('a-bc-de-fgggg-h-h-h');
+  });
+});

--- a/docs/common/component-no-axis.zh.md
+++ b/docs/common/component-no-axis.zh.md
@@ -10,7 +10,7 @@
 
 `markdown:docs/common/legend.zh.md`
 
-#### 图表标注
+#### annotations
 
 `markdown:docs/common/annotations.zh.md`
 

--- a/docs/common/component-polygon.zh.md
+++ b/docs/common/component-polygon.zh.md
@@ -2,7 +2,7 @@
 
 `markdown:docs/common/tooltip.zh.md`
 
-#### 图表标注
+#### annotations
 
 `markdown:docs/common/annotations.zh.md`
 

--- a/docs/common/component-progress.zh.md
+++ b/docs/common/component-progress.zh.md
@@ -2,7 +2,7 @@
 
 `markdown:docs/common/tooltip.zh.md`
 
-#### 图表标注
+#### annotations
 
 `markdown:docs/common/annotations.zh.md`
 

--- a/docs/common/component-tiny.zh.md
+++ b/docs/common/component-tiny.zh.md
@@ -8,7 +8,7 @@ xAxis、yAxis 配置相同。
 
 `markdown:docs/common/axis.zh.md`
 
-#### 图表标注
+#### annotations
 
 `markdown:docs/common/annotations.zh.md`
 

--- a/docs/common/component.zh.md
+++ b/docs/common/component.zh.md
@@ -16,6 +16,6 @@ xAxis、yAxis 配置相同（由于 DualAxes 是双轴， yAxis 类型是数组�
 
 `markdown:docs/common/legend.zh.md`
 
-#### 图表标注
+#### annotations
 
 `markdown:docs/common/annotations.zh.md`

--- a/docs/common/statistic.zh.md
+++ b/docs/common/statistic.zh.md
@@ -7,7 +7,8 @@ StatisticText
 
 | 配置项    | 类型     | 描述                 |
 | --------- | -------- | -------------------- |
-| style     | object   | 统计文本的样式       |
+| style     | CSSStyleDeclaration | 统计文本的样式 (css 样式)      |
+| customHtml | `(container: HTMLElement, view: View, datum: object, data: object[]) => string;` | 自定义主体文本的 html，优先级高于 formatter |
 | formatter | Function | 主体文本的格式化内容 |
 | rotate    | number   | 旋转角度             |
 | offsetX   | number   | X 偏移值             |

--- a/docs/manual/plots/liquid.zh.md
+++ b/docs/manual/plots/liquid.zh.md
@@ -33,7 +33,9 @@ order: 12
 
 `markdown:docs/common/color.zh.md`
 
-#### statistic
+### 图表组件
+
+#### statistic ✨
 
 <description>**optional** _object_</description>
 

--- a/docs/manual/plots/pie.en.md
+++ b/docs/manual/plots/pie.en.md
@@ -87,7 +87,7 @@ piePlot.render();
 
 <description>**optional** _object_</description>
 
-统计内容组件。
+统计内容组件。当内半径(`innerRadius`) 大于 0 时才生效，默认展示汇总值，可以通过 `formatter` 格式化展示内容，也可以通过 `customHtml` 自定义更多的内容。
 
 ![image](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
 
@@ -101,6 +101,6 @@ piePlot.render();
 
 `markdown:docs/common/chart-methods.en.md`
 
-### theme
+### Theme
 
 `markdown:docs/common/theme.en.md`

--- a/docs/manual/plots/pie.en.md
+++ b/docs/manual/plots/pie.en.md
@@ -83,6 +83,16 @@ piePlot.render();
 
 `markdown:docs/common/component-no-axis.en.md`
 
+#### statistic ✨
+
+<description>**optional** _object_</description>
+
+统计内容组件。
+
+![](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
+
+`markdown:docs/common/statistic.zh.md`
+
 ### Event
 
 `markdown:docs/common/events.en.md`

--- a/docs/manual/plots/pie.en.md
+++ b/docs/manual/plots/pie.en.md
@@ -89,7 +89,7 @@ piePlot.render();
 
 统计内容组件。
 
-![](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
+![image](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
 
 `markdown:docs/common/statistic.zh.md`
 

--- a/docs/manual/plots/pie.zh.md
+++ b/docs/manual/plots/pie.zh.md
@@ -75,7 +75,7 @@ piePlot.render();
 
 统计内容组件。
 
-![](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
+![image](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
 
 `markdown:docs/common/statistic.zh.md`
 

--- a/docs/manual/plots/pie.zh.md
+++ b/docs/manual/plots/pie.zh.md
@@ -73,7 +73,7 @@ piePlot.render();
 
 <description>**optional** _object_</description>
 
-统计内容组件。
+统计内容组件。当内半径(`innerRadius`) 大于 0 时才生效，默认展示汇总值，可以通过 `formatter` 格式化展示内容，也可以通过 `customHtml` 自定义更多的内容。
 
 ![image](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
 

--- a/docs/manual/plots/pie.zh.md
+++ b/docs/manual/plots/pie.zh.md
@@ -69,6 +69,16 @@ piePlot.render();
 
 `markdown:docs/common/color.zh.md`
 
+#### statistic ✨
+
+<description>**optional** _object_</description>
+
+统计内容组件。
+
+![](https://gw.alipayobjects.com/zos/bmw-prod/860bbf6e-cf20-4bdf-88bd-e8d685d12e9a.svg)
+
+`markdown:docs/common/statistic.zh.md`
+
 #### pieStyle 
 
 <description>**optional** _object_</description>

--- a/docs/manual/plots/ring-progress.zh.md
+++ b/docs/manual/plots/ring-progress.zh.md
@@ -39,6 +39,10 @@ order: 19
 
 `markdown:docs/common/color.zh.md`
 
+### 图表组件
+
+`markdown:docs/common/component-progress.zh.md`
+
 #### statistic
 
 <description>**optional** _object_</description>
@@ -46,7 +50,3 @@ order: 19
 统计内容组件，主要包含 title、content 来部分内容。
 
 `markdown:docs/common/statistic.zh.md`
-
-### 图表组件
-
-`markdown:docs/common/component-progress.zh.md`

--- a/examples/gauge/basic/demo/basic.ts
+++ b/examples/gauge/basic/demo/basic.ts
@@ -14,10 +14,10 @@ const gauge = new Gauge('container', {
   statistic: {
     content: {
       style: {
-        fontSize: 48,
+        fontSize: '48px',
+        lineHeight: '48px',
         textBaseline: 'bottom',
       },
-      offsetY: -60,
     },
   },
 });

--- a/examples/liquid/basic/demo/basic.ts
+++ b/examples/liquid/basic/demo/basic.ts
@@ -1,5 +1,23 @@
 import { Liquid } from '@antv/g2plot';
+import { isString, memoize, values } from '@antv/util';
 
+const ctx = document.createElement('canvas').getContext('2d');
+/**
+ * 计算文本在画布中的宽度
+ */
+const measureTextWidth = memoize(
+  (text, font) => {
+    const { fontSize, fontFamily = 'sans-serif', fontWeight, fontStyle, fontVariant } = font;
+    // @see https://developer.mozilla.org/zh-CN/docs/Web/CSS/font
+    ctx.font = [fontStyle, fontWeight, fontVariant, `${fontSize}px`, fontFamily].join(' ');
+    const metrics = ctx.measureText(isString(text) ? text : '');
+    return {
+      width: metrics.width,
+      height: Math.abs(metrics.actualBoundingBoxAscent - metrics.actualBoundingBoxDescent),
+    };
+  },
+  (text, font) => [text, ...values(font)].join('')
+);
 const liquidPlot = new Liquid('container', {
   percent: 0.25,
   statistic: {
@@ -7,6 +25,16 @@ const liquidPlot = new Liquid('container', {
       style: {
         fontSize: 60,
         fill: 'black',
+      },
+      customHtml: (container, view) => {
+        const circle = view.geometries[0].elements[0].shape.find((t) => t.get('type') === 'circle');
+        const { width, height } = circle.getCanvasBBox();
+        const d = Math.sqrt(Math.pow(width / 2, 2) + Math.pow(height / 2, 2));
+        const textWidth = measureTextWidth('25%', { fontSize: 60 }).width;
+        const scale = Math.min(d / textWidth, 1);
+        return `<div style="width:${d}px;height:${d}px;display:flex;align-items:center;justify-content:center;font-size:${scale}em;line-height:${
+          scale <= 1 ? 1 : 'inherit'
+        }">25%</div>`;
       },
     },
   },

--- a/examples/liquid/basic/demo/style.ts
+++ b/examples/liquid/basic/demo/style.ts
@@ -1,16 +1,16 @@
 import { Liquid } from '@antv/g2plot';
 
 const liquidPlot = new Liquid(document.getElementById('container'), {
-  percent: 0.76,
+  percent: 0.26,
   statistic: {
     content: {
       formatter: ({ percent }) => {
         return `占比 ${percent * 100}%`;
       },
-      style: {
+      style: ({ percent }) => ({
         fontSize: 60,
-        fill: 'white',
-      },
+        fill: percent > 0.5 ? 'white' : 'rgba(44,53,66,0.85)',
+      }),
     },
   },
   liquidStyle: ({ percent }) => {

--- a/examples/pie/basic/demo/basic.ts
+++ b/examples/pie/basic/demo/basic.ts
@@ -18,9 +18,8 @@ const piePlot = new Pie('container', {
   label: {
     type: 'inner',
     offset: '-30%',
-    content: '{percentage}',
+    content: ({ percent }) => `${percent * 100}%`,
     style: {
-      fill: '#fff',
       fontSize: 14,
       textAlign: 'center',
     },

--- a/examples/pie/donut/demo/basic.ts
+++ b/examples/pie/donut/demo/basic.ts
@@ -21,6 +21,7 @@ const piePlot = new Pie('container', {
     offset: '-50%',
     content: '{value}',
     style: {
+      textAlign: 'center',
       fontSize: 14,
     },
   },

--- a/examples/pie/donut/demo/basic.ts
+++ b/examples/pie/donut/demo/basic.ts
@@ -14,7 +14,7 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 1,
+  radius: 0.8,
   innerRadius: 0.6,
   label: {
     type: 'inner',
@@ -22,7 +22,6 @@ const piePlot = new Pie('container', {
     content: '{value}',
     style: {
       fontSize: 14,
-      textAlign: 'center',
     },
   },
   interactions: [{ type: 'element-selected' }, { type: 'element-active' }],

--- a/examples/pie/donut/demo/basic.ts
+++ b/examples/pie/donut/demo/basic.ts
@@ -31,6 +31,8 @@ const piePlot = new Pie('container', {
     content: {
       style: {
         whiteSpace: 'pre-wrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
       },
       formatter: () => 'AntV\nG2Plot',
     },

--- a/examples/pie/donut/demo/basic.ts
+++ b/examples/pie/donut/demo/basic.ts
@@ -14,7 +14,7 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 0.8,
+  radius: 1,
   innerRadius: 0.6,
   label: {
     type: 'inner',

--- a/examples/pie/donut/demo/basic.ts
+++ b/examples/pie/donut/demo/basic.ts
@@ -14,14 +14,13 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 0.8,
+  radius: 1,
   innerRadius: 0.6,
   label: {
     type: 'inner',
     offset: '-50%',
-    content: '{percentage}',
+    content: '{value}',
     style: {
-      fill: '#fff',
       fontSize: 14,
       textAlign: 'center',
     },
@@ -31,7 +30,7 @@ const piePlot = new Pie('container', {
     title: false,
     content: {
       style: {
-        fontSize: 44,
+        whiteSpace: 'pre-wrap',
       },
       formatter: () => 'AntV\nG2Plot',
     },

--- a/examples/pie/donut/demo/custom-statistics.ts
+++ b/examples/pie/donut/demo/custom-statistics.ts
@@ -1,0 +1,98 @@
+import { Pie } from '@antv/g2plot';
+import { isString, memoize, values } from '@antv/util';
+
+const ctx = document.createElement('canvas').getContext('2d');
+/**
+ * 计算文本在画布中的宽度
+ */
+const measureTextWidth = memoize(
+  (text, font) => {
+    const { fontSize, fontFamily = 'sans-serif', fontWeight, fontStyle, fontVariant } = font;
+    // @see https://developer.mozilla.org/zh-CN/docs/Web/CSS/font
+    ctx!.font = [fontStyle, fontWeight, fontVariant, `${fontSize}px`, fontFamily].join(' ');
+    const metrics = ctx!.measureText(isString(text) ? text : '');
+    return {
+      width: metrics.width,
+      height: Math.abs(metrics.actualBoundingBoxAscent - metrics.actualBoundingBoxDescent),
+    };
+  },
+  (text: any, font) => [text, ...values(font)].join('')
+);
+
+function renderStatistic(containerWidth: number, text: string, style) {
+  const { width: textWidth, height: textHeight } = measureTextWidth(text, style);
+  const R = containerWidth / 2;
+  // r^2 = (w / 2)^2 + (h - offsetY)^2
+  let scale = 1;
+  if (containerWidth < textWidth) {
+    scale = Math.min(Math.sqrt(Math.abs(Math.pow(R, 2) / (Math.pow(textWidth / 2, 2) + Math.pow(textHeight, 2)))), 1);
+  }
+  const textStyleStr = `width:${containerWidth}px;`;
+  return `<div style="${textStyleStr};font-size:${scale}em;line-height:${scale < 1 ? 1 : 'inherit'};">${text}</div>`;
+}
+
+const data = [
+  { type: '分类一', value: 27 },
+  { type: '分类二', value: 25 },
+  { type: '分类三', value: 18 },
+  { type: '分类四', value: 15 },
+  { type: '分类五', value: 10 },
+  { type: '其他', value: 5 },
+];
+
+const piePlot = new Pie('container', {
+  appendPadding: 10,
+  data,
+  angleField: 'value',
+  colorField: 'type',
+  radius: 0.8,
+  innerRadius: 0.64,
+  meta: {
+    value: {
+      formatter: (v) => `${v} ¥`,
+    },
+  },
+  label: {
+    type: 'inner',
+    offset: '-50%',
+    autoRotate: false,
+    content: '{value}',
+    style: {
+      textAlign: 'center',
+    },
+  },
+  statistic: {
+    title: {
+      offsetY: -4,
+      style: {
+        fontSize: 28,
+      },
+      customHtml: (container, view, datum) => {
+        const coordinate = view.getCoordinate();
+        const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
+        container.style['width'] = `${containerWidth}px`;
+
+        const text = datum ? datum.type : '总计';
+        return renderStatistic(containerWidth, text, { fontSize: 28 });
+      },
+    },
+    content: {
+      offsetY: 4,
+      style: {
+        fontSize: '32px',
+      },
+      customHtml: (container, view, datum, data) => {
+        const coordinate = view.getCoordinate();
+        const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
+        container.style['width'] = `${containerWidth}px`;
+
+        const text = datum ? `¥ ${datum.value}` : `¥ ${data.reduce((r, d) => r + d.value, 0)}`;
+        return renderStatistic(containerWidth, text, { fontSize: 32 });
+      },
+    },
+  },
+  // 添加 中心统计文本 交互
+  interactions: [{ type: 'element-selected' }, { type: 'element-active' }, { type: 'pie-statistic-active' }],
+});
+
+piePlot.render();

--- a/examples/pie/donut/demo/custom-statistics.ts
+++ b/examples/pie/donut/demo/custom-statistics.ts
@@ -55,6 +55,9 @@ const piePlot = new Pie('container', {
   label: {
     type: 'inner',
     offset: '-50%',
+    style: {
+      textAlign: 'center',
+    },
     autoRotate: false,
     content: '{value}',
   },

--- a/examples/pie/donut/demo/custom-statistics.ts
+++ b/examples/pie/donut/demo/custom-statistics.ts
@@ -45,7 +45,7 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 0.8,
+  radius: 1,
   innerRadius: 0.64,
   meta: {
     value: {
@@ -57,16 +57,10 @@ const piePlot = new Pie('container', {
     offset: '-50%',
     autoRotate: false,
     content: '{value}',
-    style: {
-      textAlign: 'center',
-    },
   },
   statistic: {
     title: {
       offsetY: -4,
-      style: {
-        fontSize: 28,
-      },
       customHtml: (container, view, datum) => {
         const coordinate = view.getCoordinate();
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;

--- a/examples/pie/donut/demo/custom-statistics.ts
+++ b/examples/pie/donut/demo/custom-statistics.ts
@@ -84,7 +84,6 @@ const piePlot = new Pie('container', {
       customHtml: (container, view, datum, data) => {
         const coordinate = view.getCoordinate();
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
-        container.style['width'] = `${containerWidth}px`;
 
         const text = datum ? `¥ ${datum.value}` : `¥ ${data.reduce((r, d) => r + d.value, 0)}`;
         return renderStatistic(containerWidth, text, { fontSize: 32 });

--- a/examples/pie/donut/demo/custom-statistics.ts
+++ b/examples/pie/donut/demo/custom-statistics.ts
@@ -9,17 +9,17 @@ const measureTextWidth = memoize(
   (text, font) => {
     const { fontSize, fontFamily = 'sans-serif', fontWeight, fontStyle, fontVariant } = font;
     // @see https://developer.mozilla.org/zh-CN/docs/Web/CSS/font
-    ctx!.font = [fontStyle, fontWeight, fontVariant, `${fontSize}px`, fontFamily].join(' ');
-    const metrics = ctx!.measureText(isString(text) ? text : '');
+    ctx.font = [fontStyle, fontWeight, fontVariant, `${fontSize}px`, fontFamily].join(' ');
+    const metrics = ctx.measureText(isString(text) ? text : '');
     return {
       width: metrics.width,
       height: Math.abs(metrics.actualBoundingBoxAscent - metrics.actualBoundingBoxDescent),
     };
   },
-  (text: any, font) => [text, ...values(font)].join('')
+  (text, font) => [text, ...values(font)].join('')
 );
 
-function renderStatistic(containerWidth: number, text: string, style) {
+function renderStatistic(containerWidth, text, style) {
   const { width: textWidth, height: textHeight } = measureTextWidth(text, style);
   const R = containerWidth / 2;
   // r^2 = (w / 2)^2 + (h - offsetY)^2

--- a/examples/pie/donut/demo/meta.json
+++ b/examples/pie/donut/demo/meta.json
@@ -15,7 +15,15 @@
     {
       "filename": "statistics.ts",
       "title": {
-        "zh": "环图 - 带统计指标卡",
+        "zh": "环图统计指标卡",
+        "en": "Donut plot with statistics"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*U9D_Sr55LEMAAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "custom-statistics.ts",
+      "title": {
+        "zh": "自定义环图统计指标卡",
         "en": "Donut plot with statistics"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*U9D_Sr55LEMAAAAAAAAAAABkARQnAQ"

--- a/examples/pie/donut/demo/statistics.ts
+++ b/examples/pie/donut/demo/statistics.ts
@@ -14,14 +14,20 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 0.8,
+  radius: 1,
   innerRadius: 0.64,
   meta: {
     value: {
       formatter: (v) => `¥ ${v}`,
     },
   },
-  label: { formatter: ({ percent }) => `${percent * 100} %` },
+  label: {
+    type: 'inner',
+    offset: '-50%',
+    autoRotate: false,
+    style: { textAlign: 'center' },
+    formatter: ({ percent }) => `${percent * 100}%`,
+  },
   statistic: {
     title: {
       offsetY: -8,

--- a/examples/pie/donut/demo/statistics.ts
+++ b/examples/pie/donut/demo/statistics.ts
@@ -14,20 +14,20 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 1,
+  radius: 0.8,
   innerRadius: 0.64,
   meta: {
     value: {
       formatter: (v) => `¥ ${v}`,
     },
   },
-  label: null,
+  label: { formatter: ({ percent }) => `${percent * 100} %` },
   statistic: {
     title: {
-      offsetY: -4,
+      offsetY: -8,
     },
     content: {
-      offsetY: 4,
+      offsetY: -4,
     },
   },
   // 添加 中心统计文本 交互

--- a/examples/pie/donut/demo/statistics.ts
+++ b/examples/pie/donut/demo/statistics.ts
@@ -14,38 +14,40 @@ const piePlot = new Pie('container', {
   data,
   angleField: 'value',
   colorField: 'type',
-  radius: 0.8,
+  radius: 1,
   innerRadius: 0.64,
-  label: {
-    type: 'inner',
-    offset: -35,
-    autoRotate: false,
-    content: '{value}',
-    style: {
-      fill: '#333',
-      stroke: '#fff',
-      strokeWidth: 1,
+  meta: {
+    value: {
+      formatter: (v) => `¥ ${v}`,
     },
   },
-  interactions: [{ type: 'element-selected' }, { type: 'element-active' }],
+  label: null,
   statistic: {
     title: {
-      offsetY: -20,
-      style: {
-        fontSize: 44,
-      },
-      formatter: (datum) => (datum ? datum.type : '总计'),
+      offsetY: -4,
     },
     content: {
-      offsetY: 30,
-      style: {
-        fontSize: 44,
-      },
-      formatter: (datum, data) => (datum ? `¥ ${datum.value}` : `¥ ${data.reduce((r, d) => r + d.value, 0)}`),
+      offsetY: 4,
     },
   },
   // 添加 中心统计文本 交互
-  interactions: [{ type: 'pie-statistic-active' }],
+  interactions: [
+    { type: 'element-selected' },
+    { type: 'element-active' },
+    {
+      type: 'pie-statistic-active',
+      cfg: {
+        start: [
+          { trigger: 'element:mouseenter', action: 'pie-statistic:change' },
+          { trigger: 'legend-item:mouseenter', action: 'pie-statistic:change' },
+        ],
+        end: [
+          { trigger: 'element:mouseleave', action: 'pie-statistic:reset' },
+          { trigger: 'legend-item:mouseleave', action: 'pie-statistic:reset' },
+        ],
+      },
+    },
+  ],
 });
 
 piePlot.render();

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -108,13 +108,12 @@ function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
   renderGaugeStatistic(
     chart,
     {
-      radius,
-      innerRadius,
       statistic: {
         title,
         content: transformContent,
       },
     },
+    { content: { field: 'percent', ...get(meta, 'percent', {}) } },
     { percent }
   );
 

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -1,4 +1,4 @@
-import { isString, clamp, get } from '@antv/util';
+import { isString, clamp } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
 import { Data } from '../../types';
@@ -89,7 +89,7 @@ function meta(params: Params<GaugeOptions>): Params<GaugeOptions> {
  */
 function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
   const { chart, options } = params;
-  const { statistic, percent, meta } = options;
+  const { statistic, percent } = options;
 
   if (statistic) {
     const { content } = statistic;

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -1,8 +1,8 @@
-import { isString, isFunction, clamp } from '@antv/util';
+import { isString, get, clamp } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
 import { Data } from '../../types';
-import { flow } from '../../utils';
+import { flow, renderGaugeStatistic } from '../../utils';
 import { RANGE_TYPE, RANGE_VALUE, PERCENT, DEFAULT_COLOR } from './constant';
 import { GaugeOptions } from './types';
 import { processRangeData } from './utils';
@@ -88,7 +88,7 @@ function meta(params: Params<GaugeOptions>): Params<GaugeOptions> {
  */
 function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
   const { chart, options } = params;
-  const { statistic, percent } = options;
+  const { statistic, percent, radius, innerRadius, meta } = options;
 
   const { title, content } = statistic;
   let transformContent = content;
@@ -97,29 +97,42 @@ function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
       formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
       style: {
         opacity: 0.75,
-        fontSize: 30,
+        fontSize: '30px',
         textAlign: 'center',
-        textBaseline: 'bottom',
+        // textBaseline: 'bottom',
       },
       offsetY: -16,
       ...content,
     };
   }
-  // annotation title 和 content 分别使用一个 text
-  [title, transformContent].forEach((annotation) => {
-    if (annotation) {
-      const { formatter, style, offsetX, offsetY, rotate } = annotation;
-      chart.annotation().text({
-        top: true,
-        position: ['50%', '100%'],
-        content: isFunction(formatter) ? formatter({ percent }) : `${percent}`,
-        style: isFunction(style) ? style({ percent }) : style,
-        offsetX,
-        offsetY,
-        rotate,
-      });
-    }
-  });
+  renderGaugeStatistic(
+    chart,
+    {
+      radius,
+      innerRadius,
+      statistic: {
+        title,
+        content: transformContent,
+      },
+    },
+    { percent }
+  );
+
+  // // annotation title 和 content 分别使用一个 text
+  // [title, transformContent].forEach((annotation) => {
+  //   if (annotation) {
+  //     const { formatter, style, offsetX, offsetY, rotate } = annotation;
+  //     chart.annotation().html({
+  //       top: true,
+  //       position: ['50%', '100%'],
+  //       html: () => isFunction(formatter) ? formatter({ percent }) : `${percent}`,
+  //       style: isFunction(style) ? style({ percent }) : style,
+  //       offsetX,
+  //       offsetY,
+  //       rotate,
+  //     });
+  //   }
+  // });
 
   return params;
 }

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -1,4 +1,4 @@
-import { isString, get, clamp } from '@antv/util';
+import { isString, clamp, get } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
 import { Data } from '../../types';
@@ -78,6 +78,7 @@ function meta(params: Params<GaugeOptions>): Params<GaugeOptions> {
         maxLimit: 1,
         minLimit: 0,
       },
+      [PERCENT]: {},
     })
   )(params);
 }
@@ -88,50 +89,27 @@ function meta(params: Params<GaugeOptions>): Params<GaugeOptions> {
  */
 function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
   const { chart, options } = params;
-  const { statistic, percent, radius, innerRadius, meta } = options;
+  const { statistic, percent, meta } = options;
 
-  const { title, content } = statistic;
-  let transformContent = content;
-  if (content) {
-    transformContent = {
-      formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
-      style: {
-        opacity: 0.75,
-        fontSize: '30px',
-        textAlign: 'center',
-        // textBaseline: 'bottom',
-      },
-      offsetY: -16,
-      ...content,
-    };
+  if (statistic) {
+    const { content } = statistic;
+    let transformContent;
+    // 当设置 content 的时候，设置默认样式
+    if (content) {
+      transformContent = {
+        formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
+        style: {
+          opacity: 0.75,
+          fontSize: '30px',
+          lineHeight: 1,
+          textAlign: 'center',
+          color: 'rgba(44,53,66,0.85)',
+        },
+        ...content,
+      };
+    }
+    renderGaugeStatistic(chart, { statistic: { ...statistic, content: transformContent } }, { percent });
   }
-  renderGaugeStatistic(
-    chart,
-    {
-      statistic: {
-        title,
-        content: transformContent,
-      },
-    },
-    { content: { field: 'percent', ...get(meta, 'percent', {}) } },
-    { percent }
-  );
-
-  // // annotation title 和 content 分别使用一个 text
-  // [title, transformContent].forEach((annotation) => {
-  //   if (annotation) {
-  //     const { formatter, style, offsetX, offsetY, rotate } = annotation;
-  //     chart.annotation().html({
-  //       top: true,
-  //       position: ['50%', '100%'],
-  //       html: () => isFunction(formatter) ? formatter({ percent }) : `${percent}`,
-  //       style: isFunction(style) ? style({ percent }) : style,
-  //       offsetX,
-  //       offsetY,
-  //       rotate,
-  //     });
-  //   }
-  // });
 
   return params;
 }

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -65,12 +65,7 @@ function statistic(params: Params<LiquidOptions>): Params<LiquidOptions> {
   const { chart, options } = params;
   const { statistic, percent, radius, meta } = options;
 
-  renderStatistic(
-    chart,
-    { radius, innerRadius: radius, statistic },
-    { content: get(meta, 'percent', { field: 'percent' }) },
-    { percent }
-  );
+  renderStatistic(chart, { statistic }, { content: { field: 'percent', ...get(meta, 'percent', {}) } }, { percent });
 
   return params;
 }

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -1,8 +1,8 @@
 import { Geometry } from '@antv/g2';
-import { isFunction } from '@antv/util';
+import { get } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow, deepAssign } from '../../utils';
+import { flow, deepAssign, renderStatistic } from '../../utils';
 import { interval } from '../../adaptor/geometries';
 import { LiquidOptions } from './types';
 
@@ -63,28 +63,14 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
  */
 function statistic(params: Params<LiquidOptions>): Params<LiquidOptions> {
   const { chart, options } = params;
-  const { statistic, percent } = options;
+  const { statistic, percent, radius, meta } = options;
 
-  const { title, content } = statistic;
-
-  // annotation title 和 content 分别使用一个 text
-  [title, content].forEach((annotation) => {
-    if (annotation) {
-      const { formatter, style, offsetX, offsetY, rotate } = annotation;
-      chart.annotation().text({
-        top: true,
-        position: {
-          type: CAT_VALUE,
-          percent: 0.5,
-        },
-        content: isFunction(formatter) ? formatter({ percent }) : `${percent}`,
-        style: isFunction(style) ? style({ percent }) : style,
-        offsetX,
-        offsetY,
-        rotate,
-      });
-    }
-  });
+  renderStatistic(
+    chart,
+    { radius, innerRadius: radius, statistic },
+    { content: get(meta, 'percent', { field: 'percent' }) },
+    { percent }
+  );
 
   return params;
 }

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -63,7 +63,14 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
  */
 function statistic(params: Params<LiquidOptions>): Params<LiquidOptions> {
   const { chart, options } = params;
-  const { statistic, percent } = options;
+  const { statistic, percent, meta } = options;
+
+  if (statistic.content && !statistic.content.formatter) {
+    const metaFormatter = get(meta, ['percent', 'formatter']);
+    // @ts-ignore
+    statistic.content.formatter = ({ percent }) =>
+      metaFormatter ? metaFormatter(percent) : `${(percent * 100).toFixed(2)}%`;
+  }
 
   renderStatistic(chart, { statistic }, { percent });
 

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -63,9 +63,9 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
  */
 function statistic(params: Params<LiquidOptions>): Params<LiquidOptions> {
   const { chart, options } = params;
-  const { statistic, percent, radius, meta } = options;
+  const { statistic, percent } = options;
 
-  renderStatistic(chart, { statistic }, { content: { field: 'percent', ...get(meta, 'percent', {}) } }, { percent });
+  renderStatistic(chart, { statistic }, { percent });
 
   return params;
 }

--- a/src/plots/liquid/index.ts
+++ b/src/plots/liquid/index.ts
@@ -24,7 +24,7 @@ export class Liquid extends Plot<LiquidOptions> {
           formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
           style: {
             opacity: 0.75,
-            fontSize: 30,
+            fontSize: '30px',
             textAlign: 'center',
           },
         },

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -178,6 +178,7 @@ function statistic(params: Params<PieOptions>): Params<PieOptions> {
   if (innerRadius && statistic) {
     chart.once('afterrender', () => {
       renderStatistic(chart, options);
+      chart.render(true);
     });
     chart.on('afterchangesize', () => {
       // todo 完善 G2 清除局部 annotation 的方法
@@ -186,6 +187,7 @@ function statistic(params: Params<PieOptions>): Params<PieOptions> {
       controller.option = controller.option.filter((opt) => !`${opt.key || ''}`.match('statistic'));
       controller.update();
       renderStatistic(chart, options);
+      chart.render(true);
     });
   }
 

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -1,4 +1,4 @@
-import { every, filter, isFunction, isString, isNil } from '@antv/util';
+import { every, filter, isFunction, isString, isNil, get } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
@@ -173,7 +173,7 @@ function statistic(params: Params<PieOptions>): Params<PieOptions> {
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
-    renderStatistic(chart, options, { content: meta[angleField] });
+    renderStatistic(chart, { statistic }, { content: { field: angleField, ...get(meta, angleField, {}) } });
   }
 
   return params;

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -176,19 +176,7 @@ function statistic(params: Params<PieOptions>): Params<PieOptions> {
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
-    chart.once('afterrender', () => {
-      renderStatistic(chart, options);
-      chart.render(true);
-    });
-    chart.on('afterchangesize', () => {
-      // todo 完善 G2 清除局部 annotation 的方法
-      const controller = chart.getController('annotation');
-      // @ts-ignore
-      controller.option = controller.option.filter((opt) => !`${opt.key || ''}`.match('statistic'));
-      controller.update();
-      renderStatistic(chart, options);
-      chart.render(true);
-    });
+    renderStatistic(chart, options);
   }
 
   return flow(annotation(annotationOptions))(params);

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -2,10 +2,9 @@ import { every, filter, isFunction, isString, isNil } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
-import { flow, LEVEL, log, template, transformLabel, deepAssign } from '../../utils';
+import { flow, LEVEL, log, template, transformLabel, deepAssign, renderStatistic } from '../../utils';
 import { adaptOffset } from './utils';
 import { PieOptions } from './types';
-import { renderStatistic } from './utils/statistic';
 
 /**
  * 字段
@@ -170,16 +169,14 @@ function label(params: Params<PieOptions>): Params<PieOptions> {
  */
 function statistic(params: Params<PieOptions>): Params<PieOptions> {
   const { chart, options } = params;
-  const { innerRadius, statistic } = options;
-
-  const annotationOptions = [];
+  const { innerRadius, statistic, angleField, meta } = options;
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
-    renderStatistic(chart, options);
+    renderStatistic(chart, options, { content: meta[angleField] });
   }
 
-  return flow(annotation(annotationOptions))(params);
+  return params;
 }
 
 /**

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -32,10 +32,16 @@ export class Pie extends Plot<PieOptions> {
       /** 饼图中心文本默认样式 */
       statistic: {
         title: {
-          style: { fontWeight: 300, color: '#4D4D4D', textAlign: 'center', fontSize: '28px', lineHeight: 1 },
+          style: { fontWeight: 300, color: '#4B535E', textAlign: 'center', fontSize: '20px', lineHeight: 1 },
         },
         content: {
-          style: { fontWeight: 'bold', color: '#4D4D4D', textAlign: 'center', fontSize: '32px', lineHeight: 1 },
+          style: {
+            fontWeight: 'bold',
+            color: 'rgba(44,53,66,0.85)',
+            textAlign: 'center',
+            fontSize: '32px',
+            lineHeight: 1,
+          },
         },
       },
       /** 默认关闭 text-annotation 动画 */

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -22,6 +22,7 @@ export class Pie extends Plot<PieOptions> {
       tooltip: {
         shared: false,
         showTitle: false,
+        showMarkers: false,
       },
       /** 饼图样式, 不影响暗黑主题 */
       pieStyle: {
@@ -31,10 +32,10 @@ export class Pie extends Plot<PieOptions> {
       /** 饼图中心文本默认样式 */
       statistic: {
         title: {
-          style: { fontSize: 14, fontWeight: 300, fill: '#4D4D4D', textAlign: 'center' },
+          style: { fontWeight: 300, color: '#4D4D4D', textAlign: 'center', fontSize: '28px', lineHeight: 1 },
         },
         content: {
-          style: { fontSize: 21, fontWeight: 'bold', fill: '#4D4D4D', textAlign: 'center' },
+          style: { fontWeight: 'bold', color: '#4D4D4D', textAlign: 'center', fontSize: '32px', lineHeight: 1 },
         },
       },
       /** 默认关闭 text-annotation 动画 */

--- a/src/plots/pie/interactions/pie-statistic-action.ts
+++ b/src/plots/pie/interactions/pie-statistic-action.ts
@@ -2,7 +2,7 @@ import { Action } from '@antv/g2/lib/interaction';
 import { ComponentOption } from '@antv/g2/lib/interface';
 import { getDelegationObject } from '@antv/g2/lib/interaction/action/util';
 import { each, get } from '@antv/util';
-import { adapteStyle, setStatisticContainerStyle } from '../utils/statistic';
+import { adapteStyle, setStatisticContainerStyle } from '../../../utils/statistic';
 
 /**
  * Pie 中心文本事件的 Action

--- a/src/plots/pie/interactions/pie-statistic-action.ts
+++ b/src/plots/pie/interactions/pie-statistic-action.ts
@@ -2,7 +2,7 @@ import { Action } from '@antv/g2/lib/interaction';
 import { ComponentOption } from '@antv/g2/lib/interface';
 import { getDelegationObject } from '@antv/g2/lib/interaction/action/util';
 import { each, get } from '@antv/util';
-import { adapteStyle } from '../utils/statistic';
+import { adapteStyle, setStatisticContainerStyle } from '../utils/statistic';
 
 /**
  * Pie 中心文本事件的 Action
@@ -78,14 +78,12 @@ export class StatisticAction extends Action {
             const coordinate = view.getCoordinate();
             const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
 
-            container.style['pointer-events'] = 'none';
-            container.style['width'] = `${containerWidth}px`;
-            container.style.transform = transform;
-            each(adapteStyle(option.style), (v, k) => {
-              container.style[k] = v;
+            setStatisticContainerStyle(container, {
+              ...adapteStyle(option.style),
+              width: `${containerWidth}px`,
+              transform,
             });
             const filteredData = view.getData();
-
             if (option.customHtml) {
               return option.customHtml(container, view, data, filteredData);
             }

--- a/src/plots/pie/interactions/pie-statistic-action.ts
+++ b/src/plots/pie/interactions/pie-statistic-action.ts
@@ -1,6 +1,8 @@
 import { Action } from '@antv/g2/lib/interaction';
 import { ComponentOption } from '@antv/g2/lib/interface';
-import { each, get, isFunction } from '@antv/util';
+import { getDelegationObject } from '@antv/g2/lib/interaction/action/util';
+import { each, get } from '@antv/util';
+import { adapteStyle } from '../utils/statistic';
 
 /**
  * Pie 中心文本事件的 Action
@@ -8,9 +10,10 @@ import { each, get, isFunction } from '@antv/util';
 export class StatisticAction extends Action {
   private initialAnnotation;
 
-  private getAnnotations() {
+  private getAnnotations(): object[] {
     const view = this.context.view;
-    return view.getComponents().filter((co) => co.type === 'annotation');
+    // @ts-ignore
+    return view.getController('annotation').option;
   }
 
   private getInitialAnnotation(): ComponentOption[] | null {
@@ -20,6 +23,11 @@ export class StatisticAction extends Action {
   init() {
     const { view } = this.context;
     view.removeInteraction('tooltip');
+
+    view.on('afterchangesize', () => {
+      const annotations = this.getAnnotations();
+      this.initialAnnotation = annotations;
+    });
   }
 
   public change() {
@@ -29,7 +37,17 @@ export class StatisticAction extends Action {
       this.initialAnnotation = annotations;
     }
 
-    const { data } = event.data;
+    let { data } = event?.data || {};
+    if (event.type.match('legend-item')) {
+      const delegateObject = getDelegationObject(this.context);
+      // @ts-ignore
+      const colorField = view.getGroupedFields()[0];
+      if (delegateObject && colorField) {
+        const { item } = delegateObject;
+        data = view.getData().find((d) => d[colorField] === item.value);
+      }
+    }
+
     if (data) {
       const annotationController = view.getController('annotation');
       annotationController.clear(true);
@@ -38,29 +56,45 @@ export class StatisticAction extends Action {
       const angleScale = view.getScaleByField(angleField);
       const colorScale = view.getScaleByField(colorField);
 
-      const annotationOptions = annotations.filter((a) => get(a, 'extra.key') !== 'statistic').map((a) => a.extra);
-      const statisticOptions = annotations.filter((a) => get(a, 'extra.key') === 'statistic').map((a) => a.extra || {});
+      const annotationOptions = annotations.filter((a) => !get(a, 'key', '').match('statistic'));
+      const statisticOptions = annotations.filter((a) => get(a, 'key', '').match('statistic'));
 
-      each(statisticOptions, (options, idx) => {
-        let value;
-        if (idx === 0) {
-          // title
-          value = colorScale ? colorScale.getText(data[colorField]) : null;
+      const titleOpt = statisticOptions.filter((opt: any) => opt.key === 'top-statistic');
+      const contentOpt = statisticOptions.filter((opt: any) => opt.key === 'top-statistic');
+      each(statisticOptions, (option) => {
+        let text;
+        let transform;
+        if (option.key === 'top-statistic') {
+          text = colorScale ? colorScale.getText(data[colorField]) : null;
+          transform = contentOpt ? 'translate(-50%, -100%)' : 'translate(-50%, -50%)';
         } else {
-          value = angleScale ? angleScale.getText(data[angleField]) : data[angleField];
+          text = angleScale ? angleScale.getText(data[angleField]) : data[angleField];
+          transform = titleOpt ? 'translate(-50%, 0)' : 'translate(-50%,-50%)';
         }
 
         annotationOptions.push({
-          ...options,
-          content: isFunction(options.content) ? options.content(view.getData(), data) : value,
+          ...option,
+          html: (container, view) => {
+            const filteredData = view.getData();
+
+            container.style['pointer-events'] = 'none';
+            container.style.transform = transform;
+            each(adapteStyle(option.style), (v, k) => {
+              container.style[k] = v;
+            });
+            if (option.customHtml) {
+              return option.customHtml(container, view, data, filteredData);
+            }
+
+            return (option.formatter && option.formatter(data, filteredData)) || `${text}`;
+          },
         });
+        annotationOptions.forEach((opt) => {
+          // @ts-ignore
+          annotationController.annotation(opt);
+        });
+        view.render(true);
       });
-      annotationOptions.forEach((opt) => {
-        // todo remove ignore
-        // @ts-ignore
-        annotationController.annotation(opt);
-      });
-      view.render(true);
     }
   }
 
@@ -70,7 +104,7 @@ export class StatisticAction extends Action {
     annotationController.clear(true);
     const initialStatistic = this.getInitialAnnotation();
     each(initialStatistic, (a) => {
-      view.annotation().text(get(a, 'extra', {}));
+      view.annotation()[a.type](a);
     });
     view.render(true);
   }

--- a/src/plots/pie/interactions/pie-statistic-action.ts
+++ b/src/plots/pie/interactions/pie-statistic-action.ts
@@ -75,13 +75,17 @@ export class StatisticAction extends Action {
         annotationOptions.push({
           ...option,
           html: (container, view) => {
-            const filteredData = view.getData();
+            const coordinate = view.getCoordinate();
+            const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
 
             container.style['pointer-events'] = 'none';
+            container.style['width'] = `${containerWidth}px`;
             container.style.transform = transform;
             each(adapteStyle(option.style), (v, k) => {
               container.style[k] = v;
             });
+            const filteredData = view.getData();
+
             if (option.customHtml) {
               return option.customHtml(container, view, data, filteredData);
             }

--- a/src/plots/pie/interactions/pie-statistic-action.ts
+++ b/src/plots/pie/interactions/pie-statistic-action.ts
@@ -79,9 +79,10 @@ export class StatisticAction extends Action {
             const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
 
             setStatisticContainerStyle(container, {
-              ...adapteStyle(option.style),
               width: `${containerWidth}px`,
               transform,
+              // user's style setting has high priority
+              ...adapteStyle(option.style),
             });
             const filteredData = view.getData();
             if (option.customHtml) {

--- a/src/plots/pie/types.ts
+++ b/src/plots/pie/types.ts
@@ -25,5 +25,5 @@ export interface PieOptions extends Options {
    * 指标卡组件: 显示在环图中心，可以代替tooltip，显示环图数据的总计值和各项数据
    * 启用 statistic 组件的同时将自动关闭tooltip
    */
-  readonly statistic?: Statistic;
+  readonly statistic?: Statistic<CSSStyleDeclaration>;
 }

--- a/src/plots/pie/types.ts
+++ b/src/plots/pie/types.ts
@@ -25,5 +25,5 @@ export interface PieOptions extends Options {
    * 指标卡组件: 显示在环图中心，可以代替tooltip，显示环图数据的总计值和各项数据
    * 启用 statistic 组件的同时将自动关闭tooltip
    */
-  readonly statistic?: Statistic<Partial<CSSStyleDeclaration>>;
+  readonly statistic?: Statistic;
 }

--- a/src/plots/pie/types.ts
+++ b/src/plots/pie/types.ts
@@ -25,5 +25,5 @@ export interface PieOptions extends Options {
    * 指标卡组件: 显示在环图中心，可以代替tooltip，显示环图数据的总计值和各项数据
    * 启用 statistic 组件的同时将自动关闭tooltip
    */
-  readonly statistic?: Statistic<CSSStyleDeclaration>;
+  readonly statistic?: Statistic<Partial<CSSStyleDeclaration>>;
 }

--- a/src/plots/pie/utils/index.ts
+++ b/src/plots/pie/utils/index.ts
@@ -1,6 +1,6 @@
 import { Data } from '@antv/g2/lib/interface';
 import { each, isString } from '@antv/util';
-import { PieLabelType } from './types';
+import { PieLabelType } from '../types';
 
 /**
  * 获取总计值

--- a/src/plots/pie/utils/kebab-case.ts
+++ b/src/plots/pie/utils/kebab-case.ts
@@ -1,0 +1,13 @@
+/**
+ * @desc simple kebabCase like lodash
+ *
+ * kebabCase('fooBar'); => 'foo-bar'
+ */
+export function kebabCase(word: string) {
+  const result = word.match(/(([A-Z]{0,1}[a-z]*[^A-Z])|([A-Z]{1}))/g);
+  return result
+    ? result.reduce((a, b) => {
+        return `${a ? `${a}-` : ''}` + b.toLowerCase();
+      })
+    : '';
+}

--- a/src/plots/pie/utils/statistic.ts
+++ b/src/plots/pie/utils/statistic.ts
@@ -92,9 +92,10 @@ export const renderStatistic = (
         const coordinate = view.getCoordinate();
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
         setStatisticContainerStyle(container, {
-          ...adapteStyle(titleOpt.style),
           transform: contentOpt ? 'translate(-50%, -100%)' : 'translate(-50%, -50%)',
           width: `${containerWidth}px`,
+          // user's style setting has high priority
+          ...adapteStyle(titleOpt.style),
         });
 
         const filteredData = view.getData();
@@ -127,9 +128,10 @@ export const renderStatistic = (
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
 
         setStatisticContainerStyle(container, {
-          ...adapteStyle(contentOpt.style),
           transform: titleOpt ? 'translate(-50%, 0)' : 'translate(-50%, -50%)',
           width: `${containerWidth}px`,
+          // user's style setting has high priority
+          ...adapteStyle(contentOpt.style),
         });
 
         const filteredData = view.getData();
@@ -157,4 +159,6 @@ export const renderStatistic = (
       ...pick(contentOpt, ['style', 'formatter']),
     });
   }
+
+  chart.render(true);
 };

--- a/src/plots/pie/utils/statistic.ts
+++ b/src/plots/pie/utils/statistic.ts
@@ -75,14 +75,17 @@ export const renderStatistic = (
     chart.annotation().html({
       position: ['50%', '50%'],
       html: (container, view) => {
-        const filteredData = view.getData();
+        const coordinate = view.getCoordinate();
+        const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
 
         container.style['pointer-events'] = 'none';
+        container.style['width'] = `${containerWidth}px`;
         container.style.transform = contentOpt ? 'translate(-50%, -100%)' : 'translate(-50%, -50%)';
         each(adapteStyle(titleOpt.style), (v, k) => {
           container.style[k] = v;
         });
 
+        const filteredData = view.getData();
         if (titleOpt.customHtml) {
           return titleOpt.customHtml(container, view, null, filteredData);
         }
@@ -108,12 +111,17 @@ export const renderStatistic = (
     chart.annotation().html({
       position: ['50%', '50%'],
       html: (container, view) => {
-        const filteredData = view.getData();
+        const coordinate = view.getCoordinate();
+        const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
+
         container.style['pointer-events'] = 'none';
+        container.style['width'] = `${containerWidth}px`;
         container.style.transform = titleOpt ? 'translate(-50%, 0)' : 'translate(-50%, -50%)';
         each(adapteStyle(contentOpt.style), (v, k) => {
           container.style[k] = v;
         });
+
+        const filteredData = view.getData();
         if (contentOpt.customHtml) {
           return contentOpt.customHtml(container, view, null, filteredData);
         }

--- a/src/plots/pie/utils/statistic.ts
+++ b/src/plots/pie/utils/statistic.ts
@@ -58,6 +58,20 @@ export function adapteStyle(style?: Partial<CSSStyleDeclaration>): object {
 }
 
 /**
+ * @desc 设置 html-statistic 容器的默认样式
+ *
+ * - 默认事件穿透
+ */
+export function setStatisticContainerStyle(container: HTMLElement, style: Partial<CSSStyleDeclaration>) {
+  container.style['pointer-events'] = 'none';
+  each(style, (v, k) => {
+    if (k && v) {
+      container.style[k] = v;
+    }
+  });
+}
+
+/**
  * 渲染 html-annotation
  * @param chart
  * @param options
@@ -77,12 +91,10 @@ export const renderStatistic = (
       html: (container, view) => {
         const coordinate = view.getCoordinate();
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
-
-        container.style['pointer-events'] = 'none';
-        container.style['width'] = `${containerWidth}px`;
-        container.style.transform = contentOpt ? 'translate(-50%, -100%)' : 'translate(-50%, -50%)';
-        each(adapteStyle(titleOpt.style), (v, k) => {
-          container.style[k] = v;
+        setStatisticContainerStyle(container, {
+          ...adapteStyle(titleOpt.style),
+          transform: contentOpt ? 'translate(-50%, -100%)' : 'translate(-50%, -50%)',
+          width: `${containerWidth}px`,
         });
 
         const filteredData = view.getData();
@@ -114,11 +126,10 @@ export const renderStatistic = (
         const coordinate = view.getCoordinate();
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
 
-        container.style['pointer-events'] = 'none';
-        container.style['width'] = `${containerWidth}px`;
-        container.style.transform = titleOpt ? 'translate(-50%, 0)' : 'translate(-50%, -50%)';
-        each(adapteStyle(contentOpt.style), (v, k) => {
-          container.style[k] = v;
+        setStatisticContainerStyle(container, {
+          ...adapteStyle(contentOpt.style),
+          transform: titleOpt ? 'translate(-50%, 0)' : 'translate(-50%, -50%)',
+          width: `${containerWidth}px`,
         });
 
         const filteredData = view.getData();
@@ -146,5 +157,4 @@ export const renderStatistic = (
       ...pick(contentOpt, ['style', 'formatter']),
     });
   }
-  chart.render(true);
 };

--- a/src/plots/pie/utils/statistic.ts
+++ b/src/plots/pie/utils/statistic.ts
@@ -1,0 +1,136 @@
+import { View } from '@antv/g2';
+import { each, get, isNumber } from '@antv/util';
+import { ShapeStyle } from '../../../types';
+import { pick } from '../../../utils';
+import { PieOptions } from '../types';
+import { kebabCase } from './kebab-case';
+import { getTotalValue } from '.';
+
+export type TextStyle = {
+  fontSize?: number;
+  lineHeight?: number;
+  [k: string]: string | number;
+};
+
+/**
+ * @desc 生成 html-statistic 的 style 字符串 (兼容 canvas 的 shapeStyle 到 css样式上)
+ *
+ * @param width
+ * @param style
+ */
+export function adapteStyle(style?: CSSStyleDeclaration): object {
+  const styleObject = {
+    overflow: 'hidden',
+    'white-space': 'nowrap',
+    'text-overflow': 'ellipsis',
+  };
+
+  const shapeStyleKeys = [
+    'stroke',
+    'lineWidth',
+    'shadowColor',
+    'strokeOpacity',
+    'shadowBlur',
+    'shadowOffsetX',
+    'shadowOffsetY',
+  ];
+
+  each(style, (v, k) => {
+    if (['fontSize', 'width', 'height'].includes(k) && isNumber(v)) {
+      styleObject[kebabCase(k)] = `${v}px`;
+    } else if (k === 'fill') {
+      styleObject['color'] = v;
+    } else if (k && !shapeStyleKeys.includes(k)) {
+      styleObject[kebabCase(k)] = `${v}`;
+    }
+  });
+
+  const { stroke, lineWidth = 0, shadowColor, shadowBlur = 0, shadowOffsetX = 0, shadowOffsetY = 0 } = pick(
+    style,
+    shapeStyleKeys
+  ) as ShapeStyle;
+
+  styleObject['text-shadow'] = `${[shadowColor, `${shadowOffsetX}px`, `${shadowOffsetY}px`, `${shadowBlur}px`].join(
+    ' '
+  )}`;
+  styleObject['-webkit-text-stroke'] = `${[`${lineWidth}px`, stroke].join(' ')}`;
+
+  return styleObject;
+}
+
+/**
+ * 渲染 html-annotation
+ * @param chart
+ * @param options
+ */
+export const renderStatistic = (
+  chart: View,
+  options: Pick<PieOptions, 'radius' | 'innerRadius' | 'angleField' | 'colorField' | 'statistic' | 'meta'>
+) => {
+  const { angleField, statistic, meta } = options;
+  const { title: titleOpt, content: contentOpt } = statistic;
+
+  if (titleOpt) {
+    const cfgOffsetY = titleOpt.offsetY || 0;
+
+    chart.annotation().html({
+      position: ['50%', '50%'],
+      html: (container, view) => {
+        const filteredData = view.getData();
+
+        container.style['pointer-events'] = 'none';
+        container.style.transform = contentOpt ? 'translate(-50%, -100%)' : 'translate(-50%, -50%)';
+        each(adapteStyle(titleOpt.style), (v, k) => {
+          container.style[k] = v;
+        });
+
+        if (titleOpt.customHtml) {
+          return titleOpt.customHtml(container, view, null, filteredData);
+        }
+        return (titleOpt.formatter && titleOpt.formatter(null, filteredData)) || '总计';
+      },
+      offsetX: titleOpt.offsetX,
+      offsetY: cfgOffsetY,
+      // @ts-ignore
+      key: 'top-statistic',
+      // 透传配置
+      ...pick(titleOpt, ['style', 'formatter']),
+    });
+  }
+
+  if (contentOpt) {
+    const cfgOffsetY = contentOpt.offsetY || 0;
+
+    chart.annotation().html({
+      position: ['50%', '50%'],
+      html: (container, view) => {
+        const filteredData = view.getData();
+        container.style['pointer-events'] = 'none';
+        container.style.transform = titleOpt ? 'translate(-50%, 0)' : 'translate(-50%, -50%)';
+        each(adapteStyle(contentOpt.style), (v, k) => {
+          container.style[k] = v;
+        });
+        if (contentOpt.customHtml) {
+          return contentOpt.customHtml(container, view, null, filteredData);
+        }
+
+        const formatter = get(contentOpt, 'formatter');
+        const metaFormatter = get(meta, [angleField, 'formatter']);
+        const totalValue = getTotalValue(filteredData, angleField);
+
+        return (
+          (formatter && formatter(null, filteredData)) ||
+          (metaFormatter && metaFormatter(totalValue)) ||
+          `${totalValue}`
+        );
+      },
+      offsetX: contentOpt.offsetX,
+      offsetY: cfgOffsetY,
+      // @ts-ignore
+      key: 'bottom-statistic',
+      // 透传配置
+      ...pick(contentOpt, ['style', 'formatter']),
+    });
+  }
+  chart.render(true);
+};

--- a/src/plots/pie/utils/statistic.ts
+++ b/src/plots/pie/utils/statistic.ts
@@ -1,9 +1,8 @@
 import { View } from '@antv/g2';
 import { each, get, isNumber } from '@antv/util';
 import { ShapeStyle } from '../../../types';
-import { pick } from '../../../utils';
+import { pick, kebabCase } from '../../../utils';
 import { PieOptions } from '../types';
-import { kebabCase } from './kebab-case';
 import { getTotalValue } from '.';
 
 export type TextStyle = {

--- a/src/plots/pie/utils/statistic.ts
+++ b/src/plots/pie/utils/statistic.ts
@@ -17,7 +17,7 @@ export type TextStyle = {
  * @param width
  * @param style
  */
-export function adapteStyle(style?: CSSStyleDeclaration): object {
+export function adapteStyle(style?: Partial<CSSStyleDeclaration>): object {
   const styleObject = {
     overflow: 'hidden',
     'white-space': 'nowrap',
@@ -86,7 +86,12 @@ export const renderStatistic = (
         if (titleOpt.customHtml) {
           return titleOpt.customHtml(container, view, null, filteredData);
         }
-        return (titleOpt.formatter && titleOpt.formatter(null, filteredData)) || '总计';
+        let text = '总计';
+        if (titleOpt.formatter) {
+          text = titleOpt.formatter(null, filteredData);
+        }
+        // todo G2 层修复可以返回空字符串
+        return text ? text : '<div></div>';
       },
       offsetX: titleOpt.offsetX,
       offsetY: cfgOffsetY,
@@ -117,11 +122,13 @@ export const renderStatistic = (
         const metaFormatter = get(meta, [angleField, 'formatter']);
         const totalValue = getTotalValue(filteredData, angleField);
 
-        return (
-          (formatter && formatter(null, filteredData)) ||
-          (metaFormatter && metaFormatter(totalValue)) ||
-          `${totalValue}`
-        );
+        let text = metaFormatter ? metaFormatter(totalValue) : totalValue ? `${totalValue}` : '';
+
+        if (formatter) {
+          text = formatter(null, filteredData);
+        }
+
+        return text ? text : '<div></div>';
       },
       offsetX: contentOpt.offsetX,
       offsetY: cfgOffsetY,

--- a/src/plots/ring-progress/adaptor.ts
+++ b/src/plots/ring-progress/adaptor.ts
@@ -32,12 +32,7 @@ function statistic(params: Params<RingProgressOptions>): Params<RingProgressOpti
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
-    renderStatistic(
-      chart,
-      { innerRadius, radius, statistic },
-      { content: get(meta, 'percent', { field: 'percent' }) },
-      { percent }
-    );
+    renderStatistic(chart, { statistic }, { content: { field: 'percent', ...get(meta, 'percent', {}) } }, { percent });
   }
 
   return params;

--- a/src/plots/ring-progress/adaptor.ts
+++ b/src/plots/ring-progress/adaptor.ts
@@ -1,6 +1,6 @@
-import { isFunction } from '@antv/util';
+import { get } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { flow } from '../../utils';
+import { flow, renderStatistic } from '../../utils';
 import { scale, animation, theme, annotation } from '../../adaptor/common';
 import { geometry } from '../progress/adaptor';
 import { RingProgressOptions } from './types';
@@ -28,23 +28,17 @@ function coordinate(params: Params<RingProgressOptions>): Params<RingProgressOpt
  */
 function statistic(params: Params<RingProgressOptions>): Params<RingProgressOptions> {
   const { chart, options } = params;
-  const { statistic, percent } = options;
+  const { innerRadius, radius, statistic, percent, meta } = options;
 
-  const { title, content } = statistic;
-
-  [title, content].forEach((annotation) => {
-    if (annotation) {
-      const { style, formatter, offsetX, offsetY, rotate } = annotation;
-      chart.annotation().text({
-        position: ['50%', '50%'],
-        content: formatter ? formatter({ percent }) : percent,
-        style: isFunction(style) ? style({ percent }) : style,
-        offsetX,
-        offsetY,
-        rotate,
-      });
-    }
-  });
+  /** 中心文本 指标卡 */
+  if (innerRadius && statistic) {
+    renderStatistic(
+      chart,
+      { innerRadius, radius, statistic },
+      { content: get(meta, 'percent', { field: 'percent' }) },
+      { percent }
+    );
+  }
 
   return params;
 }

--- a/src/plots/ring-progress/adaptor.ts
+++ b/src/plots/ring-progress/adaptor.ts
@@ -3,6 +3,7 @@ import { Params } from '../../core/adaptor';
 import { flow, renderStatistic } from '../../utils';
 import { scale, animation, theme, annotation } from '../../adaptor/common';
 import { geometry } from '../progress/adaptor';
+import { PERCENT } from '../gauge/constant';
 import { RingProgressOptions } from './types';
 
 /**
@@ -28,11 +29,22 @@ function coordinate(params: Params<RingProgressOptions>): Params<RingProgressOpt
  */
 function statistic(params: Params<RingProgressOptions>): Params<RingProgressOptions> {
   const { chart, options } = params;
-  const { innerRadius, radius, statistic, percent, meta } = options;
+  const { innerRadius, statistic, percent, meta } = options;
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
-    renderStatistic(chart, { statistic }, { content: { field: 'percent', ...get(meta, 'percent', {}) } }, { percent });
+    const transformContent = statistic.content;
+    if (transformContent && !transformContent.formatter) {
+      // @ts-ignore
+      transformContent.formatter = ({ percent }) => {
+        const metaFormatter = get(meta, [PERCENT, 'formatter']);
+        if (metaFormatter) {
+          return metaFormatter(percent);
+        }
+        return percent;
+      };
+    }
+    renderStatistic(chart, { statistic: { ...statistic, content: transformContent } }, { percent });
   }
 
   return params;

--- a/src/plots/ring-progress/index.ts
+++ b/src/plots/ring-progress/index.ts
@@ -16,6 +16,7 @@ export class RingProgress extends Plot<RingProgressOptions> {
       radius: 0.98,
       color: ['#FAAD14', '#E8EDF3'],
       statistic: {
+        title: false,
         content: {
           style: {
             fontSize: '14px',

--- a/src/plots/ring-progress/index.ts
+++ b/src/plots/ring-progress/index.ts
@@ -18,7 +18,7 @@ export class RingProgress extends Plot<RingProgressOptions> {
       statistic: {
         content: {
           style: {
-            fontSize: 14,
+            fontSize: '14px',
             fontWeight: 300,
             fill: '#4D4D4D',
             textAlign: 'center',

--- a/src/types/statistic.ts
+++ b/src/types/statistic.ts
@@ -1,10 +1,11 @@
 import { View } from '@antv/g2';
-import { StyleAttr } from './attr';
 import { Data, Datum } from './common';
 
-type StatisticText<S = StyleAttr> = {
+type CSSStyle = Partial<CSSStyleDeclaration>;
+
+export type StatisticText = {
   /** 统计文本的样式 */
-  readonly style?: S;
+  readonly style?: CSSStyle | ((datum: Datum) => CSSStyle);
   /** 文本的格式化 */
   readonly formatter?: (datum?: Datum, data?: Data /** filterData */) => string;
   readonly rotate?: number;
@@ -17,7 +18,7 @@ type StatisticText<S = StyleAttr> = {
 /**
  * 中心文本的统计信息，统一一个数据结构
  */
-export type Statistic<S = StyleAttr> = {
-  readonly title?: false | StatisticText<S>;
-  readonly content?: false | StatisticText<S>;
+export type Statistic = {
+  readonly title?: false | StatisticText;
+  readonly content?: false | StatisticText;
 };

--- a/src/types/statistic.ts
+++ b/src/types/statistic.ts
@@ -1,8 +1,9 @@
 import { View } from '@antv/g2';
 import { Data, Datum } from './common';
 
-type CSSStyle = Omit<Partial<CSSStyleDeclaration>, 'opacity'> & {
+type CSSStyle = Omit<Partial<CSSStyleDeclaration>, 'opacity' | 'lineHeight'> & {
   opacity?: number;
+  lineHeight?: string | number;
 };
 
 export type StatisticText = {

--- a/src/types/statistic.ts
+++ b/src/types/statistic.ts
@@ -1,7 +1,9 @@
 import { View } from '@antv/g2';
 import { Data, Datum } from './common';
 
-type CSSStyle = Partial<CSSStyleDeclaration>;
+type CSSStyle = Omit<Partial<CSSStyleDeclaration>, 'opacity'> & {
+  opacity?: number;
+};
 
 export type StatisticText = {
   /** 统计文本的样式 */

--- a/src/types/statistic.ts
+++ b/src/types/statistic.ts
@@ -1,20 +1,23 @@
+import { View } from '@antv/g2';
 import { StyleAttr } from './attr';
 import { Data, Datum } from './common';
 
-type StatisticText = {
+type StatisticText<S = StyleAttr> = {
   /** 统计文本的样式 */
-  readonly style?: StyleAttr;
+  readonly style?: S;
   /** 文本的格式化 */
   readonly formatter?: (datum?: Datum, data?: Data /** filterData */) => string;
   readonly rotate?: number;
   readonly offsetX?: number;
   readonly offsetY?: number;
+  /** 自定义中心文本的 html */
+  readonly customHtml?: (container: HTMLElement, view: View, datum?: Datum, data?: Data /** filterData */) => string;
 };
 
 /**
  * 中心文本的统计信息，统一一个数据结构
  */
-export type Statistic = {
-  readonly title?: false | StatisticText;
-  readonly content?: false | StatisticText;
+export type Statistic<S = StyleAttr> = {
+  readonly title?: false | StatisticText<S>;
+  readonly content?: false | StatisticText<S>;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,4 @@ export { transformLabel } from './label';
 export { getSplinePath } from './path';
 export { deepAssign } from './deep-assign';
 export { kebabCase } from './kebab-case';
+export { renderStatistic } from './statistic';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export { findViewById } from './view';
 export { transformLabel } from './label';
 export { getSplinePath } from './path';
 export { deepAssign } from './deep-assign';
+export { kebabCase } from './kebab-case';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,4 +9,4 @@ export { transformLabel } from './label';
 export { getSplinePath } from './path';
 export { deepAssign } from './deep-assign';
 export { kebabCase } from './kebab-case';
-export { renderStatistic } from './statistic';
+export { renderStatistic, renderGaugeStatistic } from './statistic';

--- a/src/utils/kebab-case.ts
+++ b/src/utils/kebab-case.ts
@@ -4,10 +4,13 @@
  * kebabCase('fooBar'); => 'foo-bar'
  */
 export function kebabCase(word: string) {
+  if (!word) {
+    return word;
+  }
   const result = word.match(/(([A-Z]{0,1}[a-z]*[^A-Z])|([A-Z]{1}))/g);
   return result
     ? result.reduce((a, b) => {
-        return `${a ? `${a}-` : ''}` + b.toLowerCase();
+        return `${a ? `${a.toLowerCase()}-` : ''}` + b.toLowerCase();
       })
     : '';
 }

--- a/src/utils/statistic.ts
+++ b/src/utils/statistic.ts
@@ -149,7 +149,7 @@ export const renderGaugeStatistic = (chart: View, options: { statistic: Statisti
         const polarCenter = polarCoord.getCenter();
         const polarRadius = polarCoord.getRadius();
         const polarMaxY = Math.max(Math.sin(polarCoord.startAngle), Math.sin(polarCoord.endAngle)) * polarRadius;
-        const offsetY = polarCenter.y + polarMaxY - coordinate.y.start - (parseFloat(style.fontSize) || 0);
+        const offsetY = polarCenter.y + polarMaxY - coordinate.y.start - parseFloat(get(style, 'fontSize', 0));
 
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
         setStatisticContainerStyle(container, {

--- a/src/utils/statistic.ts
+++ b/src/utils/statistic.ts
@@ -139,17 +139,22 @@ export const renderGaugeStatistic = (chart: View, options: { statistic: Statisti
       return;
     }
     let text = '';
-    const transform = 'translate(-50%, -100%)';
     const style = isFunction(option.style) ? option.style(datum) : option.style;
-
     chart.annotation().html({
       position: ['50%', '100%'],
       html: (container, view) => {
         const coordinate = view.getCoordinate();
+        // 弧形的坐标
+        const polarCoord = view.views[0].getCoordinate();
+        const polarCenter = polarCoord.getCenter();
+        const polarRadius = polarCoord.getRadius();
+        const polarMaxY = Math.max(Math.sin(polarCoord.startAngle), Math.sin(polarCoord.endAngle)) * polarRadius;
+        const offsetY = polarCenter.y + polarMaxY - coordinate.y.start - (parseFloat(style.fontSize) || 0);
+
         const containerWidth = coordinate.getRadius() * coordinate.innerRadius * 2;
         setStatisticContainerStyle(container, {
           width: `${containerWidth}px`,
-          transform,
+          transform: `translate(-50%, ${offsetY}px)`,
           // user's style setting has high priority
           ...adapteStyle(style),
         });

--- a/src/utils/statistic.ts
+++ b/src/utils/statistic.ts
@@ -124,7 +124,7 @@ export const renderStatistic = (chart: View, options: { statistic: Statistic }, 
 };
 
 /**
- * 渲染 html-annotation for gauge (等不规则 plot), 默认 position 居中居底 [50%, 1000%]）
+ * 渲染 html-annotation for gauge (等不规则 plot), 默认 position 居中居底 [50%, 100%]）
  * @param chart
  * @param options
  * @param meta 字段元信息

--- a/src/utils/statistic.ts
+++ b/src/utils/statistic.ts
@@ -1,6 +1,6 @@
 import { View } from '@antv/g2';
 import { each, get, isNumber } from '@antv/util';
-import { Datum, Meta, ShapeStyle, StatisticText } from '../types';
+import { Datum, Meta, ShapeStyle, Statistic, StatisticText } from '../types';
 import { PieOptions } from '../plots/pie/types';
 import { getTotalValue } from '../plots/pie/utils';
 import { pick, kebabCase } from '.';
@@ -80,7 +80,7 @@ export function setStatisticContainerStyle(container: HTMLElement, style: Partia
  */
 export const renderStatistic = (
   chart: View,
-  options: Pick<PieOptions, 'radius' | 'innerRadius' | 'statistic'>,
+  options: { statistic: Statistic },
   meta: { content: Meta & { field: string } },
   datum?: Datum
 ) => {
@@ -117,7 +117,7 @@ export const renderStatistic = (
       // @ts-ignore
       key: 'top-statistic',
       // 透传配置
-      ...pick(titleOpt, ['position', 'offsetX', 'rotate', 'style', 'formatter']),
+      ...pick(titleOpt, ['offsetX', 'rotate', 'style', 'formatter']),
     });
   }
 
@@ -143,7 +143,7 @@ export const renderStatistic = (
         }
 
         const formatter = get(contentOpt, 'formatter');
-        const metaFormatter = get(meta, 'formatter');
+        const metaFormatter = get(meta.content, 'formatter');
         const totalValue = getTotalValue(filteredData, meta.content.field);
 
         let text = metaFormatter ? metaFormatter(totalValue) : totalValue ? `${totalValue}` : '';
@@ -158,7 +158,7 @@ export const renderStatistic = (
       // @ts-ignore
       key: 'bottom-statistic',
       // 透传配置
-      ...pick(contentOpt, ['position', 'offsetX', 'rotate', 'style', 'formatter']),
+      ...pick(contentOpt, ['offsetX', 'rotate', 'style', 'formatter']),
     });
   }
 };
@@ -172,7 +172,8 @@ export const renderStatistic = (
  */
 export const renderGaugeStatistic = (
   chart: View,
-  options: Pick<PieOptions, 'radius' | 'innerRadius' | 'statistic'>,
+  options: { statistic: Statistic },
+  meta: { content: Meta & { field: string } },
   datum?: Datum
 ) => {
   const { statistic } = options;
@@ -230,13 +231,18 @@ export const renderGaugeStatistic = (
         });
 
         const filteredData = view.getData();
-        const formatter = get(contentOpt, 'formatter');
-        let text = '';
         if (contentOpt.customHtml) {
           return contentOpt.customHtml(container, view, datum, filteredData);
         }
+
+        const formatter = get(contentOpt, 'formatter');
+        const metaFormatter = get(meta.content, 'formatter');
+        const totalValue = getTotalValue(filteredData, meta.content.field);
+
+        let text = metaFormatter ? metaFormatter(totalValue) : totalValue ? `${totalValue}` : '';
+
         if (formatter) {
-          text = formatter(datum);
+          text = formatter(datum, filteredData);
         }
 
         return text ? text : '<div></div>';

--- a/src/utils/statistic.ts
+++ b/src/utils/statistic.ts
@@ -113,12 +113,11 @@ export const renderStatistic = (
         // todo G2 层修复可以返回空字符串
         return text ? text : '<div></div>';
       },
-      offsetX: titleOpt.offsetX,
       offsetY: cfgOffsetY,
       // @ts-ignore
       key: 'top-statistic',
       // 透传配置
-      ...pick(titleOpt, ['style', 'formatter']),
+      ...pick(titleOpt, ['offsetX', 'rotate', 'style', 'formatter']),
     });
   }
 
@@ -155,12 +154,11 @@ export const renderStatistic = (
 
         return text ? text : '<div></div>';
       },
-      offsetX: contentOpt.offsetX,
       offsetY: cfgOffsetY,
       // @ts-ignore
       key: 'bottom-statistic',
       // 透传配置
-      ...pick(contentOpt, ['style', 'formatter']),
+      ...pick(contentOpt, ['offsetX', 'rotate', 'style', 'formatter']),
     });
   }
 


### PR DESCRIPTION
- [x] 饼图中心文本使用 html-annotation
   - [x] ` statistic.style` 使用 css 样式，但是也对 `shapeStyle` 做了兼容（支持shadow、stroke）
  -  [x] `html container`的宽度默认使用内半径的宽度，并且直接设置在`g2-html-annotation` 容器上
  - [x] demo 增强，提供一个 demo 来展示如何进行中心文本自适应，后续再考虑内置
- [x] 测试用例
- [ ] 文档说明！！~~不说明，都不知道怎么设置样式！~~
