### PR TITLE
fix: only enable tooltip for primary geometry for line/area/radar

### DIFF
--- a/__tests__/unit/plots/area/tooltip-spec.ts
+++ b/__tests__/unit/plots/area/tooltip-spec.ts
@@ -54,4 +54,34 @@ describe('area', () => {
 
     area.destroy();
   });
+
+  it('line and point toolip', () => {
+    const area = new Area(createDiv(), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      appendPadding: 10,
+      line: {},
+      point: {},
+      tooltip: {
+        shared: true,
+      },
+    });
+
+    area.render();
+    const areaGeometry = area.chart.geometries.find((geom) => geom.type === 'area');
+    const lineGeometry = area.chart.geometries.find((geom) => geom.type === 'line');
+    const pointGeometry = area.chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(areaGeometry.tooltipOption).toBeUndefined();
+    expect(lineGeometry.tooltipOption).toBe(false);
+    expect(pointGeometry.tooltipOption).toBe(false);
+    // @ts-ignore
+    expect(area.chart.options.tooltip.shared).toBe(true);
+
+    area.destroy();
+  });
 });

--- a/__tests__/unit/plots/line/tooltip-spec.ts
+++ b/__tests__/unit/plots/line/tooltip-spec.ts
@@ -54,4 +54,31 @@ describe('line', () => {
 
     line.destroy();
   });
+
+  it('point tooltip', () => {
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      appendPadding: 10,
+      point: {},
+      tooltip: {
+        shared: true,
+      },
+    });
+
+    line.render();
+    const lineGeometry = line.chart.geometries.find((geom) => geom.type === 'line');
+    const pointGeometry = line.chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(lineGeometry.tooltipOption).toBeUndefined();
+    expect(pointGeometry.tooltipOption).toBe(false);
+    // @ts-ignore
+    expect(line.chart.getOptions().tooltip.shared).toBe(true);
+
+    line.destroy();
+  });
 });

--- a/__tests__/unit/plots/radar/tooltip-spec.ts
+++ b/__tests__/unit/plots/radar/tooltip-spec.ts
@@ -175,4 +175,35 @@ describe('radar, 自定义 tooltip', () => {
 
     radar.destroy();
   });
+
+  it('second geometry tooltip', () => {
+    const radar = new Radar(createDiv(), {
+      width: 400,
+      height: 300,
+      data: SERIES_DATA,
+      xField: 'name',
+      yField: 'value',
+      seriesField: 'type',
+      radius: 0.8,
+      point: {},
+      area: {},
+      tooltip: {
+        shared: true,
+      },
+    });
+
+    radar.render();
+
+    const lineGeometry = radar.chart.geometries.find((geom) => geom.type === 'line');
+    const pointGeometry = radar.chart.geometries.find((geom) => geom.type === 'point');
+    const areaGeometry = radar.chart.geometries.find((geom) => geom.type === 'area');
+
+    expect(lineGeometry.tooltipOption).toBeUndefined();
+    expect(pointGeometry.tooltipOption).toBe(false);
+    expect(areaGeometry.tooltipOption).toBe(false);
+    // @ts-ignore
+    expect(radar.chart.getOptions().tooltip.shared).toBe(true);
+
+    radar.destroy();
+  });
 });

--- a/__tests__/unit/plots/tiny-area/index-spec.ts
+++ b/__tests__/unit/plots/tiny-area/index-spec.ts
@@ -193,6 +193,32 @@ describe('tiny-area', () => {
     tinyArea.destroy();
   });
 
