### PR TITLE
fix: fix duplicated label renderde for line and area plot

### DIFF
--- a/__tests__/bugs/issue-2064-spec.ts
+++ b/__tests__/bugs/issue-2064-spec.ts
@@ -1,0 +1,86 @@
+import { Line, Area, Radar } from '../../src';
+import { createDiv } from '../utils/dom';
+
+const data = [
+  {
+    type: '家具家电',
+    sales: 38,
+  },
+  {
+    type: '粮油副食',
+    sales: 52,
+  },
+];
+
+describe('#2064', () => {
+  it('#2064 line', () => {
+    const plot = new Line(createDiv(), {
+      width: 400,
+      height: 400,
+      data,
+      xField: 'type',
+      yField: 'sales',
+      point: {},
+      label: {},
+    });
+
+    plot.render();
+
+    const line = plot.chart.geometries.find((geom) => geom.type === 'line');
+    const point = plot.chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(line.labelsContainer.getChildren()).toHaveLength(data.length);
+    expect(point.labelsContainer.getChildren()).toHaveLength(0);
+
+    plot.destroy();
+  });
+
+  it('#2064 area', () => {
+    const plot = new Area(createDiv(), {
+      width: 400,
+      height: 400,
+      data,
+      xField: 'type',
+      yField: 'sales',
+      line: {},
+      point: {},
+      label: {},
+    });
+
+    plot.render();
+
+    const area = plot.chart.geometries.find((geom) => geom.type === 'area');
+    const line = plot.chart.geometries.find((geom) => geom.type === 'line');
+    const point = plot.chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(area.labelsContainer.getChildren()).toHaveLength(data.length);
+    expect(line.labelsContainer.getChildren()).toHaveLength(0);
+    expect(point.labelsContainer.getChildren()).toHaveLength(0);
+
+    plot.destroy();
+  });
+
+  it('#2064 radar', () => {
+    const plot = new Radar(createDiv(), {
+      width: 400,
+      height: 400,
+      data,
+      xField: 'type',
+      yField: 'sales',
+      area: {},
+      point: {},
+      label: {},
+      radius: 0.8,
+    });
+
+    plot.render();
+
+    const area = plot.chart.geometries.find((geom) => geom.type === 'area');
+    const line = plot.chart.geometries.find((geom) => geom.type === 'line');
+    const point = plot.chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(area.labelsContainer.getChildren()).toHaveLength(0);
+    expect(line.labelsContainer.getChildren()).toHaveLength(data.length);
+    expect(point.labelsContainer.getChildren()).toHaveLength(0);
+  });
+});

--- a/src/plots/area/adaptor.ts
+++ b/src/plots/area/adaptor.ts
@@ -54,6 +54,8 @@ function geometry(params: Params<AreaOptions>): Params<AreaOptions> {
         ...pointMapping,
       },
       tooltip: tooltipOptions,
+      // label 不传递给各个 geometry adaptor，由 label adaptor 处理
+      label: undefined,
     },
   });
   // area geometry 处理

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -34,6 +34,8 @@ function geometry(params: Params<LineOptions>): Params<LineOptions> {
         shape: 'circle',
         ...pointMapping,
       },
+      // label 不传递给各个 geometry adaptor，由 label adaptor 处理
+      label: undefined,
     },
   });
 

--- a/src/plots/radar/adaptor.ts
+++ b/src/plots/radar/adaptor.ts
@@ -33,6 +33,8 @@ function geometry(params: Params<RadarOptions>): Params<RadarOptions> {
             ...areaOptions,
           }
         : areaOptions,
+      // label 不传递给各个 geometry adaptor，由 label adaptor 处理
+      label: undefined,
     },
   });
 


### PR DESCRIPTION
- 给 geometry adaptor 添加 config 配置，允许 geometry adaptor 跳过某些步骤
- line/area/radar 等大部分图形有自己的 label adaptor，需要调整基础 geometry 中内置的 label 处理逻辑