### PR TITLE
feat: changedata

### DIFF
--- a/__tests__/unit/core/index-spec.ts
+++ b/__tests__/unit/core/index-spec.ts
@@ -55,7 +55,6 @@ describe('core', () => {
     const line = new Line(createDiv(), options);
 
     line.render();
-    const curOptions = clone(line.options);
 
     // @ts-ignore
     line.updateOption({

--- a/__tests__/unit/core/index-spec.ts
+++ b/__tests__/unit/core/index-spec.ts
@@ -40,6 +40,41 @@ describe('core', () => {
     line.destroy();
   });
 
+  it('updateOption without render', () => {
+    const options = {
+      width: 400,
+      height: 300,
+      data: [
+        { date: '12-01', value: 1, type: 'bb' },
+        { date: '12-02', value: 12, type: 'bb' },
+      ],
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+    };
+    const line = new Line(createDiv(), options);
+
+    line.render();
+    const curOptions = clone(line.options);
+
+    // @ts-ignore
+    line.updateOption({
+      data: [...line.options.data, { date: '12-01', value: 4, type: 'cc' }, { date: '12-02', value: 19, type: 'cc' }],
+    });
+
+    expect(line.chart.geometries[0].elements.length).toBe(1);
+
+    line.render();
+    expect(line.chart.geometries[0].elements.length).toBe(2);
+
+    line.update({
+      data: [...line.options.data, { date: '12-01', value: 4, type: 'dd' }, { date: '12-02', value: 19, type: 'dd' }],
+    });
+    expect(line.chart.geometries[0].elements.length).toBe(3);
+
+    line.destroy();
+  });
+
   it('update mix with default options', () => {
     const options = {
       width: 400,
@@ -53,9 +88,7 @@ describe('core', () => {
     line.render();
     const curOptions = clone(line.options);
 
-    line.update({ ...options, width: 500 });
-
-    line.render();
+    line.update({ width: 500 });
 
     expect(isEqual(line.options, deepMix(curOptions, { ...options, width: 500 }))).toBeTruthy();
 

--- a/__tests__/unit/plots/gauge/index-spec.ts
+++ b/__tests__/unit/plots/gauge/index-spec.ts
@@ -1,4 +1,5 @@
 import { Gauge } from '../../../../src';
+import { INDICATEOR_VIEW_ID, RANGE_VIEW_ID } from '../../../../src/plots/gauge/constant';
 import { pick } from '../../../../src/utils';
 import { createDiv } from '../../../utils/dom';
 
@@ -114,6 +115,8 @@ describe('gauge', () => {
     });
 
     gauge.render();
+    expect(gauge.chart.views[0].id).toEqual(INDICATEOR_VIEW_ID);
+    expect(gauge.chart.views[1].id).toEqual(RANGE_VIEW_ID);
     // @ts-ignore
     expect(gauge.chart.views[1].getYScales()[0].ticks).toEqual([0, 0.25, 0.5, 0.75, 1]);
     expect(gauge.chart.views.length).toBe(2);
@@ -141,6 +144,7 @@ describe('gauge', () => {
 
     gauge.render();
 
+    expect(gauge.chart.views[0].id).toEqual(RANGE_VIEW_ID);
     expect(gauge.chart.views.length).toBe(1);
     expect(gauge.chart.views[0].geometries[0].type).toBe('interval');
 

--- a/__tests__/unit/plots/gauge/statistic-spec.ts
+++ b/__tests__/unit/plots/gauge/statistic-spec.ts
@@ -44,6 +44,23 @@ describe('gauge statistic', () => {
     expect((annotations[0] as HTMLElement).innerText).toBe('测试');
   });
 
+  it('change data', () => {
+    gauge.changeData(0.35);
+    const annotations = document.body.querySelectorAll('.g2-html-annotation');
+    expect(annotations.length).toBe(2);
+    expect((annotations[1] as HTMLElement).innerText).toBe('35.0%');
+
+    gauge.changeData(0.15);
+    expect((document.body.querySelectorAll('.g2-html-annotation')[1] as HTMLElement).innerText).toBe('15.0%');
+
+    gauge.update({ statistic: { content: {}, title: false } });
+    expect(document.body.querySelectorAll('.g2-html-annotation').length).toBe(1);
+    expect((document.body.querySelectorAll('.g2-html-annotation')[0] as HTMLElement).innerText).toBe('15.0%');
+
+    gauge.changeData(0.05);
+    expect((document.body.querySelectorAll('.g2-html-annotation')[0] as HTMLElement).innerText).toBe('5.0%');
+  });
+
   afterAll(() => {
     gauge.destroy();
   });

--- a/__tests__/unit/plots/gauge/utils-spec.ts
+++ b/__tests__/unit/plots/gauge/utils-spec.ts
@@ -1,0 +1,28 @@
+import { PERCENT, RANGE_TYPE, RANGE_VALUE } from '../../../../src/plots/gauge/constant';
+import { getIndicatorData, getRangeData } from '../../../../src/plots/gauge/utils';
+
+describe('gauge utils to getData', () => {
+  it('get indicatorData', () => {
+    expect(getIndicatorData(0.1)).toEqual([{ [PERCENT]: 0.1 }]);
+    expect(getIndicatorData(1.4)).toEqual([{ [PERCENT]: 1 }]);
+    expect(getIndicatorData(-0.4)).toEqual([{ [PERCENT]: 0 }]);
+  });
+
+  it('get rangeData', () => {
+    expect(getRangeData(0.5, { ticks: [0, 0.3, 1] })).toEqual([
+      { [RANGE_VALUE]: 0.3, [RANGE_TYPE]: '1' },
+      { [RANGE_VALUE]: 0.7, [RANGE_TYPE]: '2' },
+    ]);
+
+    expect(getRangeData(0.5)).toEqual([
+      { [RANGE_VALUE]: 0.5, [RANGE_TYPE]: '1' },
+      { [RANGE_VALUE]: 0.5, [RANGE_TYPE]: '2' },
+    ]);
+
+    expect(getRangeData(-0.5)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '2' }]);
+    expect(getRangeData(1.5)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '1' }]);
+
+    expect(getRangeData(0)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '2' }]);
+    expect(getRangeData(1)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '1' }]);
+  });
+});

--- a/__tests__/unit/plots/line/change-data-spec.ts
+++ b/__tests__/unit/plots/line/change-data-spec.ts
@@ -1,0 +1,51 @@
+import { Line } from '../../../../src';
+import { partySupport } from '../../../data/party-support';
+import { createDiv } from '../../../utils/dom';
+
+describe('line', () => {
+  it('change data', () => {
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      data: partySupport.filter((o) => ['FF'].includes(o.type)),
+      xField: 'date',
+      yField: 'value',
+      seriesField: 'type',
+      color: ['blue', 'red'],
+      appendPadding: 10,
+      connectNulls: true,
+    });
+
+    line.render();
+
+    expect(line.chart.geometries[0].elements.length).toBe(1);
+
+    line.changeData(partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)));
+    expect(line.chart.geometries[0].elements.length).toBe(2);
+    expect(line.options.data).toEqual(partySupport.filter((o) => ['FF', 'Lab'].includes(o.type)));
+
+    line.destroy();
+  });
+
+  it('add point', () => {
+    const line = new Line(createDiv(), {
+      width: 400,
+      height: 300,
+      data: [
+        { type: '1', value: 10 },
+        { type: '2', value: 3 },
+      ],
+      xField: 'type',
+      yField: 'value',
+      point: {},
+    });
+
+    line.render();
+    expect(line.chart.geometries[1].elements.length).toBe(2);
+
+    line.changeData([...line.options.data, { type: '3', value: 10 }]);
+    expect(line.chart.geometries[1].elements.length).toBe(3);
+
+    line.destroy();
+  });
+});

