### PR TITLE
fix: 双轴图和对称条形图的 limitinplot

### DIFF
--- a/__tests__/unit/adaptor/common-spec.ts
+++ b/__tests__/unit/adaptor/common-spec.ts
@@ -37,6 +37,21 @@ describe('limit-in-plot', () => {
     // @ts-ignore
     expect(limitInPlot(params).chart.limitInPlot).toBeFalsy();
   });
+
+  it('limitInPlot: limitinplot config, yaxis {} with min null', () => {
+    const params = {
+      chart: {},
+      options: {
+        limitInPlot: true,
+        yAxis: {
+          min: null,
+        },
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeTruthy();
+  });
+
   it('limitInPlot: limitinplot undefined, yaxis undefined', () => {
     const params = {
       chart: {},
@@ -68,5 +83,18 @@ describe('limit-in-plot', () => {
     };
     // @ts-ignore
     expect(limitInPlot(params).chart.limitInPlot).toBeTruthy();
+  });
+
+  it('limitInPlot: limitinplot config, yaxis {} with min null', () => {
+    const params = {
+      chart: {},
+      options: {
+        yAxis: {
+          min: null,
+        },
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeFalsy();
   });
 });

--- a/__tests__/unit/adaptor/common-spec.ts
+++ b/__tests__/unit/adaptor/common-spec.ts
@@ -1,0 +1,72 @@
+import { limitInPlot } from '../../../src/adaptor/common';
+
+describe('limit-in-plot', () => {
+  it('limitInPlot: limitinplot config, yaxis undefined', () => {
+    const params = {
+      chart: {},
+      options: {
+        limitInPlot: true,
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeTruthy();
+  });
+  it('limitInPlot: limitinplot config, yaxis {}', () => {
+    const params = {
+      chart: {},
+      options: {
+        limitInPlot: false,
+        yAxis: {
+          test: 5,
+        },
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeFalsy();
+  });
+  it('limitInPlot: limitinplot config, yaxis {} with min max', () => {
+    const params = {
+      chart: {},
+      options: {
+        limitInPlot: false,
+        yAxis: {
+          min: 5,
+        },
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeFalsy();
+  });
+  it('limitInPlot: limitinplot undefined, yaxis undefined', () => {
+    const params = {
+      chart: {},
+      options: {},
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeUndefined();
+  });
+
+  it('limitInPlot: limitinplot undefined, yaxis {}', () => {
+    const params = {
+      chart: {},
+      options: {
+        yAxis: {},
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeFalsy();
+  });
+
+  it('limitInPlot: limitinplot undefined, yaxis {min}', () => {
+    const params = {
+      chart: {},
+      options: {
+        yAxis: {
+          min: 5,
+        },
+      },
+    };
+    // @ts-ignore
+    expect(limitInPlot(params).chart.limitInPlot).toBeTruthy();
+  });
+});

--- a/__tests__/unit/plots/bidirectional-bar/limit-in-plot-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/limit-in-plot-spec.ts
@@ -1,0 +1,78 @@
+import { BidirectionalBar } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { FIRST_AXES_VIEW, SECOND_AXES_VIEW } from '../../../../src/plots/bidirectional-bar/constant';
+import { findViewById } from '../../../../src/utils/view';
+
+const data = [
+  { country: '乌拉圭', '2016年耕地总面积': -13.4, '2016年转基因种植面积': -20.3 },
+  { country: '巴拉圭', '2016年耕地总面积': 14.4, '2016年转基因种植面积': 6.3 },
+  { country: '南非', '2016年耕地总面积': 18.4, '2016年转基因种植面积': 8.3 },
+  { country: '巴基斯坦', '2016年耕地总面积': 34.4, '2016年转基因种植面积': 13.8 },
+  { country: '阿根廷', '2016年耕地总面积': 44.4, '2016年转基因种植面积': 19.5 },
+  { country: '巴西', '2016年耕地总面积': 24.4, '2016年转基因种植面积': 18.8 },
+  { country: '加拿大', '2016年耕地总面积': 54.4, '2016年转基因种植面积': 24.7 },
+  { country: '中国', '2016年耕地总面积': 104.4, '2016年转基因种植面积': 5.3 },
+  { country: '美国', '2016年耕地总面积': 165.2, '2016年转基因种植面积': 72.9 },
+];
+
+let bidirectionalBar;
+
+describe('BidirectionalBar: limitInPlot', () => {
+  beforeAll(() => {
+    bidirectionalBar = new BidirectionalBar(createDiv(), {
+      width: 400,
+      height: 400,
+      data,
+      xField: 'country',
+      yField: ['2016年耕地总面积', '2016年转基因种植面积'],
+      layout: 'vertical',
+    });
+
+    bidirectionalBar.render();
+  });
+
+  it('default', () => {
+    expect(findViewById(bidirectionalBar.chart, FIRST_AXES_VIEW).limitInPlot).toBeFalsy();
+    expect(findViewById(bidirectionalBar.chart, SECOND_AXES_VIEW).limitInPlot).toBeFalsy();
+  });
+
+  it('default: yaxis min', () => {
+    bidirectionalBar.update({
+      yAxis: {
+        '2016年转基因种植面积': {
+          max: 50,
+          min: -10,
+        },
+      },
+    });
+    expect(findViewById(bidirectionalBar.chart, FIRST_AXES_VIEW).limitInPlot).toBeFalsy();
+    expect(findViewById(bidirectionalBar.chart, SECOND_AXES_VIEW).limitInPlot).toBeTruthy();
+  });
+
+  it('limitinplot: config false', () => {
+    bidirectionalBar.update({
+      limitInPlot: false,
+      yAxis: {
+        '2016年转基因种植面积': {
+          max: 50,
+          min: -10,
+        },
+      },
+    });
+    expect(findViewById(bidirectionalBar.chart, FIRST_AXES_VIEW).limitInPlot).toBeFalsy();
+    expect(findViewById(bidirectionalBar.chart, SECOND_AXES_VIEW).limitInPlot).toBeFalsy();
+  });
+
+  it('limitinplot: config true', () => {
+    bidirectionalBar.update({
+      limitInPlot: true,
+      yAxis: {},
+    });
+    expect(findViewById(bidirectionalBar.chart, FIRST_AXES_VIEW).limitInPlot).toBeTruthy();
+    expect(findViewById(bidirectionalBar.chart, SECOND_AXES_VIEW).limitInPlot).toBeTruthy();
+  });
+
+  afterAll(() => {
+    bidirectionalBar.destroy();
+  });
+});

--- a/__tests__/unit/plots/dual-axes/limit-in-plot-spec.ts
+++ b/__tests__/unit/plots/dual-axes/limit-in-plot-spec.ts
@@ -1,0 +1,98 @@
+import { DualAxes } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { LEFT_AXES_VIEW, RIGHT_AXES_VIEW } from '../../../../src/plots/dual-axes/constant';
+import { findViewById } from '../../../../src/utils/view';
+
+export const UV_DATA = [
+  { date: '0601', uv: -1000 },
+  { date: '0602', uv: -4000 },
+  { date: '0603', uv: 5000 },
+  { date: '0604', uv: 5500 },
+  { date: '0605', uv: 7000 },
+  { date: '0606', uv: 4000 },
+  { date: '0607', uv: 6400 },
+  { date: '0608', uv: 1500 },
+  { date: '0609', uv: 2000 },
+];
+
+export const PV_DATA = [
+  { date: '0601', pv: -1000 },
+  { date: '0602', pv: -4000 },
+  { date: '0603', pv: 5000 },
+  { date: '0604', pv: 5500 },
+  { date: '0605', pv: 7000 },
+  { date: '0606', pv: 4000 },
+  { date: '0607', pv: 6400 },
+  { date: '0608', pv: 1500 },
+  { date: '0609', pv: 2000 },
+];
+
+let dualAxes;
+
+describe('dual-axes: limitInPlot', () => {
+  beforeAll(() => {
+    dualAxes = new DualAxes(createDiv(), {
+      height: 300,
+      data: [UV_DATA, PV_DATA],
+      xField: 'date',
+      yField: ['uv', 'pv'],
+      geometryOptions: [
+        {
+          geometry: 'line',
+        },
+        {
+          geometry: 'column',
+        },
+      ],
+    });
+
+    dualAxes.render();
+  });
+
+  it('default', () => {
+    expect(findViewById(dualAxes.chart, LEFT_AXES_VIEW).limitInPlot).toBeFalsy();
+    expect(findViewById(dualAxes.chart, RIGHT_AXES_VIEW).limitInPlot).toBeFalsy();
+  });
+
+  it('default: yaxis min', () => {
+    dualAxes.update({
+      yAxis: {
+        uv: {},
+        pv: {
+          max: 4000,
+          min: -2000,
+        },
+      },
+    });
+    expect(findViewById(dualAxes.chart, LEFT_AXES_VIEW).limitInPlot).toBeFalsy();
+    expect(findViewById(dualAxes.chart, RIGHT_AXES_VIEW).limitInPlot).toBeTruthy();
+  });
+
+  it('limitinplot: config false', () => {
+    dualAxes.update({
+      limitInPlot: false,
+      yAxis: {
+        uv: {},
+        pv: {
+          max: 4000,
+          min: -2000,
+        },
+      },
+    });
+    expect(findViewById(dualAxes.chart, LEFT_AXES_VIEW).limitInPlot).toBeFalsy();
+    expect(findViewById(dualAxes.chart, RIGHT_AXES_VIEW).limitInPlot).toBeFalsy();
+  });
+
+  it('limitinplot: config true', () => {
+    dualAxes.update({
+      limitInPlot: true,
+      yAxis: {},
+    });
+    expect(findViewById(dualAxes.chart, LEFT_AXES_VIEW).limitInPlot).toBeTruthy();
+    expect(findViewById(dualAxes.chart, RIGHT_AXES_VIEW).limitInPlot).toBeTruthy();
+  });
+
+  afterAll(() => {
+    dualAxes.destroy();
+  });
+});

--- a/src/adaptor/common.ts
+++ b/src/adaptor/common.ts
@@ -195,8 +195,8 @@ export function limitInPlot(params: Params<Options>): Params<Options> {
   let value = limitInPlot;
 
   // 用户没有设置 limitInPlot，则自动根据 yAxis 是否有 min/max 来设置 limitInPlot
-  if (typeof yAxis !== 'boolean' && isNil(limitInPlot) && isObject(yAxis)) {
-    if (!isNil(yAxis.min) || !isNil(yAxis.max) || !isNil(yAxis.minLimit) || !isNil(yAxis.maxLimit)) {
+  if (isObject(yAxis) && isNil(limitInPlot)) {
+    if (Object.keys(pick(yAxis, ['min', 'max', 'minLimit', 'maxLimit'])).length > 0) {
       value = true;
     } else {
       value = false;

--- a/src/adaptor/common.ts
+++ b/src/adaptor/common.ts
@@ -196,7 +196,7 @@ export function limitInPlot(params: Params<Options>): Params<Options> {
 
   // 用户没有设置 limitInPlot，则自动根据 yAxis 是否有 min/max 来设置 limitInPlot
   if (isObject(yAxis) && isNil(limitInPlot)) {
-    if (Object.keys(pick(yAxis, ['min', 'max', 'minLimit', 'maxLimit'])).length > 0) {
+    if (Object.values(pick(yAxis, ['min', 'max', 'minLimit', 'maxLimit'])).some((value) => !isNil(value))) {
       value = true;
     } else {
       value = false;

--- a/src/adaptor/common.ts
+++ b/src/adaptor/common.ts
@@ -1,5 +1,5 @@
 import { Geometry } from '@antv/g2';
-import { each, isNil } from '@antv/util';
+import { each, isNil, isObject } from '@antv/util';
 import { Params } from '../core/adaptor';
 import { Options } from '../types';
 import { Interaction } from '../types/interaction';
@@ -195,7 +195,7 @@ export function limitInPlot(params: Params<Options>): Params<Options> {
   let value = limitInPlot;
 
   // 用户没有设置 limitInPlot，则自动根据 yAxis 是否有 min/max 来设置 limitInPlot
-  if (typeof yAxis !== 'boolean' && isNil(limitInPlot)) {
+  if (typeof yAxis !== 'boolean' && isNil(limitInPlot) && isObject(yAxis)) {
     if (!isNil(yAxis.min) || !isNil(yAxis.max) || !isNil(yAxis.minLimit) || !isNil(yAxis.maxLimit)) {
       value = true;
     } else {

--- a/src/plots/bidirectional-bar/adaptor.ts
+++ b/src/plots/bidirectional-bar/adaptor.ts
@@ -6,6 +6,7 @@ import {
   interaction as commonInteraction,
   animation as commonAnimation,
   theme as commonTheme,
+  limitInPlot as commonLimitInPlot,
   scale,
 } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
@@ -198,6 +199,35 @@ export function interaction(params: Params<BidirectionalBarOptions>): Params<Bid
 }
 
 /**
+ * limitInPlot
+ * @param params
+ */
+export function limitInPlot(params: Params<BidirectionalBarOptions>): Params<BidirectionalBarOptions> {
+  const { chart, options } = params;
+  const { yField, yAxis } = options;
+
+  commonLimitInPlot(
+    deepAssign({}, params, {
+      chart: findViewById(chart, FIRST_AXES_VIEW),
+      options: {
+        yAxis: yAxis[yField[0]],
+      },
+    })
+  );
+
+  commonLimitInPlot(
+    deepAssign({}, params, {
+      chart: findViewById(chart, SECOND_AXES_VIEW),
+      options: {
+        yAxis: yAxis[yField[1]],
+      },
+    })
+  );
+
+  return params;
+}
+
+/**
  * theme
  * @param params
  */
@@ -263,5 +293,5 @@ function label(params: Params<BidirectionalBarOptions>): Params<BidirectionalBar
  */
 export function adaptor(params: Params<BidirectionalBarOptions>) {
   // flow 的方式处理所有的配置到 G2 API
-  return flow(geometry, meta, axis, theme, label, tooltip, interaction, animation)(params);
+  return flow(geometry, meta, axis, limitInPlot, theme, label, tooltip, interaction, animation)(params);
 }

--- a/src/plots/dual-axes/adaptor.ts
+++ b/src/plots/dual-axes/adaptor.ts
@@ -7,6 +7,7 @@ import {
   scale,
   interaction as commonInteraction,
   annotation as commonAnnotation,
+  limitInPlot as commonLimitInPlot,
 } from '../../adaptor/common';
 import { percent } from '../../utils/transform/percent';
 import { Params } from '../../core/adaptor';
@@ -288,6 +289,35 @@ export function animation(params: Params<DualAxesOptions>): Params<DualAxesOptio
 }
 
 /**
+ * 双轴图 limitInPlot
+ * @param params
+ */
+export function limitInPlot(params: Params<DualAxesOptions>): Params<DualAxesOptions> {
+  const { chart, options } = params;
+  const { yField, yAxis } = options;
+
+  commonLimitInPlot(
+    deepAssign({}, params, {
+      chart: findViewById(chart, LEFT_AXES_VIEW),
+      options: {
+        yAxis: yAxis[yField[0]],
+      },
+    })
+  );
+
+  commonLimitInPlot(
+    deepAssign({}, params, {
+      chart: findViewById(chart, RIGHT_AXES_VIEW),
+      options: {
+        yAxis: yAxis[yField[1]],
+      },
+    })
+  );
+
+  return params;
+}
+
+/**
  * legend 配置
  * 使用 custom，便于和类似于分组柱状图-单折线图的逻辑统一
  * @param params
@@ -384,6 +414,7 @@ export function adaptor(params: Params<DualAxesOptions>): Params<DualAxesOptions
     geometry,
     meta,
     axis,
+    limitInPlot,
     tooltip,
     interaction,
     annotation,


### PR DESCRIPTION
问题描述：
在多 view 图表中，设置了 min 和负值以后，底线超出，chart.limitInPlot 不起作用

<img width="724" alt="屏幕快照 2020-11-27 17 45 37" src="https://user-images.githubusercontent.com/11748654/100435089-6590f500-30d8-11eb-845e-0f9a5a5db6de.png">

解决方案：
根据 chart.limitinplot 和 yaxis 中的 min max 值，为每个 view 增加 limitInPlot

相关问题：
对称条形图有类似问题，一并修复， @arcsin1  可以帮忙cr下代码


![image](https://user-images.githubusercontent.com/11748654/100435678-3d55c600-30d9-11eb-9c90-6ffe509c89a8.png)




