### PR TITLE
修复 chord 单测和增加 pie 单测

### DIFF
--- a/__tests__/bugs/issue-2096-spec.ts
+++ b/__tests__/bugs/issue-2096-spec.ts
@@ -1,0 +1,37 @@
+import { Pie } from '../../src';
+import { createDiv } from '../utils/dom';
+
+describe('#2096', () => {
+  const pie = new Pie(createDiv(), {
+    data: [
+      { type: '1', value: 10 },
+      { type: '13', value: 10 },
+      { type: '55', value: 10 },
+    ],
+    angleField: 'value',
+    colorField: 'type',
+    radius: 0.8,
+  });
+
+  it('normal', () => {
+    pie.render();
+    expect(pie.chart.interactions.tooltip).toBeDefined();
+  });
+
+  it('开启中心文本交互时，默认关闭 tooltip', () => {
+    pie.update({
+      innerRadius: 0.64,
+      statistic: {},
+      interactions: [{ type: 'pie-statistic-active' }],
+    });
+
+    expect(pie.chart.interactions.tooltip).not.toBeDefined();
+  });
+
+  it('开启中心文本交互时，需要显式注册 tooltip 交互来开启 tooltip', () => {
+    pie.update({
+      interactions: [{ type: 'pie-statistic-active' }, { type: 'tooltip' }],
+    });
+    expect(pie.chart.interactions.tooltip).toBeDefined();
+  });
+});

--- a/__tests__/unit/plots/chord/index-spec.ts
+++ b/__tests__/unit/plots/chord/index-spec.ts
@@ -64,7 +64,11 @@ describe('chord', () => {
     );
 
     // tooltip
-    chord.chart.showTooltip({ x: 500, y: 100 });
+    const edgeView = chord.chart.views[0];
+    const edgeElementIdx = edgeView.getData().findIndex((d) => d.source === '北京' && d.target === '天津');
+    const element = edgeView.geometries[0].elements[edgeElementIdx];
+    const path = element.shape.attr('path');
+    chord.chart.showTooltip({ x: path[0][1], y: path[0][2] });
     expect(document.querySelector('.g2-tooltip-name').textContent).toBe('北京 -> 天津');
     expect(document.querySelector('.g2-tooltip-value').textContent).toBe('30');
 


### PR DESCRIPTION
- test: 修复 chord 测试挂了
- test: 增加单测，保证"开启中心文本交互时，显式注册 tooltip 交互可以开启 tooltip"

### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #2096
- [x] add / modify test cases


### Screenshot

|  Before  |  After  |
|----|----|
| ![](https://gw.alipayobjects.com/zos/antfincdn/tTOwFf211j/linshi-1.gif)  |  ![](https://gw.alipayobjects.com/zos/antfincdn/mu0RBA91Uo/linshi-2.gif) |
|解读：在某些场景下，环图开启中心文本交互时，需要开启开启 tooltip；这里可以通过显示声明 tooltip 交互即可|