--- a/docs/api/plots/gauge.zh.md
+++ b/docs/api/plots/gauge.zh.md
@@ -49,8 +49,10 @@ order: 22
 
 | 配置项 | 类型     | 描述                                 |
 | ------ | -------- | ------------------------------------ |
-| ticks  | number[] | 辅助圆弧显示数字数组                 |
-| color  | string[] | 辅助圆弧的颜色色板，按照色板顺序取值 |
+| ticks  | _number[]_ | 辅助圆弧显示数字数组                 |
+| color  | _string/|string[]_ | 辅助圆弧的颜色色板，按照色板顺序取值; 当设置 ticks 时，color 无法使用回调的方式 |
+
+<playground rid="gauge" path="progress-plots/gauge/demo/basic.ts"></playground>
 
 #### axis
 

--- a/examples/line/basic/demo/dynamic-line.ts
+++ b/examples/line/basic/demo/dynamic-line.ts
@@ -1,0 +1,29 @@
+import { Line } from '@antv/g2plot';
+
+fetch('https://gw.alipayobjects.com/os/bmw-prod/1d565782-dde4-4bb6-8946-ea6a38ccf184.json')
+  .then((res) => res.json())
+  .then((data) => {
+    const line = new Line('container', {
+      data,
+      padding: 'auto',
+      xField: 'Date',
+      yField: 'scales',
+      xAxis: {
+        type: 'timeCat',
+        tickCount: 5,
+      },
+    });
+
+    line.render();
+
+    let year = 2017;
+    let month = 2;
+    const interval = setInterval(() => {
+      if (year > 2211) {
+        clearInterval(interval);
+      }
+      month = (month + 1) % 12;
+      year += Math.ceil(month / 12);
+      line.changeData([...line.options.data, { Date: `${year}-${month}`, scales: 1300 * Math.random() + 500 }]);
+    }, 500);
+  });

