### PR TITLE
fix: surge preview in wrong ref

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,12 +1,14 @@
 name: 🔂 Surge PR Preview
 
-on: [push, pull_request_target]
+on: pull_request_target
 
 jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
修复部署了原始分支而不是 PR 所在分支的问题。

https://github.com/afc163/surge-preview/issues/62