### PR TITLE
fix: 对称条形图 meta 支持 yField 设置别名

### DIFF
--- a/__tests__/bugs/issue-2180-spec.ts
+++ b/__tests__/bugs/issue-2180-spec.ts
@@ -26,7 +26,7 @@ describe('#2180', () => {
     bidirectional.render();
     const firstView = bidirectional.chart.views[0];
     const elements = firstView.geometries[0].elements;
-    const transDS = transformData('country', ['2016年耕地总面积', '2016年转基因种植面积'], data);
+    const transDS = transformData('country', ['2016年耕地总面积', '2016年转基因种植面积'], 'type', data);
     // 因为横向反转了轴，即 transDS 数组反转后 length = 0 与 elements 的 length = 0 的 country 相等
     // @ts-ignore
     expect(transDS.reverse()[0].country).toEqual(elements[0].data.country);
@@ -44,7 +44,7 @@ describe('#2180', () => {
     bidirectional.render();
     const firstView = bidirectional.chart.views[0];
     const elements = firstView.geometries[0].elements;
-    const transDS = transformData('country', ['2016年耕地总面积', '2016年转基因种植面积'], data);
+    const transDS = transformData('country', ['2016年耕地总面积', '2016年转基因种植面积'], 'type', data);
     // @ts-ignore 不需要反转
     expect(transDS[0].country).toEqual(elements[0].data.country);
     // bidirectional.destroy();

--- a/__tests__/unit/plots/bidirectional-bar/data-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/data-spec.ts
@@ -25,7 +25,7 @@ export const hopedata = [
 describe('bullet*data*transfrom', () => {
   it('data*transfrom', () => {
     // 校验数据转换
-    const transDS = transformData('country', ['2016年耕地总面积', '2016年转基因种植面积'], data);
+    const transDS = transformData('country', ['2016年耕地总面积', '2016年转基因种植面积'], 'type', data);
     expect(transDS).toEqual(hopedata);
   });
 });

--- a/__tests__/unit/plots/bidirectional-bar/index-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/index-spec.ts
@@ -1,4 +1,5 @@
 import { BidirectionalBar } from '../../../../src';
+import { SERIES_FIELD_KEY } from '../../../../src/plots/bidirectional-bar/constant';
 import { data } from '../../../data/bi-directional';
 import { createDiv } from '../../../utils/dom';
 
@@ -23,7 +24,7 @@ describe('Bidirectional', () => {
     expect(leftView.options.axes.country.position).toEqual('top');
     //@ts-ignore
     expect(rightView.options.axes.country).toEqual(false);
-    expect(bidirectional.chart.getOptions().scales.type.sync).toEqual(true);
+    expect(bidirectional.chart.getOptions().scales[SERIES_FIELD_KEY].sync).toEqual(true);
 
     // 类型
     expect(leftG.type).toBe('interval');
@@ -44,19 +45,19 @@ describe('Bidirectional', () => {
     const LseriesFields = LcolorAttribute.getFields();
 
     expect(LseriesFields).toHaveLength(1);
-    expect(LseriesFields[0]).toBe('type');
+    expect(LseriesFields[0]).toBe(SERIES_FIELD_KEY);
 
     const RcolorAttribute = rightG.getAttribute('color');
     const RseriesFields = RcolorAttribute.getFields();
 
     expect(RseriesFields).toHaveLength(1);
-    expect(RseriesFields[0]).toBe('type');
+    expect(RseriesFields[0]).toBe(SERIES_FIELD_KEY);
 
     expect(bidirectional.chart.getController('legend').visible).toEqual(true);
 
     expect(bidirectional.chart.getController('legend').getComponents()[0].direction).toEqual('bottom');
 
-    expect(bidirectional.chart.getController('legend').getComponents()[0].extra.scale.field).toEqual('type');
+    expect(bidirectional.chart.getController('legend').getComponents()[0].extra.scale.field).toEqual(SERIES_FIELD_KEY);
 
     bidirectional.destroy();
   });
@@ -77,9 +78,9 @@ describe('Bidirectional', () => {
     const RseriesFields = rightG.getAttribute('color').getFields();
 
     expect(LseriesFields).toHaveLength(1);
-    expect(LseriesFields[0]).toBe('type');
+    expect(LseriesFields[0]).toBe(SERIES_FIELD_KEY);
     expect(RseriesFields).toHaveLength(1);
-    expect(RseriesFields[0]).toBe('type');
+    expect(RseriesFields[0]).toBe(SERIES_FIELD_KEY);
 
     bidirectional.destroy();
   });

--- a/__tests__/unit/plots/bidirectional-bar/meta-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/meta-spec.ts
@@ -1,0 +1,44 @@
+import { BidirectionalBar } from '../../../../src';
+import { SERIES_FIELD_KEY } from '../../../../src/plots/bidirectional-bar/constant';
+import { data } from '../../../data/bi-directional';
+import { createDiv } from '../../../utils/dom';
+
+describe('Bidirectional', () => {
+  it('进行别名设置', () => {
+    const bidirectional = new BidirectionalBar(createDiv('default'), {
+      width: 400,
+      height: 400,
+      data,
+      xField: 'country',
+      yField: ['2016年耕地总面积', '2016年转基因种植面积'],
+    });
+    bidirectional.render();
+
+    expect(bidirectional.type).toEqual('bidirectional-bar');
+
+    // @ts-ignore
+    let scalePool = bidirectional.chart.scalePool;
+    const scaleKeys = scalePool.syncScales.get(SERIES_FIELD_KEY);
+
+    expect(scalePool.scales.get(scaleKeys[0]).scaleDef.formatter('2016年耕地总面积')).toBe('2016年耕地总面积');
+    expect(scalePool.scales.get(scaleKeys[1]).scaleDef.formatter('2016年转基因种植面积')).toBe('2016年转基因种植面积');
+
+    bidirectional.update({
+      meta: {
+        '2016年耕地总面积': {
+          alias: 'a',
+        },
+        '2016年转基因种植面积': {
+          alias: 'b',
+        },
+      },
+    });
+
+    // @ts-ignore
+    scalePool = bidirectional.chart.scalePool;
+    expect(scalePool.scales.get(scaleKeys[0]).scaleDef.formatter('2016年耕地总面积')).toBe('a');
+    expect(scalePool.scales.get(scaleKeys[1]).scaleDef.formatter('2016年转基因种植面积')).toBe('b');
+
+    bidirectional.destroy();
+  });
+});

--- a/__tests__/unit/plots/bidirectional-bar/utils-spec.ts
+++ b/__tests__/unit/plots/bidirectional-bar/utils-spec.ts
@@ -16,7 +16,7 @@ describe('util', () => {
       { x: 'b', y1: 11, y2: 21, y3: 31 },
     ];
 
-    expect(transformData('x', ['y1', 'y2'], data)).toEqual([
+    expect(transformData('x', ['y1', 'y2'], 'type', data)).toEqual([
       { type: 'y1', x: 'a', y1: 10 },
       { type: 'y1', x: 'b', y1: 11 },
       { type: 'y2', x: 'a', y2: 20 },

--- a/docs/api/plots/bidirectional-bar.en.md
+++ b/docs/api/plots/bidirectional-bar.en.md
@@ -1,26 +1,25 @@
 ---
-title: 对称条形图
+title: Bidirectional Bar
 order: 26
 ---
 
-### 图表容器
+### Plot Container
 
-`markdown:docs/common/chart-options.zh.md`
+`markdown:docs/common/chart-options.en.md`
 
-### 数据映射
+### Data Mapping
 
 #### data
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：
+Configure the data source. The data source is a collection of objects. For example:
 
 ```js
 [
   { country: '乌拉圭', '2016年耕地总面积': 13.4, '2016年转基因种植面积': 12.3 },
-  { country: '巴拉圭', '2016年耕地总面积': 14.4, '2016年转基因种植面积': 6.3 }
-]
-
+  { country: '巴拉圭', '2016年耕地总面积': 14.4, '2016年转基因种植面积': 6.3 },
+];
 ```
 
 #### xField
@@ -35,44 +34,63 @@ order: 26
 
 设置 y 轴映射字段。
 
-#### yAxis
+<!-- Meta options START -->
 
-<description>**optional** object</description>
+`markdown:docs/common/meta.en.md`
 
- yAxis 为多个 key 为 yField 里面的 2 个字段。
+Example:
 
- #### layout
+```ts
+{
+  meta: {
+    '2016年耕地总面积': { alias: '耕地总面积' }
+  }
+}
+```
+
+<!-- Meta options END -->
+
+### Geometry Style
+
+#### layout
 
 <description>**optional** _'horizontal' | 'vertical'_ _default:_ 'horizontal'</description>
 
-表示对称条形图方向。
+Layout modes, whose optional values are:
 
-`markdown:docs/common/meta.zh.md`
-
-### 图形样式
+- `horizontal`: horizontally layout all bars.
+- `vertical`: vertically layout all bars (as columns).
 
 #### barStyle
 
 <description>**optional** _StyleAttr | Function_</description>
 
-柱子样式配置。
+Configurations of the style of bars.
 
-`markdown:docs/common/shape-style.zh.md`
+`markdown:docs/common/shape-style.en.md`
 
-### 图表组件
+#### xAxis
 
-`markdown:docs/common/component.zh.md`
+See the configuration of [axis](#axis).
 
-### 事件
+#### yAxis
 
-`markdown:docs/common/events.zh.md`
+<description>**optional** object</description>
 
-### 图表方法
+`yAxis` is a object. Keys are the fields defined in `yField`, values is the configuration of [axis](#axis).
 
-`markdown:docs/common/chart-methods.zh.md`
+### Plot Components
 
+`markdown:docs/common/component.en.md`
 
+### Events
 
-### 图表主题
+`markdown:docs/common/events.en.md`
 
-`markdown:docs/common/theme.zh.md`
+### Plot Methods
+
+`markdown:docs/common/chart-methods.en.md`
+
+### Plot Theme
+
+`markdown:docs/common/theme.en.md`

--- a/docs/api/plots/bidirectional-bar.zh.md
+++ b/docs/api/plots/bidirectional-bar.zh.md
@@ -35,21 +35,29 @@ order: 26
 
 设置 y 轴映射字段。
 
-#### yAxis
+<!-- Meta options START -->
 
-<description>**optional** object</description>
+`markdown:docs/common/meta.zh.md`
 
- yAxis 为多个 key 为 yField 里面的 2 个字段。
+Example:
 
- #### layout
+```ts
+{
+  meta: {
+    '2016年耕地总面积': { alias: '耕地总面积' }
+  }
+}
+```
+
+<!-- Meta options END -->
+
+### 图形样式
+
+#### layout
 
 <description>**optional** _'horizontal' | 'vertical'_ _default:_ 'horizontal'</description>
 
 表示对称条形图方向。
-
-`markdown:docs/common/meta.zh.md`
-
-### 图形样式
 
 #### barStyle
 
@@ -58,6 +66,12 @@ order: 26
 柱子样式配置。
 
 `markdown:docs/common/shape-style.zh.md`
+
+#### yAxis
+
+<description>**optional** object</description>
+
+ yAxis 为多个 key 为 yField 里面的 2 个字段。
 
 ### 图表组件
 
@@ -70,8 +84,6 @@ order: 26
 ### 图表方法
 
 `markdown:docs/common/chart-methods.zh.md`
-
-
 
 ### 图表主题
 

--- a/docs/api/plots/bullet.en.md
+++ b/docs/api/plots/bullet.en.md
@@ -13,7 +13,7 @@ order: 10
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{title: '满意度', ranges: [50,100], measures: [80], target: 85}]`。
+Configure the data source. The data source is a collection of objects. For example:`[{title: '满意度', ranges: [50,100], measures: [80], target: 85}]`。
 
 `markdown:docs/common/meta.en.md`
 

--- a/docs/api/plots/column.en.md
+++ b/docs/api/plots/column.en.md
@@ -13,7 +13,7 @@ order: 2
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 `markdown:docs/common/xy-field.en.md`
 

--- a/docs/api/plots/dual-axes.en.md
+++ b/docs/api/plots/dual-axes.en.md
@@ -152,11 +152,11 @@ xAxis、yAxis 配置相同，由于 DualAxes 是双轴， annotations 类型是�
 
 `markdown:docs/common/theme.en.md`
 
-### 事件
+### Events
 
 `markdown:docs/common/events.en.md`
 
-### 图表方法
+### Plot Methods
 
 `markdown:docs/common/chart-methods.en.md`
 

--- a/docs/api/plots/heatmap.en.md
+++ b/docs/api/plots/heatmap.en.md
@@ -13,7 +13,7 @@ order: 23
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 `markdown:docs/common/xy-field.en.md`
 

--- a/docs/api/plots/histogram.en.md
+++ b/docs/api/plots/histogram.en.md
@@ -13,7 +13,7 @@ order: 11
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 #### binField 
 

--- a/docs/api/plots/pie.en.md
+++ b/docs/api/plots/pie.en.md
@@ -13,7 +13,7 @@ order: 4
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 `markdown:docs/common/meta.en.md`
 

--- a/docs/api/plots/radar.en.md
+++ b/docs/api/plots/radar.en.md
@@ -13,7 +13,7 @@ order: 7
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 `markdown:docs/common/meta.en.md`
 

--- a/docs/api/plots/rose.en.md
+++ b/docs/api/plots/rose.en.md
@@ -13,7 +13,7 @@ order: 13
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：
+Configure the data source. The data source is a collection of objects. For example:
 
 ```ts
 [

--- a/docs/api/plots/scatter.en.md
+++ b/docs/api/plots/scatter.en.md
@@ -13,7 +13,7 @@ order: 5
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 `markdown:docs/common/xy-field.en.md`
 

--- a/docs/api/plots/stock.en.md
+++ b/docs/api/plots/stock.en.md
@@ -13,7 +13,7 @@ order: 18
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：
+Configure the data source. The data source is a collection of objects. For example:
 
 ```ts
 [

--- a/docs/api/plots/treemap.en.md
+++ b/docs/api/plots/treemap.en.md
@@ -44,7 +44,7 @@ const data = {
 
 
 
-### 图形样式
+### Geometry Style
 
 `markdown:docs/common/color.zh.md`
 
@@ -95,7 +95,7 @@ const data = {
 层级布局配置，例如 `tile`等，详细配置参考[d3-hierarchy](https://github.com/d3/d3-hierarchy#treemap)。
 默认为 `{tile: 'treemapResquarify'}`
 
-### 图表组件
+### Plot Components
 
 `markdown:docs/common/component-polygon.zh.md`
 
@@ -103,11 +103,11 @@ const data = {
 
 `markdown:docs/common/events.zh.md`
 
-### 图表方法
+### Plot Methods
 
 `markdown:docs/common/chart-methods.zh.md`
 
-### 图表主题
+### Plot Theme
 
 `markdown:docs/common/theme.zh.md`
 

--- a/docs/api/plots/waterfall.en.md
+++ b/docs/api/plots/waterfall.en.md
@@ -13,7 +13,7 @@ order: 24
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 `markdown:docs/common/xy-field.en.md`
 

--- a/docs/api/plots/word-cloud.en.md
+++ b/docs/api/plots/word-cloud.en.md
@@ -13,7 +13,7 @@ order: 8
 
 <description>**required** _array object_</description>
 
-设置图表数据源。数据源为对象集合，例如：`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
+Configure the data source. The data source is a collection of objects. For example:`[{ time: '1991'，value: 20 }, { time: '1992'，value: 20 }]`。
 
 #### wordField
 

--- a/src/plots/bidirectional-bar/constant.ts
+++ b/src/plots/bidirectional-bar/constant.ts
@@ -1,2 +1,4 @@
 export const FIRST_AXES_VIEW = 'first-axes-view';
 export const SECOND_AXES_VIEW = 'second-axes-view';
+/** 对称条形图的分组 key 值 */
+export const SERIES_FIELD_KEY = 'series-field-key';

--- a/src/plots/bidirectional-bar/types.ts
+++ b/src/plots/bidirectional-bar/types.ts
@@ -1,7 +1,7 @@
 import { Axis } from '../../types/axis';
 import { Options, StyleAttr } from '../../types';
 
-export interface BidirectionalBarOptions extends Omit<Options, 'yAxis' | 'yField' | 'meta'> {
+export interface BidirectionalBarOptions extends Omit<Options, 'yAxis' | 'yField'> {
   /** x 轴字段 */
   readonly xField: string;
   /** y 轴映射字段 */

--- a/src/plots/bidirectional-bar/utils.ts
+++ b/src/plots/bidirectional-bar/utils.ts
@@ -2,7 +2,6 @@ import { Datum } from '../../types';
 import { BidirectionalBarOptions } from '.';
 
 type TransformData = {
-  type: string;
   [key: string]: string | number;
 }[];
 
@@ -12,13 +11,13 @@ type TransformData = {
  * @param yField
  * @param data
  */
-export function transformData(xField: string, yField: string[], data: Datum): TransformData {
+export function transformData(xField: string, yField: string[], seriesField: string, data: Datum): TransformData {
   const hopeData: TransformData = [];
   yField.forEach((d: string) => {
     data.forEach((k: any) => {
       const obj = {
         [xField]: k[xField],
-        type: d,
+        [seriesField]: d,
         [d]: k[d],
       };
       hopeData.push(obj);


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [x] add / modify test cases
- [x] documents, demos

### Screenshot

```ts
  meta: {
    '2016年耕地总面积': { alias: '耕地总面积' },
    '2016年转基因种植面积': { alias: '转基因种植面积' },
  },
```

|  Before  |  After  |
|----|----|
| ![image](https://user-images.githubusercontent.com/15646325/105009956-1c28aa80-5a76-11eb-824b-3d98ad5b7993.png) |  ![image](https://user-images.githubusercontent.com/15646325/105009880-01563600-5a76-11eb-8b84-1ed2d65f6482.png) |

