### PR TITLE
feat: add default label layout for line/area/column/bar

### DIFF
--- a/__tests__/unit/plots/area/label-spec.ts
+++ b/__tests__/unit/plots/area/label-spec.ts
@@ -62,4 +62,48 @@ describe('area', () => {
 
     area.destroy();
   });
+
+  it('default layout, off', () => {
+    const area = new Area(createDiv('default layout, off'), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      appendPadding: 10,
+    });
+
+    area.render();
+    // @ts-ignore
+    expect(area.chart.geometries[0].labelOption).toBeFalsy();
+  });
+
+  it('default layout, on', () => {
+    const area = new Area(createDiv('default layout, on'), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      appendPadding: 10,
+      animation: false,
+      label: {},
+    });
+
+    area.render();
+    // @ts-ignore
+    window.__plot__ = area;
+
+    // @ts-ignore
+    expect(area.chart.geometries[0].labelOption.cfg).toEqual({
+      layout: [
+        { type: 'limit-in-plot' },
+        { type: 'path-adjust-position' },
+        { type: 'point-adjust-position' },
+        { type: 'limit-in-plot', cfg: { action: 'hide' } },
+      ],
+    });
+  });
 });

--- a/__tests__/unit/plots/area/label-spec.ts
+++ b/__tests__/unit/plots/area/label-spec.ts
@@ -77,6 +77,8 @@ describe('area', () => {
     area.render();
     // @ts-ignore
     expect(area.chart.geometries[0].labelOption).toBeFalsy();
+
+    area.destroy();
   });
 
   it('default layout, on', () => {
@@ -103,5 +105,7 @@ describe('area', () => {
         { type: 'limit-in-plot', cfg: { action: 'hide' } },
       ],
     });
+
+    area.destroy();
   });
 });

--- a/__tests__/unit/plots/area/label-spec.ts
+++ b/__tests__/unit/plots/area/label-spec.ts
@@ -93,8 +93,6 @@ describe('area', () => {
     });
 
     area.render();
-    // @ts-ignore
-    window.__plot__ = area;
 
     // @ts-ignore
     expect(area.chart.geometries[0].labelOption.cfg).toEqual({

--- a/__tests__/unit/plots/bar/label-spec.ts
+++ b/__tests__/unit/plots/bar/label-spec.ts
@@ -228,6 +228,8 @@ describe('bar label', () => {
     plot.render();
 
     expect(plot.chart.geometries[0].labelOption).toBeFalsy();
+
+    plot.destroy();
   });
 
   it('default layout, on', () => {
@@ -258,6 +260,8 @@ describe('bar label', () => {
         { type: 'limit-in-plot', cfg: { action: 'hide' } },
       ],
     });
+
+    plot.destroy();
   });
 
   it('default layout, custom', () => {
@@ -288,5 +292,7 @@ describe('bar label', () => {
       layout: [{ type: 'adjust-color' }],
       position: 'left',
     });
+
+    plot.destroy();
   });
 });

--- a/__tests__/unit/plots/bar/label-spec.ts
+++ b/__tests__/unit/plots/bar/label-spec.ts
@@ -209,4 +209,84 @@ describe('bar label', () => {
 
     bar.destroy();
   });
+
+  it('default layout, off', () => {
+    const plot = new Bar(createDiv('default layout, off'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      yField: 'area',
+      xField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+          formatter: (v) => `${Math.floor(v / 10000)}万`,
+        },
+      },
+    });
+
+    plot.render();
+
+    expect(plot.chart.geometries[0].labelOption).toBeFalsy();
+  });
+
+  it('default layout, on', () => {
+    const plot = new Bar(createDiv('default layout, on'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      yField: 'area',
+      xField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+          formatter: (v) => `${Math.floor(v / 10000)}万`,
+        },
+      },
+      label: {},
+    });
+
+    plot.render();
+
+    // @ts-ignore
+    expect(plot.chart.geometries[0].labelOption.cfg).toEqual({
+      position: 'left',
+      layout: [
+        { type: 'interval-adjust-position' },
+        { type: 'interval-hide-overlap' },
+        { type: 'adjust-color' },
+        { type: 'limit-in-plot', cfg: { action: 'hide' } },
+      ],
+    });
+  });
+
+  it('default layout, custom', () => {
+    const plot = new Bar(createDiv('default layout, custom'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      yField: 'area',
+      xField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+          formatter: (v) => `${Math.floor(v / 10000)}万`,
+        },
+      },
+      label: {
+        layout: [
+          {
+            type: 'adjust-color',
+          },
+        ],
+      },
+    });
+
+    plot.render();
+    // @ts-ignore
+    expect(plot.chart.geometries[0].labelOption.cfg).toEqual({
+      layout: [{ type: 'adjust-color' }],
+      position: 'left',
+    });
+  });
 });

