### PR TITLE
Fix/nest treemap

### DIFF
--- a/__tests__/unit/plots/treemap/color-spec.ts
+++ b/__tests__/unit/plots/treemap/color-spec.ts
@@ -1,0 +1,122 @@
+import { Treemap } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { TREEMAP } from '../../../data/treemap';
+
+const color = ['#D3EEF9', '#945FB9', '#DECFEA', '#FF9845', '#FFE0C7', '#1E9493', '#BBDEDE', '#FF99C3', '#FFE0ED'];
+
+const data = {
+  name: 'root',
+  children: [
+    {
+      name: '三星',
+      brand: 'a',
+      children: [
+        {
+          name: '三星1',
+          value: 100,
+        },
+        {
+          name: '三星2',
+          value: 50,
+        },
+      ],
+    },
+    {
+      name: '小米',
+      brand: 'b',
+      children: [
+        {
+          name: '小米1',
+          children: [
+            {
+              name: '小米1.2',
+              value: 4,
+            },
+            {
+              name: '小米9',
+              value: 9,
+            },
+          ],
+        },
+        {
+          name: '小米2',
+          value: 20,
+        },
+      ],
+    },
+    {
+      name: '华为',
+      value: 50,
+    },
+  ],
+};
+
+describe('treemap color', () => {
+  let treemapPlot;
+  const options = {
+    data: TREEMAP,
+  };
+
+  beforeAll(() => {
+    treemapPlot = new Treemap(createDiv(''), options);
+    treemapPlot.render();
+  });
+
+  afterAll(() => {
+    treemapPlot.destroy();
+  });
+
+  it('default', () => {
+    treemapPlot.render();
+
+    const geometry = treemapPlot.chart.geometries[0];
+
+    // @ts-ignore
+    expect(geometry.attributeOption.color.fields).toEqual(['name']);
+  });
+
+  it('color panel', () => {
+    treemapPlot.update({
+      color,
+    });
+
+    const geometry = treemapPlot.chart.geometries[0];
+
+    // @ts-ignore
+    expect(geometry.attributeOption.color.fields).toEqual(['name']);
+    expect(geometry.attributeOption.color.values).toEqual(color);
+  });
+
+  it('color function', () => {
+    treemapPlot.update({
+      color: (v) => {
+        return v.name === '分类 1' ? '#f00' : '#0f0';
+      },
+    });
+
+    const elements = treemapPlot.chart.geometries[0].elements;
+    expect(elements[0].model.color).toBe('#f00');
+    expect(elements[5].model.color).toBe('#0f0');
+  });
+
+  it('multi nest treemap', () => {
+    treemapPlot.update({
+      data: data,
+      colorField: 'brand',
+      color,
+    });
+
+    const elements = treemapPlot.chart.geometries[0].elements;
+
+    const expectColorMap = {
+      三星: color[0],
+      小米: color[1],
+      华为: undefined,
+    };
+
+    elements.forEach((element) => {
+      const expectColorKey = Object.keys(expectColorMap).find((key) => element.data.name.indexOf(key) > -1);
+      expect(element.model.color).toBe(expectColorMap[expectColorKey]);
+    });
+  });
+});

--- a/__tests__/unit/plots/treemap/utils-spec.ts
+++ b/__tests__/unit/plots/treemap/utils-spec.ts
@@ -52,6 +52,60 @@ const data2 = {
   ],
 };
 