+  it('second geometry tooltip', () => {
+    const tinyArea = new TinyArea(createDiv(), {
+      width: 80,
+      height: 40,
+      line: {},
+      point: {},
+      data: partySupport
+        .filter((o) => o.type === 'FF')
+        .map((item) => {
+          return item.value;
+        }),
+      autoFit: false,
+    });
+
+    tinyArea.render();
+
+    const chart = tinyArea.chart;
+    const areaGeometry = chart.geometries.find((geom) => geom.type === 'area');
+    const lineGeometry = chart.geometries.find((geom) => geom.type === 'line');
+    const pointGeometry = chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(areaGeometry.tooltipOption).toBeUndefined();
+    expect(lineGeometry.tooltipOption).toBe(false);
+    expect(pointGeometry.tooltipOption).toBe(false);
+  });
+
   it('annotation', () => {
     const tinyArea = new TinyArea(createDiv(), {
       width: 200,

--- a/__tests__/unit/plots/tiny-line/index-spec.ts
+++ b/__tests__/unit/plots/tiny-line/index-spec.ts
@@ -119,6 +119,30 @@ describe('tiny-line', () => {
     tinyLine.destroy();
   });
 
+  it('second geometry tooltip', () => {
+    const tinyLine = new TinyLine(createDiv(), {
+      width: 80,
+      height: 40,
+      point: {},
+      data: partySupport
+        .filter((o) => o.type === 'FF')
+        .map((item) => {
+          return item.value;
+        }),
+      autoFit: true,
+    });
+
+    tinyLine.render();
+    const chart = tinyLine.chart;
+    const lineGeometry = chart.geometries.find((geom) => geom.type === 'line');
+    const pointGeometry = chart.geometries.find((geom) => geom.type === 'point');
+
+    expect(lineGeometry.tooltipOption).toBeUndefined();
+    expect(pointGeometry.tooltipOption).toBe(false);
+
+    tinyLine.destroy();
+  });
+
   it('data with custom tooltip', () => {
     const tinyLine = new TinyLine(createDiv(), {
       width: 80,

--- a/src/plots/area/adaptor.ts
+++ b/src/plots/area/adaptor.ts
@@ -40,7 +40,7 @@ function geometry(params: Params<AreaOptions>): Params<AreaOptions> {
         ...tooltip,
       }
     : tooltip;
-  const p = deepAssign({}, params, {
+  const primary = deepAssign({}, params, {
     options: {
       area: { color, style: areaStyle },
       // 颜色保持一致，因为如果颜色不一致，会导致 tooltip 中元素重复。
@@ -58,10 +58,12 @@ function geometry(params: Params<AreaOptions>): Params<AreaOptions> {
       label: undefined,
     },
   });
+  const second = deepAssign({}, primary, { options: { tooltip: false } });
+
   // area geometry 处理
-  area(p);
-  line(p);
-  point(p);
+  area(primary);
+  line(second);
+  point(second);
 
   return params;
 }

--- a/src/plots/line/adaptor.ts
+++ b/src/plots/line/adaptor.ts
@@ -19,7 +19,7 @@ function geometry(params: Params<LineOptions>): Params<LineOptions> {
   chart.data(data);
 
   // line geometry 处理
-  const p = deepAssign({}, params, {
+  const primary = deepAssign({}, params, {
     options: {
       shapeField: seriesField,
       line: {
@@ -38,9 +38,11 @@ function geometry(params: Params<LineOptions>): Params<LineOptions> {
       label: undefined,
     },
   });
+  const second = deepAssign({}, primary, { options: { tooltip: false } });
 
-  line(p);
-  point(p);
+  line(primary);
+  point(second);
+
   return params;
 }
 

--- a/src/plots/radar/adaptor.ts
+++ b/src/plots/radar/adaptor.ts
@@ -14,8 +14,8 @@ function geometry(params: Params<RadarOptions>): Params<RadarOptions> {
 
   chart.data(data);
 
-  // 雷达图 geometry
-  const p = deepAssign({}, params, {
+  // 雷达图 主 geometry
+  const primary = deepAssign({}, params, {
     options: {
       line: {
         style: lineStyle,
@@ -37,10 +37,16 @@ function geometry(params: Params<RadarOptions>): Params<RadarOptions> {
       label: undefined,
     },
   });
+  // 副 Geometry
+  const second = deepAssign({}, primary, {
+    options: {
+      tooltip: false,
+    },
+  });
 
-  line(p);
-  point(p);
-  area(p);
+  line(primary);
+  point(second);
+  area(second);
 
   return params;
 }

--- a/src/plots/tiny-area/adaptor.ts
+++ b/src/plots/tiny-area/adaptor.ts
@@ -20,7 +20,7 @@ function geometry(params: Params<TinyAreaOptions>): Params<TinyAreaOptions> {
 
   chart.data(seriesData);
 
-  const p = deepAssign({}, params, {
+  const primary = deepAssign({}, params, {
     options: {
       xField: X_FIELD,
       yField: Y_FIELD,
@@ -29,10 +29,12 @@ function geometry(params: Params<TinyAreaOptions>): Params<TinyAreaOptions> {
       point: pointOptions,
     },
   });
+  const second = deepAssign({}, primary, { options: { tooltip: false } });
+
   // area geometry 处理
-  area(p);
-  line(p);
-  point(p);
+  area(primary);
+  line(second);
+  point(second);
 
   chart.axis(false);
   chart.legend(false);

--- a/src/plots/tiny-line/adaptor.ts
+++ b/src/plots/tiny-line/adaptor.ts
@@ -21,7 +21,7 @@ function geometry(params: Params<TinyLineOptions>): Params<TinyLineOptions> {
   chart.data(seriesData);
 
   // line geometry 处理
-  const p = deepAssign({}, params, {
+  const primary = deepAssign({}, params, {
     options: {
       xField: X_FIELD,
       yField: Y_FIELD,
@@ -32,9 +32,10 @@ function geometry(params: Params<TinyLineOptions>): Params<TinyLineOptions> {
       point: pointMapping,
     },
   });
+  const second = deepAssign({}, primary, { options: { tooltip: false } });
 
-  line(p);
-  point(p);
+  line(primary);
+  point(second);
 
   chart.axis(false);
   chart.legend(false);


### PR DESCRIPTION
修复折线上图上 tooltip 有时会出现重复的 tooltip items，原因为多个 geometry 的 tooltip 同时显示出来了：

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1142242/101505021-d83e8200-39ae-11eb-82eb-c87c395e6b98.png) | ![image](https://user-images.githubusercontent.com/1142242/101505154-ff954f00-39ae-11eb-8f06-f5cdd0ae0a49.png) |