--- a/__tests__/unit/plots/column/label-spec.ts
+++ b/__tests__/unit/plots/column/label-spec.ts
@@ -226,6 +226,8 @@ describe('column label', () => {
     plot.render();
 
     expect(plot.chart.geometries[0].labelOption).toBeFalsy();
+
+    plot.destroy();
   });
 
   it('default layout, on', () => {
@@ -255,6 +257,8 @@ describe('column label', () => {
         { type: 'limit-in-plot', cfg: { action: 'hide' } },
       ],
     });
+
+    plot.destroy();
   });
 
   it('default layout, custom', () => {
@@ -284,5 +288,7 @@ describe('column label', () => {
     expect(plot.chart.geometries[0].labelOption.cfg).toEqual({
       layout: [{ type: 'adjust-color' }],
     });
+
+    plot.destroy();
   });
 });

--- a/__tests__/unit/plots/column/label-spec.ts
+++ b/__tests__/unit/plots/column/label-spec.ts
@@ -207,4 +207,82 @@ describe('column label', () => {
 
     column.destroy();
   });
+
+  it('default layout, off', () => {
+    const plot = new Column(createDiv('default layout, off'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      xField: 'area',
+      yField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+          formatter: (v) => `${Math.floor(v / 10000)}万`,
+        },
+      },
+    });
+
+    plot.render();
+
+    expect(plot.chart.geometries[0].labelOption).toBeFalsy();
+  });
+
+  it('default layout, on', () => {
+    const plot = new Column(createDiv('default layout, on'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      xField: 'area',
+      yField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+          formatter: (v) => `${Math.floor(v / 10000)}万`,
+        },
+      },
+      label: {},
+    });
+
+    plot.render();
+
+    // @ts-ignore
+    expect(plot.chart.geometries[0].labelOption.cfg).toEqual({
+      layout: [
+        { type: 'interval-adjust-position' },
+        { type: 'interval-hide-overlap' },
+        { type: 'adjust-color' },
+        { type: 'limit-in-plot', cfg: { action: 'hide' } },
+      ],
+    });
+  });
+
+  it('default layout, custom', () => {
+    const plot = new Column(createDiv('default layout, custom'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      xField: 'area',
+      yField: 'sales',
+      meta: {
+        sales: {
+          nice: true,
+          formatter: (v) => `${Math.floor(v / 10000)}万`,
+        },
+      },
+      label: {
+        layout: [
+          {
+            type: 'adjust-color',
+          },
+        ],
+      },
+    });
+
+    plot.render();
+    // @ts-ignore
+    expect(plot.chart.geometries[0].labelOption.cfg).toEqual({
+      layout: [{ type: 'adjust-color' }],
+    });
+  });
 });

--- a/__tests__/unit/plots/line/label-spec.ts
+++ b/__tests__/unit/plots/line/label-spec.ts
@@ -62,4 +62,45 @@ describe('line', () => {
 
     line.destroy();
   });
+
+  it('default layout, off', () => {
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      appendPadding: 10,
+    });
+
+    line.render();
+
+    expect(line.chart.geometries[0].labelOption).toBeFalsy();
+  });
+
+  it('default layout, on', () => {
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      appendPadding: 10,
+      label: {},
+    });
+
+    line.render();
+
+    // @ts-ignore
+    expect(line.chart.geometries[0].labelOption.cfg).toEqual({
+      layout: [
+        { type: 'limit-in-plot' },
+        { type: 'path-adjust-position' },
+        { type: 'point-adjust-position' },
+        { type: 'limit-in-plot', cfg: { action: 'hide' } },
+      ],
+    });
+  });
 });