+// 自己有分类，父类有分类
+// 没有，父类有
+// 自己有，父类没有，
+// 自己没有，父类没有
+
+const data3 = {
+  name: 'root',
+  children: [
+    {
+      name: '分类1',
+      category: 'A',
+      children: [
+        {
+          name: '分类1.1',
+          children: [
+            {
+              name: '分类1.1.1',
+              children: [
+                {
+                  name: '分类1.1.1.1',
+                  category: 'A.A',
+                  expectCategory: 'A.A',
+                  value: 50,
+                },
+                {
+                  name: '分类1.1.1.2',
+                  expectCategory: 'A',
+                  value: 50,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: '分类2',
+      children: [
+        {
+          name: '分类2.1',
+          value: 10,
+          category: 'B.B',
+          expectCategory: 'B.B',
+        },
+        {
+          name: '分类2.1',
+          value: 10,
+          expectCategory: undefined,
+        },
+      ],
+    },
+  ],
+};
+
 describe('treemap transformData', () => {
   it('transformData, basic treemap', () => {
     const data = transformData({
@@ -96,5 +150,15 @@ describe('treemap transformData', () => {
     );
 
     expect(data[2].ext).toBe('自定义数据');
+  });
+
+  it('transformData, nest treemap, colorField', () => {
+    const data = transformData({
+      data: data3,
+      colorField: 'category',
+    });
+    data.forEach((d) => {
+      expect(d.category).toEqual(d.expectCategory);
+    });
   });
 });

--- a/__tests__/unit/utils/hierarchy/treemap-spec.ts
+++ b/__tests__/unit/utils/hierarchy/treemap-spec.ts
@@ -1,0 +1,57 @@
+import { treemap } from '../../../../src/utils/hierarchy/treemap';
+
+const data = {
+  children: [
+    {
+      value: 20,
+      children: [
+        {
+          value: 10,
+        },
+        {
+          value: 10,
+        },
+      ],
+    },
+  ],
+};
+
+describe('hierarchy/treemap', () => {
+  it('treemap', () => {
+    expect(() => {
+      // @ts-ignore
+      treemap([], {
+        as: null,
+      });
+    }).toThrow(`Invalid as: it must be an array with 2 strings (e.g. [ "x", "y" ])!`);
+
+    expect(() => {
+      treemap([], {
+        // @ts-ignore
+        as: ['x', 'y', 'z'],
+      });
+    }).toThrow(`Invalid as: it must be an array with 2 strings (e.g. [ "x", "y" ])!`);
+  });
+});
+
+it('treemap: ignore parent value', () => {
+  const res = treemap(data, { as: ['x', 'y'], field: 'value' });
+  const leaves = res[0].leaves();
+  leaves.forEach((leaf) => {
+    const width = Math.abs(leaf.x[1] - leaf.x[0]);
+    const height = Math.abs(leaf.y[2] - leaf.y[1]);
+    expect(width * height).toEqual(0.5);
+  });
+});
+
+it('treemap, dont ignore parent value', () => {
+  const res = treemap(data, { as: ['x', 'y'], field: 'value', ignoreParentValue: false });
+
+  const leaves = res[0].leaves();
+
+  leaves.forEach((leaf) => {
+    const width = Math.abs(leaf.x[1] - leaf.x[0]);
+    const height = Math.abs(leaf.y[2] - leaf.y[1]);
+    expect(width * height).toEqual(0.25);
+  });
+});

--- a/docs/api/plots/treemap.en.md
+++ b/docs/api/plots/treemap.en.md
@@ -32,6 +32,7 @@ const data = {
 - value (叶子节点)
 - children (非叶子节点)
 
+嵌套矩形树图中，布局由叶子节点的 value 值决定。
 
 #### colorField
 

--- a/docs/api/plots/treemap.zh.md
+++ b/docs/api/plots/treemap.zh.md
@@ -32,6 +32,7 @@ const data = {
 - value (叶子节点)
 - children (非叶子节点)
 
+嵌套矩形树图中，布局由叶子节点的 value 值决定。
 #### colorField
 
 <description>**optional** _string_</description>

--- a/examples/more-plots/sunburst/demo/reflect.ts
+++ b/examples/more-plots/sunburst/demo/reflect.ts
@@ -3,9 +3,6 @@ import { Sunburst } from '@antv/g2plot';
 fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/mobile.json')
   .then((res) => res.json())
   .then((fetchData) => {
-    fetchData.forEach((mobile) => {
-      mobile.value = null;
-    });
     const data = {
       name: 'root',
       children: fetchData,

--- a/examples/more-plots/treemap/demo/treemap-nest.ts
+++ b/examples/more-plots/treemap/demo/treemap-nest.ts
@@ -3,10 +3,6 @@ import { Treemap } from '@antv/g2plot';
 fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/mobile.json')
   .then((res) => res.json())
   .then((fetchData) => {
-    fetchData.forEach((mobile) => {
-      mobile.value = null;
-    });
-
     const data = {
       name: 'root',
       children: fetchData,

--- a/src/plots/treemap/adaptor.ts
+++ b/src/plots/treemap/adaptor.ts
@@ -16,6 +16,8 @@ function defaultOptions(params: Params<TreemapOptions>): Params<TreemapOptions> 
   return deepAssign(
     {
       options: {
+        // 默认按照 name 字段对颜色进行分类
+        colorField: 'name',
         label: {
           fields: ['name'],
           layout: {

--- a/src/plots/treemap/utils.ts
+++ b/src/plots/treemap/utils.ts
@@ -22,7 +22,8 @@ export function transformData(options: TreemapOptions) {
         value: node.value,
       });
       if (!node.data[colorField] && node.parent) {
-        eachNode[colorField] = node.parent.data[colorField];
+        const ancestorNode = node.ancestors().find((n) => n.data[colorField]);
+        eachNode[colorField] = ancestorNode?.data[colorField];
       } else {
         eachNode[colorField] = node.data[colorField];
       }

--- a/src/utils/hierarchy/treemap.ts
+++ b/src/utils/hierarchy/treemap.ts
@@ -46,6 +46,15 @@ export function treemap(data: any, options: HierarchyOption): any[] {
       .paddingRight(options.paddingRight)
       .paddingBottom(options.paddingBottom)
       .paddingLeft(options.paddingLeft)(
+      /**
+       * d3Hierarchy 布局中需指定 sum 函数计算 node 值，规则是：从当前 node 开始以 post-order traversal 的次序为当前节点以及每个后代节点调用指定的 value 函数，并返回当前 node。
+       * for example:
+       * { node: 'parent', value: 10, children: [{node: 'child1', value: 5}, {node: 'child2', value: 5}, ]}
+       * parent 所得的计算值是 sum(node(parent)) + sum(node(child1)) + sum(node(child2))
+       * ignoreParentValue 为 true(默认) 时，父元素的值由子元素累加而来，该值为 0 + 5 + 5 = 10
+       * ignoreParentValue 为 false 时，父元素的值由当前节点 及子元素累加而来，该值为 10 + 5 + 5 = 20
+       * sum 函数中，d 为用户传入的 data, children 为保留字段
+       */
       d3Hierarchy.hierarchy(data).sum((d) => (options.ignoreParentValue && d.children ? 0 : d[field]))
     );
   const root = partition(data);

--- a/src/utils/hierarchy/treemap.ts
+++ b/src/utils/hierarchy/treemap.ts
@@ -8,6 +8,7 @@ const DEFAULT_OPTIONS: HierarchyOption = {
   tile: 'treemapSquarify', // treemapBinary, treemapDice, treemapSlice, treemapSliceDice, treemapSquarify, treemapResquarify
   size: [1, 1], // width, height
   round: false,
+  ignoreParentValue: true,
   padding: 0,
   paddingInner: 0,
   paddingOuter: 0,
@@ -44,7 +45,9 @@ export function treemap(data: any, options: HierarchyOption): any[] {
       .paddingTop(options.paddingTop)
       .paddingRight(options.paddingRight)
       .paddingBottom(options.paddingBottom)
-      .paddingLeft(options.paddingLeft)(d3Hierarchy.hierarchy(data).sum((d) => d[field]));
+      .paddingLeft(options.paddingLeft)(
+      d3Hierarchy.hierarchy(data).sum((d) => (options.ignoreParentValue && d.children ? 0 : d[field]))
+    );
   const root = partition(data);
 
   /*

--- a/src/utils/hierarchy/types.ts
+++ b/src/utils/hierarchy/types.ts
@@ -12,6 +12,8 @@ export interface HierarchyOption {
     | 'treemapResquarify';
   size?: [number, number];
   round?: boolean;
+  // 是否在计算总值时，忽略父节点的值
+  ignoreParentValue?: boolean;
   ratio?: number;
   padding?: number;
   paddingInner?: number;


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #0
- [x] add / modify test cases
- [x] documents, demos



### Screenshot

|  Before  |  After  |
|----|----|
|  <img width="592" alt="屏幕快照 2021-01-08 16 44 52" src="https://user-images.githubusercontent.com/11748654/103995996-3049ed80-51d4-11eb-9049-c0c1eccd6bdd.png"> |  <img width="591" alt="屏幕快照 2021-01-08 16 44 18" src="https://user-images.githubusercontent.com/11748654/103996016-38099200-51d4-11eb-8d62-43fea4cdc69c.png"> |

问题描述：嵌套树图中，若子节点没有 colorField 字段，采用父节点 colorField 字段



|  Before  |  After  |
|----|----|
|   <img width="590" alt="屏幕快照 2021-01-08 17 13 59" src="https://user-images.githubusercontent.com/11748654/103996524-f0373a80-51d4-11eb-94ef-3f6888ecdae7.png"> | <img width="588" alt="屏幕快照 2021-01-08 17 13 48" src="https://user-images.githubusercontent.com/11748654/103996532-f3322b00-51d4-11eb-8774-16c7776772ec.png"> |
|  <img width="566" alt="屏幕快照 2021-01-08 17 19 59" src="https://user-images.githubusercontent.com/11748654/103997253-d3e7cd80-51d5-11eb-833f-52ddbb5219d4.png"> | <img width="538" alt="屏幕快照 2021-01-08 17 19 34" src="https://user-images.githubusercontent.com/11748654/103997266-d77b5480-51d5-11eb-9f81-7443e7450410.png"> |
| 父元素存在 value 值时，计算布局时为 父元素 + 子元素值 | 布局由子元素之和计算，不计入父元素 value |


示例数据
```
{
  name: 'root',
  children: [
    {
      name: '分类1',
      brand: 'a',
      value: 20,
      children: [
        {
          name: '分类1.1',
          brand: 'a',
          value: 10,
        },
        {
          name: '分类1.2',
          brand: 'a',
          value: 20,
        },
      ],
    },
    {
      name: '分类2',
      brand: 'b',
      value: 30,
    },
  ],
};
```



