### PR TITLE
test: coverage for conversion-tag

### DIFF
--- a/__tests__/unit/adaptor/conversion-tag-spec.ts
+++ b/__tests__/unit/adaptor/conversion-tag-spec.ts
@@ -40,7 +40,7 @@ describe('column conversion tag', () => {
 
   it('render', async () => {
     plot.render();
-    await delay(500);
+    await delay(100);
 
     const shapes = plot.chart.geometries[0].getShapes();
     const shapeBBoxes = shapes.map((shape) => shape.getBBox());
@@ -89,9 +89,8 @@ describe('column conversion tag', () => {
         size: 40,
       },
     });
-    plot.render();
 
-    await delay(500);
+    await delay(100);
 
     const shapes = plot.chart.geometries[0].getShapes();
     const shapeBBoxes = shapes.map((shape) => shape.getBBox());
@@ -132,6 +131,24 @@ describe('column conversion tag', () => {
       // size: 40
       expect(near(bbox.height, 40)).toBeTruthy();
     });
+
+    plot.update({
+      conversionTag: {
+        arrow: false,
+      },
+    });
+    await delay(100);
+
+    expect(group.findAllByName('conversion-tag-arrow')).toEqual([]);
+
+    plot.update({
+      conversionTag: {
+        text: false,
+      },
+    });
+    await delay(100);
+
+    expect(group.findAllByName('conversion-tag-text')).toEqual([]);
   });
 
   it('clear', async () => {
@@ -141,7 +158,7 @@ describe('column conversion tag', () => {
     });
     plot.render();
 
-    await delay(500);
+    await delay(100);
 
     const foreground = plot.chart.foregroundGroup;
     const group: IGroup = foreground.findAllByName('conversion-tag-group')[0] as IGroup;
@@ -175,7 +192,7 @@ describe('bar conversion tag', () => {
   it('render', async () => {
     plot.render();
 
-    await delay(500);
+    await delay(100);
 
     const shapes = plot.chart.geometries[0].getShapes();
     const shapeBBoxes = shapes.map((shape) => shape.getBBox());
@@ -226,7 +243,7 @@ describe('bar conversion tag', () => {
     });
     plot.render();
 
-    await delay(500);
+    await delay(100);
 
     const shapes = plot.chart.geometries[0].getShapes();
     const shapeBBoxes = shapes.map((shape) => shape.getBBox());
@@ -274,7 +291,7 @@ describe('bar conversion tag', () => {
     });
     plot.render();
 
-    await delay(500);
+    await delay(100);
 
     const foreground = plot.chart.foregroundGroup;
     const group: IGroup = foreground.findAllByName('conversion-tag-group')[0] as IGroup;
@@ -301,6 +318,7 @@ describe('zero data no NaN', () => {
       nice: true,
     },
     conversionTag: {},
+    animation: false,
   });
   plot.render();
 
@@ -333,6 +351,74 @@ describe('zero data no NaN', () => {
   });
 
   afterAll(() => {
+    plot.destroy();
+  });
+});
+
+describe('totalWidth - headSize) / 2 < spacing', () => {
+  it('column', async () => {
+    const plot = new Column(createDiv(), {
+      data: DATA_WITH_ZERO,
+      autoFit: false,
+      width: 200,
+      height: 400,
+      xField: 'action',
+      yField: 'pv',
+      label: {},
+      yAxis: {
+        nice: true,
+      },
+      conversionTag: {},
+      animation: false,
+    });
+
+    plot.render();
+    await delay(50);
+
+    const foreground = plot.chart.foregroundGroup;
+    // 整体
+    const group: IGroup = foreground.findAllByName('conversion-tag-group')[0] as IGroup;
+    // 文本
+    const texts = group.findAllByName('conversion-tag-text');
+
+    expect(texts).toHaveLength(DATA_WITH_ZERO.length - 1);
+    expect(texts[0].attr('text')).toBe('66...');
+
+    const arrows = group.findAllByName('conversion-tag-arrow');
+    expect(arrows[0].getBBox().width).toBe(12);
+    plot.destroy();
+  });
+
+  it('bar', async () => {
+    const plot = new Bar(createDiv(), {
+      data: DATA_WITH_ZERO,
+      autoFit: false,
+      width: 500,
+      height: 300,
+      xField: 'pv',
+      yField: 'action',
+      label: {},
+      yAxis: {
+        nice: true,
+      },
+      conversionTag: {},
+      animation: false,
+    });
+
+    plot.render();
+    await delay(50);
+
+    const foreground = plot.chart.foregroundGroup;
+    // 整体
+    const group: IGroup = foreground.findAllByName('conversion-tag-group')[0] as IGroup;
+    // 文本
+    const texts = group.findAllByName('conversion-tag-text');
+
+    expect(texts).toHaveLength(DATA_WITH_ZERO.length - 1);
+    expect(texts[0].attr('text')).toBe('66.67%');
+
+    const arrows = group.findAllByName('conversion-tag-arrow');
+    expect(arrows[0].getBBox().width).toBe(80);
     plot.destroy();
   });
 });

--- a/__tests__/unit/utils/conversion-spec.ts
+++ b/__tests__/unit/utils/conversion-spec.ts
@@ -1,0 +1,25 @@
+import { conversionTagformatter } from '../../../src/utils/conversion';
+
+describe('conversionTagformatter', () => {
+  it('conversionTagformatter', () => {
+    expect(conversionTagformatter(0, 0)).toBe('0.00%');
+    expect(conversionTagformatter(0, 1)).toBe('∞');
+    expect(conversionTagformatter(1, 0)).toBe('-∞');
+    expect(conversionTagformatter(10, 20)).toBe('200.00%');
+    expect(conversionTagformatter(40, 20)).toBe('50.00%');
+
+    expect(conversionTagformatter(null, 20)).toBe('-');
+    expect(conversionTagformatter(20, null)).toBe('-');
+    expect(conversionTagformatter(null, null)).toBe('-');
+    expect(conversionTagformatter(undefined, 20)).toBe('-');
+    expect(conversionTagformatter(20, undefined)).toBe('-');
+    expect(conversionTagformatter(undefined, undefined)).toBe('-');
+
+    // @ts-ignore
+    expect(conversionTagformatter(false, 20)).toBe('-');
+    // @ts-ignore
+    expect(conversionTagformatter(20, 'wef')).toBe('-');
+    // @ts-ignore
+    expect(conversionTagformatter(30, {})).toBe('-');
+  });
+});

--- a/src/adaptor/conversion-tag.ts
+++ b/src/adaptor/conversion-tag.ts
@@ -4,6 +4,7 @@ import { Geometry, View } from '@antv/g2';
 import Element from '@antv/g2/lib/geometry/element';
 import { Params } from '../core/adaptor';
 import { deepAssign } from '../utils';
+import { conversionTagformatter } from '../utils/conversion';
 
 /** 转化率组件配置选项 */
 export interface ConversionTagOptions {
@@ -74,18 +75,7 @@ function getConversionTagOptionsWithDefaults(options: ConversionTagOptions, hori
           textAlign: 'center',
           textBaseline: 'middle',
         },
-        formatter: (prev: number, next: number) => {
-          if (prev === next) {
-            return `${(0).toFixed(2)}%`;
-          }
-          if (prev === 0) {
-            return '∞';
-          }
-          if (next === 0) {
-            return '-∞';
-          }
-          return `${((100 * next) / prev).toFixed(2)}%`;
-        },
+        formatter: conversionTagformatter,
       },
     },
     options

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,0 +1,23 @@
+import { isNumber } from '@antv/util';
+/**
+ * 转化率的计算方式
+ * @param prev
+ * @param next
+ */
+export function conversionTagformatter(prev: number, next: number): string {
+  if (!isNumber(prev) || !isNumber(next)) {
+    return '-';
+  }
+
+  if (prev === next) {
+    return `${(0).toFixed(2)}%`;
+  }
+  if (prev === 0) {
+    return '∞';
+  }
+  if (next === 0) {
+    return '-∞';
+  }
+
+  return `${((100 * next) / prev).toFixed(2)}%`;
+}


### PR DESCRIPTION
代码的片段拆分，可以大大提高代码的可测性

 - [x] conversion-tag 目前的覆盖率是 83%，可提升空间最大，当前提升至 97%