### PR TITLE
fix(issue-2078): 修复 waterfall 无法关闭 tooltip

### DIFF
--- a/__tests__/bugs/issue-2078-spec.ts
+++ b/__tests__/bugs/issue-2078-spec.ts
@@ -1,0 +1,34 @@
+import { Waterfall } from '../../src';
+import { createDiv } from '../utils/dom';
+
+describe('#2078', () => {
+  const data = [
+    { type: '日用品', money: 300 },
+    { type: '伙食费', money: 900 },
+    { type: '交通费', money: -200 },
+    { type: '水电费', money: 300 },
+    { type: '房租', money: 1200 },
+    { type: '商场消费', money: 1000 },
+    { type: '应酬交际', money: 2000 },
+    { type: '总费用', money: 5900 },
+  ];
+
+  const waterfall = new Waterfall(createDiv(), {
+    width: 400,
+    height: 300,
+    xField: 'type',
+    yField: 'money',
+    data: data,
+    tooltip: false,
+  });
+
+  it('关闭 tooltip', () => {
+    waterfall.render();
+    // @ts-ignore
+    expect(waterfall.chart.getController('tooltip').isVisible()).toBe(false);
+  });
+
+  afterAll(() => {
+    waterfall.destroy();
+  });
+});

--- a/__tests__/unit/plots/waterfall/component-spec.ts
+++ b/__tests__/unit/plots/waterfall/component-spec.ts
@@ -9,6 +9,9 @@ describe('waterfall components', () => {
     data: salesByArea,
     xField: 'area',
     yField: 'sales',
+    total: {
+      label: '总计',
+    },
   });
 
   waterfall.render();
@@ -19,6 +22,11 @@ describe('waterfall components', () => {
     // 默认展示：rising, falling & total
     expect(legendController.getComponents()[0].id).toMatch('custom');
     expect(legendController.getComponents()[0].component.get('items').length).toBe(3);
+    expect(legendController.getComponents()[0].component.get('items')[2].name).toBe('总计');
+    expect(legendController.getComponents()[0].component.get('items')[2].value).toBe('total');
+
+    waterfall.update({ total: { label: '测试' } });
+    expect(legendController.getComponents()[0].component.get('items')[2].name).toBe('测试');
 
     waterfall.update({ total: false });
     expect(legendController.getComponents()[0].component.get('items').length).toBe(2);

--- a/__tests__/unit/plots/waterfall/component-spec.ts
+++ b/__tests__/unit/plots/waterfall/component-spec.ts
@@ -50,7 +50,7 @@ describe('waterfall components', () => {
       tooltip: false,
     });
     // @ts-ignore
-    expect(waterfall.chart.options.tooltip).toBe(undefined);
+    expect(waterfall.chart.options.tooltip).toBe(false);
     expect(waterfall.chart.getComponents().find((co) => co.type === 'tooltip')).toBe(undefined);
   });
 

--- a/src/plots/waterfall/adaptor.ts
+++ b/src/plots/waterfall/adaptor.ts
@@ -206,6 +206,8 @@ export function tooltip(params: Params<WaterfallOptions>): Params<WaterfallOptio
       fields: [yField],
       ...tooltip,
     });
+  } else {
+    chart.tooltip(false);
   }
 
   return params;


### PR DESCRIPTION
修复瀑布图(waterfall) 设置 `tooltip: false` 失效

- [x] testcase passed