--- a/examples/line/basic/demo/line-with-data-marker.ts
+++ b/examples/line/basic/demo/line-with-data-marker.ts
@@ -1,0 +1,118 @@
+import { G2, Line } from '@antv/g2plot';
+
+G2.registerShape('point', 'breath-point', {
+  draw(cfg, container) {
+    const data = cfg.data;
+    const point = { x: cfg.x, y: cfg.y };
+    const group = container.addGroup();
+    if (data.time === '14.20' && data.date === 'today') {
+      const decorator1 = group.addShape('circle', {
+        attrs: {
+          x: point.x,
+          y: point.y,
+          r: 10,
+          fill: cfg.color,
+          opacity: 0.5,
+        },
+      });
+      const decorator2 = group.addShape('circle', {
+        attrs: {
+          x: point.x,
+          y: point.y,
+          r: 10,
+          fill: cfg.color,
+          opacity: 0.5,
+        },
+      });
+      const decorator3 = group.addShape('circle', {
+        attrs: {
+          x: point.x,
+          y: point.y,
+          r: 10,
+          fill: cfg.color,
+          opacity: 0.5,
+        },
+      });
+      decorator1.animate(
+        {
+          r: 20,
+          opacity: 0,
+        },
+        {
+          duration: 1800,
+          easing: 'easeLinear',
+          repeat: true,
+        }
+      );
+      decorator2.animate(
+        {
+          r: 20,
+          opacity: 0,
+        },
+        {
+          duration: 1800,
+          easing: 'easeLinear',
+          repeat: true,
+          delay: 600,
+        }
+      );
+      decorator3.animate(
+        {
+          r: 20,
+          opacity: 0,
+        },
+        {
+          duration: 1800,
+          easing: 'easeLinear',
+          repeat: true,
+          delay: 1200,
+        }
+      );
+      group.addShape('circle', {
+        attrs: {
+          x: point.x,
+          y: point.y,
+          r: 6,
+          fill: cfg.color,
+          opacity: 0.7,
+        },
+      });
+      group.addShape('circle', {
+        attrs: {
+          x: point.x,
+          y: point.y,
+          r: 1.5,
+          fill: cfg.color,
+        },
+      });
+    }
+
+    return group;
+  },
+});
+
+fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/cpu-data.json')
+  .then((res) => res.json())
+  .then((data) => {
+    const plot = new Line('container', {
+      autoFit: true,
+      height: 500,
+      data,
+      meta: {
+        cpu: {
+          time: { type: 'cat' },
+          max: 100,
+          min: 0,
+        },
+      },
+      xField: 'time',
+      yField: 'cpu',
+      seriesField: 'date',
+      tooltip: { showMarkers: false },
+      point: {
+        shape: 'breath-point',
+      },
+    });
+
+    plot.render();
+  });

