### PR TITLE
feat: add default label layout for bullet

### DIFF
--- a/__tests__/unit/plots/bullet/label-spec.ts
+++ b/__tests__/unit/plots/bullet/label-spec.ts
@@ -3,8 +3,8 @@ import { bulletData } from '../../../data/bullet';
 import { createDiv } from '../../../utils/dom';
 
 describe('bullet*label', () => {
-  it('lable', () => {
-    const bullet = new Bullet(createDiv('lable bullet'), {
+  it('label', () => {
+    const bullet = new Bullet(createDiv('label bullet'), {
       width: 400,
       height: 100,
       data: bulletData,
@@ -68,7 +68,7 @@ describe('bullet*label', () => {
     bullet.destroy();
   });
 
-  it('lable*measure*null', () => {
+  it('label*measure*null', () => {
     const bullet = new Bullet(createDiv('lable*measure*null'), {
       width: 400,
       height: 100,
@@ -93,14 +93,14 @@ describe('bullet*label', () => {
     const chart = bullet.chart;
     const [rangeGeometry, measureGeometry, targetGeometry] = chart.geometries;
 
-    expect(rangeGeometry.labelOption).toEqual(undefined);
+    expect(rangeGeometry.labelOption).toEqual(false);
     expect(measureGeometry.getAdjust('stack')).toMatchObject({
       xField: 'title',
       yField: 'measures',
     });
 
     // @ts-ignore
-    expect(measureGeometry.labelOption).toEqual(undefined);
+    expect(measureGeometry.labelOption).toEqual(false);
     // @ts-ignore
     expect(targetGeometry.labelOption.fields[0]).toEqual('target');
     // @ts-ignore
@@ -109,5 +109,50 @@ describe('bullet*label', () => {
     expect(targetGeometry.labelOption.cfg.style.fill).toEqual('#fff');
 
     bullet.destroy();
+  });
+
+  it('label default layout', () => {
+    const bullet = new Bullet(createDiv('label bullet'), {
+      width: 400,
+      height: 100,
+      data: bulletData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+      label: {
+        range: {},
+        measure: {},
+        target: {},
+      },
+    });
+
+    bullet.render();
+
+    const chart = bullet.chart;
+    let [rangeGeometry, measureGeometry, targetGeometry] = chart.geometries;
+
+    // @ts-ignore
+    expect(rangeGeometry.labelOption.cfg.layout).toEqual([{ type: 'limit-in-plot' }]);
+    // @ts-ignore
+    expect(measureGeometry.labelOption.cfg.layout).toEqual([{ type: 'limit-in-plot' }]);
+    // @ts-ignore
+    expect(targetGeometry.labelOption.cfg.layout).toEqual([{ type: 'limit-in-plot' }]);
+
+    bullet.update({
+      label: {
+        range: {},
+        measure: {},
+        target: false,
+      },
+    });
+    bullet.render();
+    [rangeGeometry, measureGeometry, targetGeometry] = chart.geometries;
+
+    // @ts-ignore
+    expect(rangeGeometry.labelOption.cfg.layout).toEqual([{ type: 'limit-in-plot' }]);
+    // @ts-ignore
+    expect(measureGeometry.labelOption.cfg.layout).toEqual([{ type: 'limit-in-plot' }]);
+    expect(targetGeometry.labelOption).toBe(false);
   });
 });

--- a/src/plots/bullet/adaptor.ts
+++ b/src/plots/bullet/adaptor.ts
@@ -172,13 +172,28 @@ function label(params: Params<BulletOptions>): Params<BulletOptions> {
   const [rangeGeometry, measureGeometry, targetGeometry] = chart.geometries;
 
   if (get(label, 'range')) {
-    rangeGeometry.label(`${rangeField}`, transformLabel(label.range));
+    rangeGeometry.label(`${rangeField}`, {
+      layout: [{ type: 'limit-in-plot' }],
+      ...transformLabel(label.range),
+    });
+  } else {
+    rangeGeometry.label(false);
   }
   if (get(label, 'measure')) {
-    measureGeometry.label(`${measureField}`, transformLabel(label.measure));
+    measureGeometry.label(`${measureField}`, {
+      layout: [{ type: 'limit-in-plot' }],
+      ...transformLabel(label.measure),
+    });
+  } else {
+    measureGeometry.label(false);
   }
   if (get(label, 'target')) {
-    targetGeometry.label(`${targetField}`, transformLabel(label.target));
+    targetGeometry.label(`${targetField}`, {
+      layout: [{ type: 'limit-in-plot' }],
+      ...transformLabel(label.target),
+    });
+  } else {
+    targetGeometry.label(false);
   }
 
   return params;

--- a/src/plots/bullet/types.ts
+++ b/src/plots/bullet/types.ts
@@ -22,7 +22,7 @@ export interface BulletOptions extends Omit<Options, 'color' | 'label' | 'style'
   readonly targetField: string;
 
   /** label 包含了 measure,target,range */
-  readonly label?: BulletAttr<GeometryLabelAttr>;
+  readonly label?: BulletAttr<GeometryLabelAttr | false>;
 
   /** size 包含了 measure,target,range */
   readonly size?: BulletAttr<SizeAttr>;


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #1914 
- [ ] add / modify test cases
- [ ] documents, demos

给 bullet 的 label 添加默认的 layout
close https://github.com/antvis/G2Plot/issues/1914

### Screenshot

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/1142242/103052335-da6e2680-45d3-11eb-9e53-78341eef57c8.png) |  ![image](https://user-images.githubusercontent.com/1142242/103052260-a7c42e00-45d3-11eb-8379-7b28152a1626.png) |
