### PR TITLE
feat: 重写子弹图changeData方法 && 添加单测

### DIFF
--- a/__tests__/unit/plots/bullet/change-data-spec.ts
+++ b/__tests__/unit/plots/bullet/change-data-spec.ts
@@ -54,14 +54,6 @@ describe('Bullet changeData', () => {
       targetField: 'target',
       xField: 'title',
     });
-
-    const { min, max, ds } = transformData({
-      data: [],
-      measureField: 'measures',
-      rangeField: 'ranges',
-      targetField: 'target',
-      xField: 'title',
-    });
     bullet.render();
 
     expect(bullet.chart.geometries[0].scales.measures.max).toEqual(0);

--- a/__tests__/unit/plots/bullet/change-data-spec.ts
+++ b/__tests__/unit/plots/bullet/change-data-spec.ts
@@ -1,0 +1,85 @@
+import { Bullet } from '../../../../src';
+import { bulletData } from '../../../data/bullet';
+import { createDiv } from '../../../utils/dom';
+import { transformData } from '../../../../src/plots/bullet/utils';
+
+describe('Bullet changeData', () => {
+  it('changeData: normal', () => {
+    const bullet = new Bullet(createDiv(''), {
+      width: 400,
+      height: 100,
+      data: bulletData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+
+    const { min, max, ds } = transformData({
+      data: bulletData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+    bullet.render();
+
+    expect(bullet.chart.geometries[0].scales.measures.max).toEqual(max);
+    expect(bullet.chart.geometries[0].scales.measures.min).toEqual(min);
+    expect(bullet.chart.geometries[0].data).toEqual(ds);
+
+    const newData = [{ title: '数学', ranges: [-10, 50, 100], measures: [120], target: 85 }];
+    bullet.changeData(newData);
+    const { min: newMin, max: newMax, ds: newDs } = transformData({
+      data: newData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+    expect(bullet.chart.geometries[0].scales.measures.max).toEqual(newMax);
+    expect(bullet.chart.geometries[0].scales.measures.min).toEqual(newMin);
+    expect(bullet.chart.geometries[0].data).toEqual(newDs);
+
+    bullet.destroy();
+  });
+
+  it('changeData: from empty to have data', () => {
+    const bullet = new Bullet(createDiv(''), {
+      width: 400,
+      height: 100,
+      data: [],
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+
+    const { min, max, ds } = transformData({
+      data: [],
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+    bullet.render();
+
+    expect(bullet.chart.geometries[0].scales.measures.max).toEqual(0);
+    expect(bullet.chart.geometries[0].scales.measures.min).toEqual(0);
+    expect(bullet.chart.geometries[0].data).toEqual([]);
+
+    bullet.changeData(bulletData);
+    const { min: newMin, max: newMax, ds: newDs } = transformData({
+      data: bulletData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+    expect(bullet.chart.geometries[0].scales.measures.max).toEqual(newMax);
+    expect(bullet.chart.geometries[0].scales.measures.min).toEqual(newMin);
+    expect(bullet.chart.geometries[0].data).toEqual(newDs);
+
+    bullet.destroy();
+  });
+});

--- a/__tests__/unit/plots/bullet/change-data-spec.ts
+++ b/__tests__/unit/plots/bullet/change-data-spec.ts
@@ -28,7 +28,7 @@ describe('Bullet changeData', () => {
     expect(bullet.chart.geometries[0].scales.measures.min).toEqual(min);
     expect(bullet.chart.geometries[0].data).toEqual(ds);
 
-    const newData = [{ title: '数学', ranges: [-10, 50, 100], measures: [120], target: 85 }];
+    const newData = [{ title: '数学', ranges: [0, 50, 100], measures: [120], target: 85 }];
     bullet.changeData(newData);
     const { min: newMin, max: newMax, ds: newDs } = transformData({
       data: newData,

--- a/src/plots/bullet/adaptor.ts
+++ b/src/plots/bullet/adaptor.ts
@@ -82,7 +82,7 @@ function geometry(params: Params<BulletOptions>): Params<BulletOptions> {
  * meta 配置
  * @param params
  */
-function meta(params: Params<BulletOptions>): Params<BulletOptions> {
+export function meta(params: Params<BulletOptions>): Params<BulletOptions> {
   const { options, ext } = params;
   const { xAxis, yAxis, targetField, rangeField, measureField, xField } = options;
 

--- a/src/plots/bullet/index.ts
+++ b/src/plots/bullet/index.ts
@@ -3,12 +3,27 @@ import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BulletOptions } from './types';
 import { adaptor } from './adaptor';
+import { transformData } from './utils';
 
 export { BulletOptions };
 
 export class Bullet extends Plot<BulletOptions> {
   /** 图表类型 */
   public type: string = 'bullet';
+
+  public changeData(data) {
+    this.updateOption({ data });
+    const { min, max, ds } = transformData(this.options);
+    const { measureField } = this.options;
+    // 处理scale
+    this.chart.scale({
+      [measureField]: {
+        min,
+        max,
+      },
+    });
+    this.chart.changeData(ds);
+  }
 
   /**
    * 获取子弹图的适配器

--- a/src/plots/bullet/index.ts
+++ b/src/plots/bullet/index.ts
@@ -2,7 +2,7 @@ import { Plot } from '../../core/plot';
 import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
 import { BulletOptions } from './types';
-import { adaptor } from './adaptor';
+import { adaptor, meta } from './adaptor';
 import { transformData } from './utils';
 
 export { BulletOptions };
@@ -14,14 +14,8 @@ export class Bullet extends Plot<BulletOptions> {
   public changeData(data) {
     this.updateOption({ data });
     const { min, max, ds } = transformData(this.options);
-    const { measureField } = this.options;
     // 处理scale
-    this.chart.scale({
-      [measureField]: {
-        min,
-        max,
-      },
-    });
+    meta({ options: this.options, ext: { data: { min, max } }, chart: this.chart });
     this.chart.changeData(ds);
   }
 


### PR DESCRIPTION
### PR includes
override the changeData method of Bullet plot

- [x] fixed #0


### Screenshot

|  Before  |  After  |
|----|----|
|![子弹图before](https://user-images.githubusercontent.com/24318174/104566780-ff146600-5688-11eb-95b0-7cade7712a29.gif)|![子弹图after](https://user-images.githubusercontent.com/24318174/104566798-05a2dd80-5689-11eb-9eed-86d95b325748.gif)|
