### PR TITLE
fix(sankey): close sankey node tooltip

### DIFF
--- a/__tests__/bugs/issue-2015-spec.ts
+++ b/__tests__/bugs/issue-2015-spec.ts
@@ -33,7 +33,7 @@ describe('issue 2015', () => {
       tooltip: false,
     });
     // @ts-ignore
-    expect(scatter.chart.geometries[0].tooltipOption).toBeUndefined();
+    expect(scatter.chart.geometries[0].tooltipOption).toBe(false);
     scatter.destroy();
   });
 });

--- a/__tests__/unit/plots/scatter/tooltip-spec.ts
+++ b/__tests__/unit/plots/scatter/tooltip-spec.ts
@@ -44,10 +44,10 @@ describe('scatter', () => {
       tooltip: false,
     });
     expect(scatter.chart.getOptions().tooltip).toBe(false);
-    expect(scatter.chart.geometries[0].tooltipOption).toBeUndefined();
+    expect(scatter.chart.geometries[0].tooltipOption).toBe(false);
     expect(scatter.chart.getComponents().find((co) => co.type === 'tooltip')).toBe(undefined);
 
-    scatter.destroy();
+    // scatter.destroy();
   });
 
   it('tooltip: itemTpl options', () => {

--- a/__tests__/unit/utils/tooltip-spec.ts
+++ b/__tests__/unit/utils/tooltip-spec.ts
@@ -2,7 +2,7 @@ import { getTooltipMapping } from '../../../src/utils/tooltip';
 
 describe('util tooltip', () => {
   it('getTooltipMapping', () => {
-    expect(getTooltipMapping(false, [])).toEqual({});
+    expect(getTooltipMapping(false, [])).toEqual({ fields: false });
 
     expect(getTooltipMapping({}, ['x'])).toEqual({});
 

--- a/src/types/tooltip.ts
+++ b/src/types/tooltip.ts
@@ -3,7 +3,7 @@ import { TooltipAttr } from '../types/attr';
 
 export type TooltipMapping = {
   /** 指定需要显示 tooltip 中的字段，默认是包含 x seriesFields y  */
-  readonly fields?: string[];
+  readonly fields?: string[] | false;
   /** value 格式化 **/
   readonly formatter?: TooltipAttr;
 };

--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -9,7 +9,7 @@ import { Tooltip, TooltipMapping } from '../types/tooltip';
 export function getTooltipMapping(tooltip: Tooltip, defaultFields: string[]): TooltipMapping {
   if (tooltip === false) {
     return {
-      fields: false,
+      fields: false, // 关闭 tooltip
     };
   }
 

--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -8,7 +8,9 @@ import { Tooltip, TooltipMapping } from '../types/tooltip';
  */
 export function getTooltipMapping(tooltip: Tooltip, defaultFields: string[]): TooltipMapping {
   if (tooltip === false) {
-    return {};
+    return {
+      fields: false,
+    };
   }
 
   let fields = get(tooltip, 'fields');


### PR DESCRIPTION
 - [x] 桑基图的 node 节点不显示 tooltip

|  before  |  after  |
|---|---|
|  ![image](https://user-images.githubusercontent.com/7856674/101147655-a1d3d080-3657-11eb-9817-14a9b7ea207f.png)  |  ![image](https://user-images.githubusercontent.com/7856674/101147697-aef0bf80-3657-11eb-9342-00b7b09483d0.png) |
| 桑基图节点其实信息有限，所以不显示 tooltip  |   |