--- a/__tests__/unit/plots/line/label-spec.ts
+++ b/__tests__/unit/plots/line/label-spec.ts
@@ -77,6 +77,8 @@ describe('line', () => {
     line.render();
 
     expect(line.chart.geometries[0].labelOption).toBeFalsy();
+
+    line.destroy();
   });
 
   it('default layout, on', () => {
@@ -102,5 +104,7 @@ describe('line', () => {
         { type: 'limit-in-plot', cfg: { action: 'hide' } },
       ],
     });
+
+    line.destroy();
   });
 });

--- a/src/plots/area/adaptor.ts
+++ b/src/plots/area/adaptor.ts
@@ -82,7 +82,15 @@ function label(params: Params<AreaOptions>): Params<AreaOptions> {
     areaGeometry.label({
       fields: [yField],
       callback,
-      cfg: transformLabel(cfg),
+      cfg: {
+        layout: [
+          { type: 'limit-in-plot' },
+          { type: 'path-adjust-position' },
+          { type: 'point-adjust-position' },
+          { type: 'limit-in-plot', cfg: { action: 'hide' } },
+        ],
+        ...transformLabel(cfg),
+      },
     });
   }
 

--- a/src/plots/bar/adaptor.ts
+++ b/src/plots/bar/adaptor.ts
@@ -14,6 +14,15 @@ export function adaptor(params: Params<BarOptions>) {
   // label of bar charts default position is left, if plot has label
   if (label && !label.position) {
     label.position = 'left';
+    // 配置默认的 label layout： 如果用户没有指定 layout 和 position， 则自动配置 layout
+    if (!label.layout) {
+      label.layout = [
+        { type: 'interval-adjust-position' },
+        { type: 'interval-hide-overlap' },
+        { type: 'adjust-color' },
+        { type: 'limit-in-plot', cfg: { action: 'hide' } },
+      ];
+    }
   }
 
   // 默认 legend 位置

--- a/src/plots/column/adaptor.ts
+++ b/src/plots/column/adaptor.ts
@@ -165,16 +165,27 @@ function label(params: Params<ColumnOptions>): Params<ColumnOptions> {
     geometry.label({
       fields: [yField],
       callback,
-      cfg: transformLabel(
-        isRange
-          ? {
-              content: (item: object) => {
-                return item[yField]?.join('-');
-              },
-              ...cfg,
-            }
-          : cfg
-      ),
+      cfg: {
+        // 配置默认的 label layout： 如果用户没有指定 layout 和 position， 则自动配置 layout
+        layout: cfg?.position
+          ? undefined
+          : [
+              { type: 'interval-adjust-position' },
+              { type: 'interval-hide-overlap' },
+              { type: 'adjust-color' },
+              { type: 'limit-in-plot', cfg: { action: 'hide' } },
+            ],
+        ...transformLabel(
+          isRange
+            ? {
+                content: (item: object) => {
+                  return item[yField]?.join('-');
+                },
+                ...cfg,
+              }
+            : cfg
+        ),
+      },
     });
   }
 

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -124,7 +124,15 @@ function label(params: Params<LineOptions>): Params<LineOptions> {
     lineGeometry.label({
       fields: [yField],
       callback,
-      cfg: transformLabel(cfg),
+      cfg: {
+        layout: [
+          { type: 'limit-in-plot' },
+          { type: 'path-adjust-position' },
+          { type: 'point-adjust-position' },
+          { type: 'limit-in-plot', cfg: { action: 'hide' } },
+        ],
+        ...transformLabel(cfg),
+      },
     });
   }
 


### PR DESCRIPTION
为 Line/Area/Column/Bar 加上默认的 的 label layout，如果用户有配置，则以用户配置为准

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1142242/100870303-5d222b00-34d9-11eb-8f58-ff25797ab1bf.png) | ![image](https://user-images.githubusercontent.com/1142242/100870343-70cd9180-34d9-11eb-86e2-bba6a3feb289.png) |