--- a/examples/line/basic/demo/meta.json
+++ b/examples/line/basic/demo/meta.json
@@ -10,7 +10,7 @@
         "zh": "基础折线图",
         "en": "Basic line plot"
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*DRzUQ4UkxjMAAAAAAAAAAAAAARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/aiERL4ey%24U/08d95f7b-46cb-4bfd-89b2-be36343d44a1.png"
     },
     {
       "filename": "spline.ts",
@@ -42,15 +42,15 @@
         "zh": "动态更新折线图",
         "en": "Line plot updated dynamic"
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*7V6nSpj64uYAAAAAAAAAAAAAARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/vOmMGBA1k6/dongtaigengxinzhexiantushuju2.gif"
     },
     {
-      "filename": "line-with-data-marker",
+      "filename": "line-with-data-marker.ts",
       "title": {
         "zh": "带标注点的折线图",
         "en": "Line plot with dataMarker"
       },
-      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/HUfUqARs9x/de2a0680-0276-499a-88f3-6bf75a9e197b.png"
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/7jMv8M%26Dlh/dongtaigengxinzhexiantushuju.gif"
     },
     {
       "filename": "line-annotation.ts",

--- a/examples/line/basic/demo/meta.json
+++ b/examples/line/basic/demo/meta.json
@@ -13,10 +13,18 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*DRzUQ4UkxjMAAAAAAAAAAAAAARQnAQ"
     },
     {
+      "filename": "spline.ts",
+      "title": {
+        "zh": "基础曲线图",
+        "en": "Basic spline plot"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*DRzUQ4UkxjMAAAAAAAAAAAAAARQnAQ"
+    },
+    {
       "filename": "line-point-style.ts",
       "title": {
         "zh": "配置折线数据点样式",
-        "en": "Line plot data point style"
+        "en": "Set style of line plot point"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*VN5SQYsPOaIAAAAAAAAAAAAAARQnAQ"
     },
@@ -29,10 +37,18 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*r8MPQ4n9CIQAAAAAAAAAAAAAARQnAQ"
     },
     {
+      "filename": "line-with-data-marker",
+      "title": {
+        "zh": "带标注点的折线图",
+        "en": "Line plot with dataMarker"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/HUfUqARs9x/de2a0680-0276-499a-88f3-6bf75a9e197b.png"
+    },
+    {
       "filename": "line-annotation.ts",
       "title": {
-        "zh": "折线图带图表标注",
-        "en": "Line plot with guide line"
+        "zh": "条件样式折线图",
+        "en": "Line plot with regionFilter"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*7V6nSpj64uYAAAAAAAAAAAAAARQnAQ"
     }

--- a/examples/line/basic/demo/meta.json
+++ b/examples/line/basic/demo/meta.json
@@ -37,6 +37,14 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*r8MPQ4n9CIQAAAAAAAAAAAAAARQnAQ"
     },
     {
+      "filename": "dynamic-line.ts",
+      "title": {
+        "zh": "动态更新折线图",
+        "en": "Line plot updated dynamic"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*7V6nSpj64uYAAAAAAAAAAAAAARQnAQ"
+    },
+    {
       "filename": "line-with-data-marker",
       "title": {
         "zh": "带标注点的折线图",

--- a/examples/line/basic/demo/spline.ts
+++ b/examples/line/basic/demo/spline.ts
@@ -12,6 +12,7 @@ fetch('https://gw.alipayobjects.com/os/bmw-prod/1d565782-dde4-4bb6-8946-ea6a38cc
         type: 'timeCat',
         tickCount: 5,
       },
+      smooth: true,
     });
 
     line.render();

--- a/examples/progress-plots/gauge/demo/basic.ts
+++ b/examples/progress-plots/gauge/demo/basic.ts
@@ -49,9 +49,8 @@ const interval = setInterval(() => {
   if (data >= 0.85) {
     clearInterval(interval);
   } else {
-    data += 0.005;
+    data += 0.001;
     gauge.changeData(data);
     // range color 需要提供回调的方式
-    gauge.update({ range: { color: getColor(data) } });
   }
-}, 500);
+}, 100);

--- a/examples/progress-plots/gauge/demo/basic.ts
+++ b/examples/progress-plots/gauge/demo/basic.ts
@@ -49,7 +49,9 @@ const interval = setInterval(() => {
   if (data >= 0.85) {
     clearInterval(interval);
   } else {
-    data += 0.095;
-    gauge.update({ percent: data, range: { color: getColor(data) } });
+    data += 0.005;
+    gauge.changeData(data);
+    // range color 需要提供回调的方式
+    gauge.update({ range: { color: getColor(data) } });
   }
 }, 500);

--- a/examples/progress-plots/gauge/demo/basic.ts
+++ b/examples/progress-plots/gauge/demo/basic.ts
@@ -51,6 +51,6 @@ const interval = setInterval(() => {
   } else {
     data += 0.001;
     gauge.changeData(data);
-    // range color 需要提供回调的方式
+    gauge.update({ range: { color: getColor(data) } });
   }
 }, 100);

