### PR TITLE
fix: 修复玉珏图changeData时未同步变更scale

### DIFF
--- a/__tests__/unit/plots/radial-bar/change-data-spec.ts
+++ b/__tests__/unit/plots/radial-bar/change-data-spec.ts
@@ -1,6 +1,7 @@
 import { RadialBar } from '../../../../src';
 import { createDiv } from '../../../utils/dom';
 import { antvStar } from '../../../data/antv-star';
+import { getScaleMax } from '../../../../src/plots/radial-bar/utils';
 
 describe('radial-bar changeData', () => {
   it('changeData: normal', () => {
@@ -9,16 +10,19 @@ describe('radial-bar changeData', () => {
       height: 300,
       data: antvStar,
       xField: 'name',
-      yField: 'start',
+      yField: 'star',
       radius: 0.8,
       innerRadius: 0.2,
     });
     bar.render();
 
+    const { maxAngle } = bar.options;
     expect(bar.chart.geometries[0].elements.length).toEqual(antvStar.length);
+    expect(bar.chart.geometries[0].scales.star.max).toEqual(getScaleMax(maxAngle, 'star', antvStar));
 
     const newData = antvStar.slice(0, 4);
     bar.changeData(newData);
+    expect(bar.chart.geometries[0].scales.star.max).toEqual(getScaleMax(maxAngle, 'star', newData));
     expect(bar.chart.geometries[0].elements.length).toEqual(newData.length);
     expect(bar.options.data).toEqual(newData);
 
@@ -31,16 +35,19 @@ describe('radial-bar changeData', () => {
       height: 300,
       data: [],
       xField: 'name',
-      yField: 'start',
+      yField: 'star',
       radius: 0.8,
       innerRadius: 0.2,
     });
 
     bar.render();
 
+    const { maxAngle } = bar.options;
     expect(bar.chart.geometries[0].elements.length).toEqual(0);
+    expect(bar.chart.geometries[0].scales.star.max).toEqual(getScaleMax(maxAngle, 'star', []));
 
     bar.changeData(antvStar);
+    expect(bar.chart.geometries[0].scales.star.max).toEqual(getScaleMax(maxAngle, 'star', antvStar));
     expect(bar.chart.geometries[0].elements.length).toEqual(antvStar.length);
     expect(bar.options.data).toEqual(antvStar);
 

--- a/__tests__/unit/plots/radial-bar/utils-spec.ts
+++ b/__tests__/unit/plots/radial-bar/utils-spec.ts
@@ -17,4 +17,8 @@ describe('utils of radial-bar', () => {
     expect(getScaleMax(-300, yField, [...antvStar, { name: 'c', star: undefined }])).toBe((maxValue * 360) / 300);
     expect(getScaleMax(-300, yField, [...antvStar, { name: 'c', star: null }])).toBe((maxValue * 360) / 300);
   });
+
+  it('getScaleMax: empty array', () => {
+    expect(getScaleMax(360, yField, [])).toBe(0);
+  });
 });

--- a/src/plots/radial-bar/index.ts
+++ b/src/plots/radial-bar/index.ts
@@ -3,6 +3,7 @@ import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RadialBarOptions } from './types';
 import { adaptor } from './adaptor';
+import { getScaleMax } from './utils';
 
 export { RadialBarOptions };
 
@@ -19,6 +20,14 @@ export class RadialBar extends Plot<RadialBarOptions> {
    */
   public changeData(data) {
     this.updateOption({ data });
+    // 更新玉珏图的scale
+    const { yField, maxAngle } = this.options;
+    this.chart.scale({
+      [yField]: {
+        min: 0,
+        max: getScaleMax(maxAngle, yField, data),
+      },
+    });
     this.chart.changeData(data);
   }
 

--- a/src/plots/radial-bar/index.ts
+++ b/src/plots/radial-bar/index.ts
@@ -2,8 +2,7 @@ import { Plot } from '../../core/plot';
 import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { RadialBarOptions } from './types';
-import { adaptor } from './adaptor';
-import { getScaleMax } from './utils';
+import { adaptor, meta } from './adaptor';
 
 export { RadialBarOptions };
 
@@ -21,13 +20,7 @@ export class RadialBar extends Plot<RadialBarOptions> {
   public changeData(data) {
     this.updateOption({ data });
     // 更新玉珏图的scale
-    const { yField, maxAngle } = this.options;
-    this.chart.scale({
-      [yField]: {
-        min: 0,
-        max: getScaleMax(maxAngle, yField, data),
-      },
-    });
+    meta({ chart: this.chart, options: this.options });
     this.chart.changeData(data);
   }
 

--- a/src/plots/radial-bar/utils.ts
+++ b/src/plots/radial-bar/utils.ts
@@ -1,8 +1,8 @@
 import { Data } from '../../types';
 
 export function getScaleMax(maxAngle: number, yField: string, data: Data): number {
-  const yData = data.map((item) => item[yField]);
-  const maxValue = Math.max(...yData.filter((v) => v !== undefined));
+  const yData = data.map((item) => item[yField]).filter((v) => v !== undefined);
+  const maxValue = yData.length > 0 ? Math.max(...yData) : 0;
   const formatRadian = Math.abs(maxAngle) % 360;
   if (!formatRadian) {
     return maxValue;


### PR DESCRIPTION
### PR includes


- [x] fixed: change scale when data changed

### Screenshot

|  Before  |  After  |
|----|----|
|  ![玉珏图before](https://user-images.githubusercontent.com/24318174/104293039-84b4dc00-54f8-11eb-9316-7ae72c8d327a.gif) | ![玉珏图after](https://user-images.githubusercontent.com/24318174/104293457-fdb43380-54f8-11eb-9fb0-9f1dc0d5fa6a.gif)
 | 
