### PR TITLE
chore: v2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 2.3.5 (2020-12-28)
+
+##### Bug Fixes
+
+*  funnel undefined render ([#2150](https://github.com/antvis/g2plot/pull/2150)) ([b443dbdf](https://github.com/antvis/g2plot/commit/b443dbdf8f870c770a83d7e63ebcf4ac7945c610))
+
 #### 2.3.4 (2020-12-24)
 
 ##### Documentation Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2plot",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "An interactive and responsive charting library",
   "keywords": [
     "chart",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const version = '2.3.4';
+export const version = '2.3.5';
 
 // G2 自定义能力透出
 import * as G2 from '@antv/g2';


### PR DESCRIPTION
- [x] 2.3.5

发新版本，今天的发布需求依赖这个漏斗图的修复。