### PR TITLE
fix: 去除双轴图默认meta设置

### DIFF
--- a/__tests__/unit/plots/dual-axes/default-options-spec.ts
+++ b/__tests__/unit/plots/dual-axes/default-options-spec.ts
@@ -1,6 +1,8 @@
 import { DualAxes } from '../../../../src';
 import { PV_DATA, UV_DATA, UV_DATA_MULTI } from '../../../data/pv-uv';
 import { createDiv } from '../../../utils/dom';
+import { LEFT_AXES_VIEW, RIGHT_AXES_VIEW } from '../../../../src/plots/dual-axes/constant';
+import { findViewById } from '../../../../src/utils/view';
 
 describe('default options', () => {
   it('dual line', () => {
@@ -19,7 +21,12 @@ describe('default options', () => {
     expect(dualAxes.chart.options.tooltip.showCrosshairs).toEqual(true);
     // @ts-ignore
     expect(dualAxes.chart.options.tooltip.showMarkers).toEqual(true);
-
+    const leftView = findViewById(dualAxes.chart, LEFT_AXES_VIEW);
+    const rightView = findViewById(dualAxes.chart, RIGHT_AXES_VIEW);
+    // @ts-ignore
+    expect(leftView.options.scales.date.type).toBeUndefined();
+    // @ts-ignore
+    expect(rightView.options.scales.date.type).toBeUndefined();
     dualAxes.destroy();
   });
 

--- a/src/plots/dual-axes/adaptor.ts
+++ b/src/plots/dual-axes/adaptor.ts
@@ -44,7 +44,7 @@ export function transformOptions(params: Params<DualAxesOptions>): Params<DualAx
         meta: {
           [xField]: {
             // 默认为 cat 类型
-            type: 'cat',
+            // type: 'cat',
             // x 轴一定是同步 scale 的
             sync: true,
             // 如果有没有柱子，则


### PR DESCRIPTION
原因：
上个版本和柱线图保持一致，x 轴的 scale 默认设置为 ‘cat’ 类型。
但双轴图的 cat 类型，在某一方有空数据的情况下，会导致渲染错误，（见示例 https://riddle.alibaba-inc.com/riddles/7245c531 粗略看了眼，是 g2 在 syncScale 时，cat类型的时候两个 x 轴的排序没有对上。我再看下是在 g2 上修还是 g2 plot 上修）
这个 pr 先去除掉这个默认设置，随后再 fix cat 分类问题