### PR TITLE
fix pie label percentage

### DIFF
--- a/__tests__/bugs/issue-2054-spec.ts
+++ b/__tests__/bugs/issue-2054-spec.ts
@@ -5,15 +5,17 @@ describe('#2054', () => {
   it('pie {percentage} label', () => {
     const pie = new Pie(createDiv(), {
       width: 400,
-      height: 300,
-      data: [
-        { type: '1', value: 10 },
-        { type: '2', value: 40 },
-        { type: '3', value: 0 },
-        { type: '4', value: null },
-      ],
+      height: 400,
+      radius: 1,
+      innerRadius: 0.3,
       angleField: 'value',
       colorField: 'type',
+      data: [
+        { type: 'type-1', value: 10 },
+        { type: 'type-2', value: 40 },
+        { type: 'type-3', value: 0 },
+        { type: 'type-4', value: null },
+      ],
       label: {
         content: '{percentage}',
       },
@@ -22,10 +24,8 @@ describe('#2054', () => {
     pie.render();
 
     const labels = pie.chart.geometries[0].labelsContainer.getChildren();
-    // @ts-ignore
-    expect(labels[2].find((shape) => shape.get('type') === 'text')).toEqual('0.00%');
-    // @ts-ignore
-    expect(labels[3].find((shape) => shape.get('type') === 'text')).toEqual(null);
+    expect(labels[2].get('children')[0].attr('text')).toBe('0.00%');
+    expect(labels[3].get('children')[0].attr('text')).toBe(null);
 
     pie.destroy();
   });

--- a/__tests__/bugs/issue-2054-spec.ts
+++ b/__tests__/bugs/issue-2054-spec.ts
@@ -2,7 +2,7 @@ import { Pie } from '../../src';
 import { createDiv } from '../utils/dom';
 
 describe('#2054', () => {
-  it('pie', () => {
+  it('pie {percentage} label', () => {
     const pie = new Pie(createDiv(), {
       width: 400,
       height: 300,

--- a/__tests__/bugs/issue-2054-spec.ts
+++ b/__tests__/bugs/issue-2054-spec.ts
@@ -25,7 +25,6 @@ describe('#2054', () => {
 
     const labels = pie.chart.geometries[0].labelsContainer.getChildren();
     expect(labels[2].get('children')[0].attr('text')).toBe('0.00%');
-    expect(labels[3].get('children')[0].attr('text')).toBe(null);
 
     pie.destroy();
   });

--- a/__tests__/bugs/issue-2054-spec.ts
+++ b/__tests__/bugs/issue-2054-spec.ts
@@ -1,0 +1,32 @@
+import { Pie } from '../../src';
+import { createDiv } from '../utils/dom';
+
+describe('#2054', () => {
+  it('pie', () => {
+    const pie = new Pie(createDiv(), {
+      width: 400,
+      height: 300,
+      data: [
+        { type: '1', value: 10 },
+        { type: '2', value: 40 },
+        { type: '3', value: 0 },
+        { type: '4', value: null },
+      ],
+      angleField: 'value',
+      colorField: 'type',
+      label: {
+        content: '{percentage}',
+      },
+    });
+
+    pie.render();
+
+    const labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    // @ts-ignore
+    expect(labels[2].find((shape) => shape.get('type') === 'text')).toEqual('0.00%');
+    // @ts-ignore
+    expect(labels[3].find((shape) => shape.get('type') === 'text')).toEqual(null);
+
+    pie.destroy();
+  });
+});

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -135,7 +135,7 @@ function label(params: Params<PieOptions>): Params<PieOptions> {
               value,
               name,
               // percentage (string), default keep 2
-              percentage: isNumber(percent) && !isNil(percent) ? `${(percent * 100).toFixed(2)}%` : null,
+              percentage: isNumber(percent) && !isNil(value) ? `${(percent * 100).toFixed(2)}%` : null,
             })
           : content;
       };

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -1,4 +1,4 @@
-import { every, filter, isFunction, isString, isNil, get } from '@antv/util';
+import { every, filter, isFunction, isString, isNil, get, isArray, isNumber } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
@@ -135,7 +135,7 @@ function label(params: Params<PieOptions>): Params<PieOptions> {
               value,
               name,
               // percentage (string), default keep 2
-              percentage: percent ? `${(percent * 100).toFixed(2)}%` : null,
+              percentage: isNumber(percent) ? `${(percent * 100).toFixed(2)}%` : null,
             })
           : content;
       };

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -1,4 +1,4 @@
-import { every, filter, isFunction, isString, isNil, get, isArray, isNumber } from '@antv/util';
+import { every, filter, isFunction, isString, isNil, get, isNumber } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
@@ -135,7 +135,7 @@ function label(params: Params<PieOptions>): Params<PieOptions> {
               value,
               name,
               // percentage (string), default keep 2
-              percentage: isNumber(percent) ? `${(percent * 100).toFixed(2)}%` : null,
+              percentage: isNumber(percent) && !isNil(percent) ? `${(percent * 100).toFixed(2)}%` : null,
             })
           : content;
       };


### PR DESCRIPTION
- feat: 添加bugs测试
- fix(issue-2054): 修复数据为 0，label 设置 `content: '{percentage}'` 显示 null

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/15646325/100850890-6dc5a780-34bf-11eb-8be0-d31487ff498b.png)|![image](https://user-images.githubusercontent.com/15646325/100850769-41119000-34bf-11eb-9eff-3c7ccfb34706.png)|

