### PR TITLE
fix(issue-2161): 修复数据项存在非法 undefined 时，获取数据 max 为 NaN，导致玉珏图渲染页面崩溃

### DIFF
--- a/__tests__/bugs/issue-2161-spec.ts
+++ b/__tests__/bugs/issue-2161-spec.ts
@@ -1,0 +1,37 @@
+import { RadialBar } from '../../src';
+import { createDiv } from '../utils/dom';
+
+describe('#2161', () => {
+  it('[玉珏图] 当某一数据项 value 为 undefined 时，页面崩溃', () => {
+    const data = [
+      { name: 'X6', star: 297 },
+      { name: 'G' },
+      { name: 'AVA', star: 805 },
+      { name: 'G2Plot', star: 1478 },
+      { name: 'L7', star: 2029 },
+      { name: 'G6', star: 7100 },
+      { name: 'F2', star: 7346 },
+      { name: 'G2', star: 10178 },
+    ];
+
+    const bar = new RadialBar(createDiv(), {
+      width: 400,
+      height: 300,
+      data,
+      xField: 'name',
+      yField: 'star',
+      radius: 0.8,
+      innerRadius: 0.2,
+      tooltip: {
+        formatter: (datum) => {
+          return { name: 'star数', value: datum.star };
+        },
+      },
+    });
+    bar.render();
+
+    expect(bar.chart).toBeDefined();
+
+    bar.destroy();
+  });
+});

--- a/__tests__/unit/plots/radial-bar/utils-spec.ts
+++ b/__tests__/unit/plots/radial-bar/utils-spec.ts
@@ -12,4 +12,9 @@ describe('utils of radial-bar', () => {
     expect(getScaleMax(-300, yField, antvStar)).toBe((maxValue * 360) / 300);
     expect(getScaleMax(660, yField, antvStar)).toBe((maxValue * 360) / 300);
   });
+
+  it('getScaleMax: existed nil value', () => {
+    expect(getScaleMax(-300, yField, [...antvStar, { name: 'c', star: undefined }])).toBe((maxValue * 360) / 300);
+    expect(getScaleMax(-300, yField, [...antvStar, { name: 'c', star: null }])).toBe((maxValue * 360) / 300);
+  });
 });

--- a/src/plots/radial-bar/utils.ts
+++ b/src/plots/radial-bar/utils.ts
@@ -2,7 +2,7 @@ import { Data } from '../../types';
 
 export function getScaleMax(maxAngle: number, yField: string, data: Data): number {
   const yData = data.map((item) => item[yField]);
-  const maxValue = Math.max(...yData);
+  const maxValue = Math.max(...yData.filter((v) => v !== undefined));
   const formatRadian = Math.abs(maxAngle) % 360;
   if (!formatRadian) {
     return maxValue;


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #2161 
- [x] add / modify test cases

### Screenshot

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/15646325/103467568-3fbbd780-4d8b-11eb-9613-b7d4b3baabbc.png)|  ![image](https://user-images.githubusercontent.com/15646325/103467585-611cc380-4d8b-11eb-961b-ce61375773ac.png) |
