### PR TITLE
feat: column and bar plot support pixel width setting

### DIFF
--- a/docs/api/plots/bar.en.md
+++ b/docs/api/plots/bar.en.md
@@ -63,6 +63,18 @@ Whether the plot is Percent Bar. When isPercent is `true`, isStack must be `true
 
 The ratio of bar width( Range:[0-1] ).
 
+#### minBarWidth
+
+<description>**optional** _number_</description>
+
+The min width of bar, pixel value。
+
+#### maxBarWidth
+
+<description>**optional** _number_</description>
+
+The max width of bar, pixel value。
+
 #### marginRatio
 
 <description>**optional** _number_</description>

--- a/docs/api/plots/bar.zh.md
+++ b/docs/api/plots/bar.zh.md
@@ -63,6 +63,17 @@ order: 3
 
 条形图宽度占比 [0-1]。
 
+#### minBarWidth
+
+<description>**optional** _number_</description>
+
+条形图最小宽度设置，像素值。
+
+#### maxBarWidth
+
+<description>**optional** _number_</description>
+
+条形图最大宽度设置，像素值。
 #### marginRatio
 
 <description>**optional** _number_</description>

--- a/docs/api/plots/column.en.md
+++ b/docs/api/plots/column.en.md
@@ -63,6 +63,18 @@ order: 2
 
 柱状图宽度占比 [0-1]。
 
+#### minColumnWidth
+
+<description>**optional** _number_</description>
+
+The min width of column, pixel value。
+
+#### maxColumnWidth
+
+<description>**optional** _number_</description>
+
+The max width of column, pixel value。
+
 #### marginRatio
 
 <description>**optional** _number_</description>

--- a/docs/api/plots/column.zh.md
+++ b/docs/api/plots/column.zh.md
@@ -65,6 +65,18 @@ order: 2
 
 柱状图宽度占比 [0-1]。
 
+#### minColumnWidth
+
+<description>**optional** _number_</description>
+
+柱状图最小宽度设置，像素值。
+
+#### maxColumnWidth
+
+<description>**optional** _number_</description>
+
+柱状图最大宽度设置，像素值。
+
 #### marginRatio
 
 <description>**optional** _number_</description>

--- a/docs/common/connected-area.en.md
+++ b/docs/common/connected-area.en.md
@@ -1,5 +1,3 @@
-#### connectedArea
-
 适用于堆叠柱状图和堆叠条形图，联通区域组件通过绘制同一字段的联通区域提供视觉上的辅助识别，方便进行数据对比。
 
 <description>**optional** _object_ | _false_</description>

--- a/docs/common/connected-area.zh.md
+++ b/docs/common/connected-area.zh.md
@@ -1,5 +1,3 @@
-#### connectedArea
-
 适用于堆叠柱状图和堆叠条形图，联通区域组件通过绘制同一字段的联通区域提供视觉上的辅助识别，方便进行数据对比。
 
 <description>**optional** _object_ | _false_</description>

--- a/docs/common/conversion-tag.en.md
+++ b/docs/common/conversion-tag.en.md
@@ -1,5 +1,3 @@
-#### conversionTag
-
 适用于基础柱形图和基础条形图，转化率组件可以让用户关注到数据的变化比例。
 
 <description>**optional** _object_ | _false_</description>

--- a/docs/common/conversion-tag.zh.md
+++ b/docs/common/conversion-tag.zh.md
@@ -1,5 +1,3 @@
-#### conversionTag
-
 适用于基础柱形图和基础条形图，转化率组件可以让用户关注到数据的变化比例。
 
 <description>**optional** _object_ | _false_</description>

--- a/examples/area/percent/demo/meta.json
+++ b/examples/area/percent/demo/meta.json
@@ -7,8 +7,8 @@
     {
       "filename": "basic.ts",
       "title": {
-        "zh": "百分比面积图",
-        "en": "Percented area plot"
+        "zh": "百分比堆叠面积图",
+        "en": "Percent Stacked Area"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*vr8gQJiyNmQAAAAAAAAAAAAAARQnAQ"
     }

--- a/examples/bar/basic/demo/meta.json
+++ b/examples/bar/basic/demo/meta.json
@@ -15,23 +15,31 @@
     {
       "filename": "color.ts",
       "title": {
-        "zh": "基础条形图 - 自定义颜色",
+        "zh": "自定义条形图颜色",
         "en": "Bar plot color"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*U-D1S4w5HNsAAAAAAAAAAAAAARQnAQ"
     },
     {
+      "filename": "width-ratio.ts",
+      "title": {
+        "zh": "指定条形图宽度比例",
+        "en": "Bar plot column width"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*uqtcQJ-N-qUAAAAAAAAAAAAAARQnAQ"
+    },
+    {
       "filename": "width.ts",
       "title": {
-        "zh": "基础条形图 - 柱子宽度",
-        "en": "Bar plot bar width"
+        "zh": "指定条形图最小最大宽度",
+        "en": "Bar plot with customize width"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*uqtcQJ-N-qUAAAAAAAAAAAAAARQnAQ"
     },
     {
       "filename": "scrollbar.ts",
       "title": {
-        "zh": "基础条形图 - 滚动条",
+        "zh": "带缩略轴条形图",
         "en": "Bar chart with scrollbar"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*01-mRqASP78AAAAAAAAAAAAAARQnAQ"
@@ -39,7 +47,7 @@
     {
       "filename": "conversion-tag.ts",
       "title": {
-        "zh": "基础条形图 - 转化率",
+        "zh": "带转化率条形图",
         "en": "Bar plot conversion tag"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*QPt7QbZ726QAAAAAAAAAAAAAARQnAQ"

--- a/examples/bar/basic/demo/meta.json
+++ b/examples/bar/basic/demo/meta.json
@@ -34,7 +34,7 @@
         "zh": "指定条形图最小最大宽度",
         "en": "Bar plot with customize width"
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*uqtcQJ-N-qUAAAAAAAAAAAAAARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/E6pUfKKBCh/bef42127-d21a-43c6-8a89-89bb3ba41a9f.png"
     },
     {
       "filename": "scrollbar.ts",

--- a/examples/bar/basic/demo/width-ratio.ts
+++ b/examples/bar/basic/demo/width-ratio.ts
@@ -1,4 +1,4 @@
-import { Column } from '@antv/g2plot';
+import { Bar } from '@antv/g2plot';
 
 const data = [
   {
@@ -35,16 +35,11 @@ const data = [
   },
 ];
 
-const columnPlot = new Column('container', {
+const barPlot = new Bar('container', {
   data,
-  xField: 'type',
-  yField: 'sales',
-  xAxis: {
-    label: {
-      autoHide: true,
-      autoRotate: false,
-    },
-  },
+  xField: 'sales',
+  yField: 'type',
+  barWidthRatio: 0.8,
   meta: {
     type: {
       alias: '类别',
@@ -53,8 +48,6 @@ const columnPlot = new Column('container', {
       alias: '销售额',
     },
   },
-  minColumnWidth: 20,
-  maxColumnWidth: 20,
 });
 
-columnPlot.render();
+barPlot.render();

--- a/examples/bar/basic/demo/width.ts
+++ b/examples/bar/basic/demo/width.ts
@@ -39,7 +39,6 @@ const barPlot = new Bar('container', {
   data,
   xField: 'sales',
   yField: 'type',
-  barWidthRatio: 0.8,
   meta: {
     type: {
       alias: '类别',
@@ -48,6 +47,8 @@ const barPlot = new Bar('container', {
       alias: '销售额',
     },
   },
+  minBarWidth: 20,
+  maxBarWidth: 20,
 });
 
 barPlot.render();

--- a/examples/column/basic/demo/meta.json
+++ b/examples/column/basic/demo/meta.json
@@ -34,7 +34,7 @@
         "zh": "指定柱状图最小最大宽度",
         "en": "Column plot with customize width"
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*92VnSrkQLeAAAAAAAAAAAABkARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/VXpimaHvuV/6fbe7c39-c14a-493c-ad45-4b335ab24ba9.png"
     },
     {
       "filename": "slider.ts",

--- a/examples/column/basic/demo/meta.json
+++ b/examples/column/basic/demo/meta.json
@@ -15,18 +15,50 @@
     {
       "filename": "color.ts",
       "title": {
-        "zh": "基础柱状图 - 自定义颜色",
+        "zh": "自定义柱状图颜色",
         "en": "Column plot color"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*dr27SafKNzIAAAAAAAAAAAAAARQnAQ"
     },
     {
-      "filename": "width.ts",
+      "filename": "width-ratio.ts",
       "title": {
-        "zh": "基础柱状图 - 柱子宽度",
+        "zh": "指定柱状图宽度比例",
         "en": "Column plot column width"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*92VnSrkQLeAAAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "width.ts",
+      "title": {
+        "zh": "指定柱状图最小最大宽度",
+        "en": "Column plot with customize width"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*92VnSrkQLeAAAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "slider.ts",
+      "title": {
+        "zh": "带缩略轴柱状图",
+        "en": "Column plot slider"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*QhoHQ4QIts0AAAAAAAAAAAAAARQnAQ"
+    },
+    {
+      "filename": "scrollbar.ts",
+      "title": {
+        "zh": "带滚动条柱状图",
+        "en": "Column plot scroll bar"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*IkdWTaXf4vAAAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "conversion-tag.ts",
+      "title": {
+        "zh": "带转化率柱状图",
+        "en": "Column plot conversion tag"
+      },
+      "screenshot": "https://gw.alicdn.com/tfs/TB1u3.cvUY1gK0jSZFMXXaWcVXa-1638-1228.png"
     },
     {
       "filename": "region-annotation.ts",
@@ -35,30 +67,6 @@
         "en": "Basic column plot with region annotation"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*FOmATLFeuxkAAAAAAAAAAAAAARQnAQ"
-    },
-    {
-      "filename": "slider.ts",
-      "title": {
-        "zh": "基础柱状图 - 缩略轴",
-        "en": "Column plot slider"
-      },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*QhoHQ4QIts0AAAAAAAAAAAAAARQnAQ"
-    },
-    {
-      "filename": "scrollbar.ts",
-      "title": {
-        "zh": "基础柱状图 - 滚动条",
-        "en": "Column plot scroll bar"
-      },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*IkdWTaXf4vAAAAAAAAAAAABkARQnAQ"
-    },
-    {
-      "filename": "conversion-tag.ts",
-      "title": {
-        "zh": "基础柱状图 - 转化率",
-        "en": "Column plot conversion tag"
-      },
-      "screenshot": "https://gw.alicdn.com/tfs/TB1u3.cvUY1gK0jSZFMXXaWcVXa-1638-1228.png"
     }
   ]
 }

--- a/examples/column/basic/demo/width-ratio.ts
+++ b/examples/column/basic/demo/width-ratio.ts
@@ -39,6 +39,7 @@ const columnPlot = new Column('container', {
   data,
   xField: 'type',
   yField: 'sales',
+  columnWidthRatio: 0.8,
   xAxis: {
     label: {
       autoHide: true,
@@ -53,8 +54,6 @@ const columnPlot = new Column('container', {
       alias: '销售额',
     },
   },
-  minColumnWidth: 20,
-  maxColumnWidth: 20,
 });
 
 columnPlot.render();

--- a/src/adaptor/geometries/interval.ts
+++ b/src/adaptor/geometries/interval.ts
@@ -20,10 +20,6 @@ export interface IntervalGeometryOptions extends GeometryOptions {
   readonly widthRatio?: number;
   /** 分组中柱子之间的间距 [0-1]，仅对分组柱状图适用 */
   readonly marginRatio?: number;
-  /** 组间间隔 */
-  readonly intervalPadding?: number;
-  /** 组内间隔 */
-  readonly dodgePadding?: number;
   /** 柱状图最小宽度（像素） */
   readonly minColumnWidth?: number;
   /** 柱状图最大宽度（像素） */
@@ -84,17 +80,7 @@ function otherAdaptor<O extends IntervalGeometryOptions>(params: Params<O>): Par
 
 export function interval<O extends IntervalGeometryOptions>(params: Params<O>): Params<O> {
   const { options } = params;
-  const {
-    xField,
-    yField,
-    interval,
-    seriesField,
-    tooltip,
-    minColumnWidth,
-    maxColumnWidth,
-    intervalPadding,
-    dodgePadding,
-  } = options;
+  const { xField, yField, interval, seriesField, tooltip, minColumnWidth, maxColumnWidth } = options;
 
   const { fields, formatter } = getTooltipMapping(tooltip, [xField, yField, seriesField]);
 
@@ -110,7 +96,7 @@ export function interval<O extends IntervalGeometryOptions>(params: Params<O>): 
               tooltip: formatter,
               ...interval,
             },
-            args: { minColumnWidth, maxColumnWidth, intervalPadding, dodgePadding },
+            args: { minColumnWidth, maxColumnWidth },
           },
         })
       )

--- a/src/adaptor/geometries/interval.ts
+++ b/src/adaptor/geometries/interval.ts
@@ -20,6 +20,14 @@ export interface IntervalGeometryOptions extends GeometryOptions {
   readonly widthRatio?: number;
   /** 分组中柱子之间的间距 [0-1]，仅对分组柱状图适用 */
   readonly marginRatio?: number;
+  /** 组间间隔 */
+  readonly intervalPadding?: number;
+  /** 组内间隔 */
+  readonly dodgePadding?: number;
+  /** 柱状图最小宽度（像素） */
+  readonly minColumnWidth?: number;
+  /** 柱状图最大宽度（像素） */
+  readonly maxColumnWidth?: number;
   /** 柱子样式配置 */
   readonly interval?: MappingOptions;
   /** 分组字段，优先级高于 seriesField , isGroup: true 时会根据 groupField 进行分组。*/
@@ -76,7 +84,17 @@ function otherAdaptor<O extends IntervalGeometryOptions>(params: Params<O>): Par
 
 export function interval<O extends IntervalGeometryOptions>(params: Params<O>): Params<O> {
   const { options } = params;
-  const { xField, yField, interval, seriesField, tooltip } = options;
+  const {
+    xField,
+    yField,
+    interval,
+    seriesField,
+    tooltip,
+    minColumnWidth,
+    maxColumnWidth,
+    intervalPadding,
+    dodgePadding,
+  } = options;
 
   const { fields, formatter } = getTooltipMapping(tooltip, [xField, yField, seriesField]);
 
@@ -92,6 +110,7 @@ export function interval<O extends IntervalGeometryOptions>(params: Params<O>): 
               tooltip: formatter,
               ...interval,
             },
+            args: { minColumnWidth, maxColumnWidth, intervalPadding, dodgePadding },
           },
         })
       )

--- a/src/plots/bar/adaptor.ts
+++ b/src/plots/bar/adaptor.ts
@@ -9,7 +9,20 @@ import { BarOptions } from './types';
  */
 export function adaptor(params: Params<BarOptions>) {
   const { chart, options } = params;
-  const { xField, yField, xAxis, yAxis, barStyle, barWidthRatio, label, data, seriesField, isStack } = options;
+  const {
+    xField,
+    yField,
+    xAxis,
+    yAxis,
+    barStyle,
+    barWidthRatio,
+    label,
+    data,
+    seriesField,
+    isStack,
+    minBarWidth,
+    maxBarWidth,
+  } = options;
 
   // label of bar charts default position is left, if plot has label
   if (label && !label.position) {
@@ -71,6 +84,8 @@ export function adaptor(params: Params<BarOptions>) {
         // rename attrs as column
         columnStyle: barStyle,
         columnWidthRatio: barWidthRatio,
+        minColumnWidth: minBarWidth,
+        maxColumnWidth: maxBarWidth,
         // bar 调整数据顺序
         data: data ? data.slice().reverse() : data,
       },

--- a/src/plots/bar/types.ts
+++ b/src/plots/bar/types.ts
@@ -1,7 +1,12 @@
 import { ColumnOptions } from '../column/types';
 
 // rename column to bar
-export interface BarOptions extends Omit<ColumnOptions, 'columnStyle' | 'columnWidthRatio'> {
+export interface BarOptions
+  extends Omit<ColumnOptions, 'columnStyle' | 'columnWidthRatio' | 'minColumnWidth' | 'maxColumnWidth'> {
   readonly barStyle?: ColumnOptions['columnStyle'];
   readonly barWidthRatio?: ColumnOptions['columnWidthRatio'];
+  /** 条形图最小宽度（像素） */
+  readonly minBarWidth?: ColumnOptions['minColumnWidth'];
+  /** 条形图最大宽度（像素） */
+  readonly maxBarWidth?: ColumnOptions['maxColumnWidth'];
 }

--- a/src/plots/column/types.ts
+++ b/src/plots/column/types.ts
@@ -25,10 +25,6 @@ export interface ColumnOptions extends Options, OptionWithConversionTag, OptionW
   readonly minColumnWidth?: number;
   /** 柱状图最大宽度（像素） */
   readonly maxColumnWidth?: number;
-  /** 组间间隔 */
-  readonly intervalPadding?: number;
-  /** 组内间隔 */
-  readonly dodgePadding?: number;
   /** 柱子样式配置，可选 */
   readonly columnStyle?: StyleAttr;
   /** 分组字段，优先级高于 seriesField , isGroup: true 时会根据 groupField 进行分组。*/

--- a/src/plots/column/types.ts
+++ b/src/plots/column/types.ts
@@ -21,6 +21,14 @@ export interface ColumnOptions extends Options, OptionWithConversionTag, OptionW
   readonly columnWidthRatio?: number;
   /** 分组中柱子之间的间距 [0-1]，仅对分组柱状图适用 */
   readonly marginRatio?: number;
+  /** 柱状图最小宽度（像素） */
+  readonly minColumnWidth?: number;
+  /** 柱状图最大宽度（像素） */
+  readonly maxColumnWidth?: number;
+  /** 组间间隔 */
+  readonly intervalPadding?: number;
+  /** 组内间隔 */
+  readonly dodgePadding?: number;
   /** 柱子样式配置，可选 */
   readonly columnStyle?: StyleAttr;
   /** 分组字段，优先级高于 seriesField , isGroup: true 时会根据 groupField 进行分组。*/


### PR DESCRIPTION
### PR includes

Column plot supports `minColumnWidth` and `maxColumnWidth`, and bar plot   supports `minBarWidth` and `maxBarWidth`. With this feature, you can set pixel column or bar width.

- [x] fixed #1629 
- [ ] add / modify test cases
- [x] documents, demos

### Screenshot

|  Before  |  After  |
|----|----|
|  ❌  |  ✅  |
