### PR TITLE
修复折线图类型错误 & 调整默认 autoHide 配置

### DIFF
--- a/__tests__/unit/core/index-spec.ts
+++ b/__tests__/unit/core/index-spec.ts
@@ -211,12 +211,61 @@ describe('core', () => {
       xField: 'date',
       yField: 'value',
     });
-
-    line.render();
-
     expect(container.dataset.chartSourceType).toBe('G2Plot');
     line.destroy();
 
     expect(container.dataset.chartSourceType).toBe(undefined);
+  });
+
+  it('default autoHide', () => {
+    const line = new Line(createDiv(''), {
+      data: partySupport.filter((o) => o.type === 'FF'),
+      xField: 'date',
+      yField: 'value',
+    });
+
+    line.render();
+
+    expect(line.chart.getOptions().axes['date'].label.autoRotate).toBe(false);
+    expect(line.chart.getOptions().axes['date'].label.autoHide).toEqual({
+      type: 'equidistance',
+      cfg: {
+        minGap: 6,
+      },
+    });
+
+    line.update({
+      xAxis: {
+        label: {
+          autoHide: {
+            type: 'equidistance',
+            cfg: {
+              minGap: 12,
+            },
+          },
+        },
+      },
+    });
+    line.render();
+    expect(line.chart.getOptions().axes['date'].label.autoRotate).toBe(false);
+    expect(line.chart.getOptions().axes['date'].label.autoHide).toEqual({
+      type: 'equidistance',
+      cfg: {
+        minGap: 12,
+      },
+    });
+
+    line.update({
+      xAxis: {
+        label: {
+          autoHide: false,
+        },
+      },
+    });
+    line.render();
+    expect(line.chart.getOptions().axes['date'].label.autoRotate).toBe(false);
+    expect(line.chart.getOptions().axes['date'].label.autoHide).toBe(false);
+
+    line.destroy();
   });
 });

--- a/__tests__/unit/plots/histogram/axis-spec.ts
+++ b/__tests__/unit/plots/histogram/axis-spec.ts
@@ -112,7 +112,12 @@ describe('Histogram: axis', () => {
     expect(histogram.chart.options.axes.range).toEqual({
       nice: true,
       label: {
-        autoHide: true,
+        autoHide: {
+          type: 'equidistance',
+          cfg: {
+            minGap: 6,
+          },
+        },
         autoRotate: false,
       },
     });

--- a/__tests__/unit/plots/histogram/index-spec.ts
+++ b/__tests__/unit/plots/histogram/index-spec.ts
@@ -36,7 +36,12 @@ describe('histogram', () => {
     expect(histogram.chart.options.axes.range).toEqual({
       nice: true,
       label: {
-        autoHide: true,
+        autoHide: {
+          type: 'equidistance',
+          cfg: {
+            minGap: 6,
+          },
+        },
         autoRotate: false,
       },
     });

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -118,7 +118,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
         nice: true,
         label: {
           autoRotate: false,
-          autoHide: true,
+          autoHide: { type: 'equidistance', cfg: { minGap: 6 } },
         },
       },
       yAxis: {

--- a/src/plots/line/types.ts
+++ b/src/plots/line/types.ts
@@ -19,7 +19,7 @@ export interface LineOptions extends Options {
   /** 折线图形样式 */
   readonly lineStyle?: StyleAttr;
   /** 折线 shape 配置 */
-  readonly lineShape?: LineGeometryOptions['line']['shape'];
+  readonly lineShape?: Required<LineGeometryOptions>['line']['shape'];
   /** 折线数据点图形样式 */
   readonly point?: PointGeometryOptions['point'];
 }


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

### Screenshot

1. 调整默认的 autoHide 配置

|  Before  |  After  |
|----|----|
| ![image](https://user-images.githubusercontent.com/1142242/100538364-517cfd00-326a-11eb-9a09-1ba080ad86a9.png)| ![image](https://user-images.githubusercontent.com/1142242/100538359-3f02c380-326a-11eb-953a-dcd451a7af6f.png)| 

2. 修复折线图类型错误，close #2104 