--- a/examples/progress-plots/gauge/demo/complex.ts
+++ b/examples/progress-plots/gauge/demo/complex.ts
@@ -56,6 +56,6 @@ const interval = setInterval(() => {
   if (data >= 1) {
     clearInterval(interval);
   }
-  data += 0.1;
+  data += 0.01;
   gauge.changeData(data);
-}, 1000);
+}, 400);

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -161,12 +161,20 @@ export abstract class Plot<O extends PickOptions> extends EE {
   }
 
   /**
-   * 更新配置
+   * 更新: 更新配置且重新渲染
    * @param options
    */
   public update(options: Partial<O>) {
-    this.options = deepAssign({}, this.options, options);
+    this.updateOptions(options);
     this.render();
+  }
+
+  /**
+   * 更新配置
+   * @param options
+   */
+  public updateOptions(options: Partial<O>) {
+    this.options = deepAssign({}, this.options, options);
   }
 
   /**
@@ -205,6 +213,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
 
   /**
    * 更新数据
+   * @override
    * @param options
    */
   public changeData(data: any) {

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -165,7 +165,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * @param options
    */
   public update(options: Partial<O>) {
-    this.updateOptions(options);
+    this.updateOption(options);
     this.render();
   }
 
@@ -173,7 +173,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * 更新配置
    * @param options
    */
-  public updateOptions(options: Partial<O>) {
+  protected updateOption(options: Partial<O>) {
     this.options = deepAssign({}, this.options, options);
   }
 

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -6,7 +6,7 @@ import { Data } from '../../types';
 import { deepAssign, flow, pick, renderGaugeStatistic } from '../../utils';
 import { RANGE_TYPE, RANGE_VALUE, PERCENT, DEFAULT_COLOR, INDICATEOR_VIEW_ID, RANGE_VIEW_ID } from './constant';
 import { GaugeOptions } from './types';
-import { getIndicatorViewData, getRangeViewData } from './utils';
+import { getIndicatorData, getRangeData } from './utils';
 
 /**
  * geometry 处理
@@ -20,7 +20,7 @@ function geometry(params: Params<GaugeOptions>): Params<GaugeOptions> {
   // 指标 & 指针
   // 如果开启在应用
   if (indicator) {
-    const indicatorData = getIndicatorViewData(percent);
+    const indicatorData = getIndicatorData(percent);
 
     const v1 = chart.createView({ id: INDICATEOR_VIEW_ID });
     v1.data(indicatorData);
@@ -47,7 +47,7 @@ function geometry(params: Params<GaugeOptions>): Params<GaugeOptions> {
 
   // 辅助 range
   // [{ range: 1, type: '0' }]
-  const rangeData: Data = getRangeViewData(percent, options.range);
+  const rangeData: Data = getRangeData(percent, options.range);
   const v2 = chart.createView({ id: RANGE_VIEW_ID });
   v2.data(rangeData);
 
@@ -87,10 +87,12 @@ function meta(params: Params<GaugeOptions>): Params<GaugeOptions> {
  * 统计指标文档
  * @param params
  */
-function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
+function statistic(params: Params<GaugeOptions>, updated?: boolean): Params<GaugeOptions> {
   const { chart, options } = params;
   const { statistic, percent } = options;
 
+  // 先清空标注，再重新渲染
+  chart.getController('annotation').clear(true);
   if (statistic) {
     const { content } = statistic;
     let transformContent;
@@ -114,6 +116,10 @@ function statistic(params: Params<GaugeOptions>): Params<GaugeOptions> {
     renderGaugeStatistic(chart, { statistic: { ...statistic, content: transformContent } }, { percent });
   }
 
+  if (updated) {
+    chart.render(true);
+  }
+
   return params;
 }
 
@@ -129,6 +135,11 @@ function other(params: Params<GaugeOptions>): Params<GaugeOptions> {
 
   return params;
 }
+
+/**
+ * 对外暴露的 adaptor
+ */
+export { statistic };
 
 /**
  * 图适配器

--- a/src/plots/gauge/adaptor.ts
+++ b/src/plots/gauge/adaptor.ts
@@ -1,12 +1,12 @@
-import { isString, clamp, size } from '@antv/util';
+import { isString } from '@antv/util';
 import { interaction, animation, theme, scale } from '../../adaptor/common';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 import { Params } from '../../core/adaptor';
 import { Data } from '../../types';
 import { deepAssign, flow, pick, renderGaugeStatistic } from '../../utils';
-import { RANGE_TYPE, RANGE_VALUE, PERCENT, DEFAULT_COLOR } from './constant';
+import { RANGE_TYPE, RANGE_VALUE, PERCENT, DEFAULT_COLOR, INDICATEOR_VIEW_ID, RANGE_VIEW_ID } from './constant';
 import { GaugeOptions } from './types';
-import { processRangeData } from './utils';
+import { getIndicatorViewData, getRangeViewData } from './utils';
 
 /**
  * geometry 处理
@@ -15,15 +15,14 @@ import { processRangeData } from './utils';
 function geometry(params: Params<GaugeOptions>): Params<GaugeOptions> {
   const { chart, options } = params;
   const { percent, range, radius, innerRadius, startAngle, endAngle, axis, indicator } = options;
-  const { ticks, color } = range;
-  const clampTicks = size(ticks) ? ticks : [0, clamp(percent, 0, 1), 1];
+  const { color } = range;
 
   // 指标 & 指针
   // 如果开启在应用
   if (indicator) {
-    const indicatorData = [{ [PERCENT]: clamp(percent, 0, 1) }];
+    const indicatorData = getIndicatorViewData(percent);
 
-    const v1 = chart.createView();
+    const v1 = chart.createView({ id: INDICATEOR_VIEW_ID });
     v1.data(indicatorData);
 
     v1.point()
@@ -48,8 +47,8 @@ function geometry(params: Params<GaugeOptions>): Params<GaugeOptions> {
 
   // 辅助 range
   // [{ range: 1, type: '0' }]
-  const rangeData: Data = processRangeData(clampTicks as number[]);
-  const v2 = chart.createView();
+  const rangeData: Data = getRangeViewData(percent, options.range);
+  const v2 = chart.createView({ id: RANGE_VIEW_ID });
   v2.data(rangeData);
 
   const rangeColor = isString(color) ? [color, DEFAULT_COLOR] : color;

--- a/src/plots/gauge/constant.ts
+++ b/src/plots/gauge/constant.ts
@@ -3,3 +3,7 @@ export const RANGE_TYPE = 'type';
 export const PERCENT = 'percent';
 
 export const DEFAULT_COLOR = '#f0f0f0';
+
+/** 仪表盘由 指针和表盘 组成 */
+export const INDICATEOR_VIEW_ID = 'indicator_view';
+export const RANGE_VIEW_ID = 'range_view';

--- a/src/plots/gauge/constant.ts
+++ b/src/plots/gauge/constant.ts
@@ -5,5 +5,5 @@ export const PERCENT = 'percent';
 export const DEFAULT_COLOR = '#f0f0f0';
 
 /** 仪表盘由 指针和表盘 组成 */
-export const INDICATEOR_VIEW_ID = 'indicator_view';
-export const RANGE_VIEW_ID = 'range_view';
+export const INDICATEOR_VIEW_ID = 'indicator-view';
+export const RANGE_VIEW_ID = 'range-view';

--- a/src/plots/gauge/index.ts
+++ b/src/plots/gauge/index.ts
@@ -1,9 +1,9 @@
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { GaugeOptions } from './types';
-import { adaptor } from './adaptor';
+import { adaptor, statistic } from './adaptor';
 import { RANGE_VALUE, PERCENT, INDICATEOR_VIEW_ID, RANGE_VIEW_ID } from './constant';
-import { getIndicatorViewData, getRangeViewData } from './utils';
+import { getIndicatorData, getRangeData } from './utils';
 // 注册 shape
 import './shapes/gauge';
 
@@ -82,17 +82,19 @@ export class Gauge extends Plot<GaugeOptions> {
    * @param percent
    */
   public changeData(percent: number) {
-    this.updateOptions({ percent });
+    this.updateOption({ percent });
 
     const indicatorView = this.chart.views.find((v) => v.id === INDICATEOR_VIEW_ID);
     if (indicatorView) {
-      indicatorView.changeData(getIndicatorViewData(percent));
+      indicatorView.data(getIndicatorData(percent));
     }
 
     const rangeView = this.chart.views.find((v) => v.id === RANGE_VIEW_ID);
     if (rangeView) {
-      rangeView.changeData(getRangeViewData(percent, this.options.range));
+      rangeView.data(getRangeData(percent, this.options.range));
     }
+    // todo 后续让 G2 层在 afterrender 之后，来重绘 annotations
+    statistic({ chart: this.chart, options: this.options }, true);
   }
 
   /**

--- a/src/plots/gauge/index.ts
+++ b/src/plots/gauge/index.ts
@@ -2,7 +2,8 @@ import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { GaugeOptions } from './types';
 import { adaptor } from './adaptor';
-import { RANGE_VALUE, PERCENT } from './constant';
+import { RANGE_VALUE, PERCENT, INDICATEOR_VIEW_ID, RANGE_VIEW_ID } from './constant';
+import { getIndicatorViewData, getRangeViewData } from './utils';
 // 注册 shape
 import './shapes/gauge';
 
@@ -81,9 +82,17 @@ export class Gauge extends Plot<GaugeOptions> {
    * @param percent
    */
   public changeData(percent: number) {
-    this.update({
-      percent,
-    });
+    this.updateOptions({ percent });
+
+    const indicatorView = this.chart.views.find((v) => v.id === INDICATEOR_VIEW_ID);
+    if (indicatorView) {
+      indicatorView.changeData(getIndicatorViewData(percent));
+    }
+
+    const rangeView = this.chart.views.find((v) => v.id === RANGE_VIEW_ID);
+    if (rangeView) {
+      rangeView.changeData(getRangeViewData(percent, this.options.range));
+    }
   }
 
   /**

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -1,5 +1,7 @@
+import { clamp, get, size } from '@antv/util';
 import { Data, Datum } from '../../types';
-import { RANGE_VALUE, RANGE_TYPE } from './constant';
+import { RANGE_VALUE, RANGE_TYPE, PERCENT } from './constant';
+import { GaugeOptions } from './types';
 
 /**
  * 将 range 生成为 data 数据
@@ -16,4 +18,19 @@ export function processRangeData(range: number[]): Data {
       // 去掉 0 的数据
       .filter((d: Datum) => !!d[RANGE_VALUE])
   );
+}
+
+/**
+ * 获取 仪表盘 指针数据
+ * @param percent
+ */
+export function getIndicatorViewData(percent: GaugeOptions['percent']): Data {
+  return [{ [PERCENT]: clamp(percent, 0, 1) }];
+}
+
+export function getRangeViewData(percent: GaugeOptions['percent'], range: GaugeOptions['range']): Data {
+  const ticks = get(range, ['ticks'], []);
+
+  const clampTicks = size(ticks) ? ticks : [0, clamp(percent, 0, 1), 1];
+  return processRangeData(clampTicks as number[]);
 }

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -33,7 +33,7 @@ export function getIndicatorData(percent: GaugeOptions['percent']): Data {
  * @param percent
  * @param range
  */
-export function getRangeData(percent: GaugeOptions['percent'], range: GaugeOptions['range']): Data {
+export function getRangeData(percent: GaugeOptions['percent'], range?: GaugeOptions['range']): Data {
   const ticks = get(range, ['ticks'], []);
 
   const clampTicks = size(ticks) ? ticks : [0, clamp(percent, 0, 1), 1];

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -24,11 +24,16 @@ export function processRangeData(range: number[]): Data {
  * 获取 仪表盘 指针数据
  * @param percent
  */
-export function getIndicatorViewData(percent: GaugeOptions['percent']): Data {
+export function getIndicatorData(percent: GaugeOptions['percent']): Data {
   return [{ [PERCENT]: clamp(percent, 0, 1) }];
 }
 
-export function getRangeViewData(percent: GaugeOptions['percent'], range: GaugeOptions['range']): Data {
+/**
+ * 获取仪表盘 表盘弧形数据
+ * @param percent
+ * @param range
+ */
+export function getRangeData(percent: GaugeOptions['percent'], range: GaugeOptions['range']): Data {
   const ticks = get(range, ['ticks'], []);
 
   const clampTicks = size(ticks) ? ticks : [0, clamp(percent, 0, 1), 1];

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -13,6 +13,16 @@ export class Line extends Plot<LineOptions> {
   public type: string = 'line';
 
   /**
+   * @override
+   * @param data
+   */
+  public changeData(data: LineOptions['data']) {
+    // @ts-ignore
+    this.updateOptions({ data });
+    this.chart.changeData(data);
+  }
+
+  /**
    * 获取 折线图 默认配置
    */
   protected getDefaultOptions() {

--- a/src/plots/line/index.ts
+++ b/src/plots/line/index.ts
@@ -17,8 +17,7 @@ export class Line extends Plot<LineOptions> {
    * @param data
    */
   public changeData(data: LineOptions['data']) {
-    // @ts-ignore
-    this.updateOptions({ data });
+    this.updateOption({ data });
     this.chart.changeData(data);
   }
 


### PR DESCRIPTION
### Descriptions

- 使用 g2 的 `changeData` api 来更新数据，每个 plot 复写 core 的 `changeData` 方法（后续全面迁移完成后，设置为**抽象方法**）
- `core/plot` 提供 `updateOption` 方法
- 图表大致可以分为两类：数据为正常 Data 类型（无需转换） & 单数据、组合数据或 多view（数据转换），关于组合的，可以把数据获取抽取为通用纯函数，在 chagneData 的时候，也可以对数据进行相应转换，但存在问题是：逻辑会存在在 adpator 和 changeData 处，比较分散；
- 另外，为此提供两个示例验证下：折线图 和 仪表盘
    - [x] line
    - [x] 仪表盘(annotation):  需要更新两个 view 的数据，同时重新执行 annotation adaptor
    - [ ] 其他...

### Screenshot

|  Before  |  After  |
|----|----|
| ![](https://gw.alipayobjects.com/zos/antfincdn/YSyzHbOmkX/dongtaigengxinzhexiantushuju.gif)   |  ![](https://gw.alipayobjects.com/zos/antfincdn/AlVS5aBYOi/dongtaigengxinzhexiantushuju2.gif)  |
