### PR TITLE
feat(change-data): 饼图支持动态更新数据 & 其他若干处理，见 PR 描述

### DIFF
--- a/__tests__/unit/core/index-spec.ts
+++ b/__tests__/unit/core/index-spec.ts
@@ -1,5 +1,5 @@
 import { deepMix, isEqual, clone } from '@antv/util';
-import { Line, G2 } from '../../../src';
+import { Line, G2, Plot } from '../../../src';
 import { partySupport } from '../../data/party-support';
 import { createDiv } from '../../utils/dom';
 import { delay } from '../../utils/delay';
@@ -299,5 +299,18 @@ describe('core', () => {
     expect(line.chart.getOptions().axes['date'].label.autoHide).toBe(false);
 
     line.destroy();
+  });
+
+  it('default-options', () => {
+    type CustomPlotOptions = {};
+    class CustomPlot extends Plot<CustomPlotOptions> {
+      type: 'custom';
+      getSchemaAdaptor() {
+        return () => {};
+      }
+    }
+    const plot = new CustomPlot(createDiv(), {});
+    // @ts-ignore
+    expect(Plot.getDefaultOptions()).toEqual(plot.getDefaultOptions());
   });
 });

--- a/__tests__/unit/plots/pie/annotation-spec.ts
+++ b/__tests__/unit/plots/pie/annotation-spec.ts
@@ -55,6 +55,26 @@ describe('annotation', () => {
     expect(pie.chart.getController('annotation').getComponents()[1].component.get('type')).toBe('line');
   });
 
+  it('annotation with change data', () => {
+    pie.update({ data: [], statistic: {} });
+    expect(pie.chart.getController('annotation').getComponents().length).toBe(4);
+    expect(pie.chart.getController('annotation').getComponents()[0].component.get('content')).toBe('辅助文本');
+    // @ts-ignore
+    let annotations = pie.chart.ele.querySelectorAll('.g2-html-annotation') as HTMLDivElement[];
+    expect(annotations[0].innerText).toBe('总计');
+    expect(annotations[1].innerText).toBe('');
+
+    pie.changeData(salesByArea);
+    setTimeout(() => {
+      expect(pie.chart.getController('annotation').getComponents().length).toBe(4);
+      expect(pie.chart.getController('annotation').getComponents()[0].component.get('content')).toBe('辅助文本');
+      // @ts-ignore
+      annotations = pie.chart.ele.querySelectorAll('.g2-html-annotation') as HTMLDivElement[];
+      expect(annotations[0].innerText).toBe('总计');
+      expect(annotations[1].innerText).toBe(salesByArea.reduce((a, b) => a + b.sales, 0));
+    }, 0);
+  });
+
   it('先更新为 false，再更新出现, 且样式不变', () => {
     const pie1 = new Pie(createDiv(), {
       width: 300,

--- a/__tests__/unit/plots/pie/annotation-spec.ts
+++ b/__tests__/unit/plots/pie/annotation-spec.ts
@@ -16,6 +16,9 @@ describe('annotation', () => {
 
   it('text annotation', () => {
     expect(pie.chart.getController('annotation').getComponents().length).toBe(2);
+    const annotation1: HTMLDivElement = pie.chart.ele.querySelector('.g2-html-annotation');
+    // @ts-ignore
+    expect(annotation1.style.fontWeight).toBe(`${Pie.getDefaultOptions().statistic.title.style.fontWeight}`);
 
     pie.update({
       annotations: [
@@ -52,18 +55,33 @@ describe('annotation', () => {
     expect(pie.chart.getController('annotation').getComponents()[1].component.get('type')).toBe('line');
   });
 
-  it('先更新为 false，再更新出现', () => {
-    pie.update({ statistic: {} });
-    expect(pie.chart.getController('annotation').getComponents().length).toBe(4);
+  it('先更新为 false，再更新出现, 且样式不变', () => {
+    const pie1 = new Pie(createDiv(), {
+      width: 300,
+      height: 400,
+      data: salesByArea,
+      colorField: 'sales',
+      angleField: 'area',
+      innerRadius: 0.64,
+    });
 
-    pie.update({ statistic: { title: false, content: false } });
-    expect(pie.chart.getController('annotation').getComponents().length).toBe(2);
+    pie1.render();
+    let annotation1: HTMLDivElement = pie1.chart.ele.querySelector('.g2-html-annotation');
+    const style = annotation1.style;
 
-    pie.update({ statistic: { title: {}, content: {} } });
-    const annotations = pie.chart.getController('annotation').getComponents();
-    expect(annotations.length).toBe(4);
+    pie1.update({ statistic: { title: false, content: false } });
+    expect(pie1.chart.getController('annotation').getComponents().length).toBe(0);
+
+    pie1.update({ statistic: { title: {}, content: {} } });
+    expect(pie1.chart.getController('annotation').getComponents().length).toBe(2);
+    annotation1 = pie1.chart.ele.querySelector('.g2-html-annotation');
     // @ts-ignore
-    expect(pie.chart.ele.querySelector('.g2-html-annotation').innerText).toBe('总计');
+    expect(annotation1.innerText).toBe('总计');
+    // 样式依然是默认样式
+    // @ts-ignore
+    expect(annotation1.style).toEqual(style);
+
+    pie1.destroy();
   });
 
   afterAll(() => {

--- a/__tests__/unit/plots/pie/annotation-spec.ts
+++ b/__tests__/unit/plots/pie/annotation-spec.ts
@@ -18,7 +18,6 @@ describe('annotation', () => {
     expect(pie.chart.getController('annotation').getComponents().length).toBe(2);
 
     pie.update({
-      ...pie.options,
       annotations: [
         {
           type: 'text',
@@ -34,7 +33,6 @@ describe('annotation', () => {
 
   it('text annotation and line annotation', () => {
     pie.update({
-      ...pie.options,
       statistic: null,
       annotations: [
         {
@@ -52,6 +50,20 @@ describe('annotation', () => {
     expect(pie.chart.getController('annotation').getComponents().length).toBe(2);
     expect(pie.chart.getController('annotation').getComponents()[0].component.get('content')).toBe('辅助文本');
     expect(pie.chart.getController('annotation').getComponents()[1].component.get('type')).toBe('line');
+  });
+
+  it('先更新为 false，再更新出现', () => {
+    pie.update({ statistic: {} });
+    expect(pie.chart.getController('annotation').getComponents().length).toBe(4);
+
+    pie.update({ statistic: { title: false, content: false } });
+    expect(pie.chart.getController('annotation').getComponents().length).toBe(2);
+
+    pie.update({ statistic: { title: {}, content: {} } });
+    const annotations = pie.chart.getController('annotation').getComponents();
+    expect(annotations.length).toBe(4);
+    // @ts-ignore
+    expect(pie.chart.ele.querySelector('.g2-html-annotation').innerText).toBe('总计');
   });
 
   afterAll(() => {

--- a/__tests__/unit/plots/pie/data-spec.ts
+++ b/__tests__/unit/plots/pie/data-spec.ts
@@ -125,7 +125,7 @@ describe('饼图 异常数据', () => {
 });
 
 describe('数据存在 NaN', () => {
-  const createPie = (data) => {
+  const createPie = (data): Pie => {
     const pie = new Pie(createDiv(), {
       angleField: 'value',
       colorField: 'type',
@@ -143,6 +143,8 @@ describe('数据存在 NaN', () => {
     ]);
     expect(pie.chart).toBeDefined();
     expect(pie.chart.getData()).toEqual([{ type: '2', value: 10 }]);
+
+    pie.destroy();
   });
 
   it('从正常数据 change 到存在 NaN', () => {
@@ -151,6 +153,7 @@ describe('数据存在 NaN', () => {
     expect(pie.chart).toBeDefined();
     expect(pie.options.data).toEqual([{ type: '1', value: NaN }]);
     expect(pie.chart.getData()).toEqual([]);
+    pie.destroy();
   });
 
   it('从 [] change 到存在 NaN', () => {
@@ -159,6 +162,7 @@ describe('数据存在 NaN', () => {
     expect(pie.chart).toBeDefined();
     expect(pie.options.data).toEqual([{ type: '1', value: NaN }]);
     expect(pie.chart.getData()).toEqual([]);
+    pie.destroy();
   });
 
   it('从存在数据 0 change 到存在 NaN', () => {
@@ -178,11 +182,12 @@ describe('数据存在 NaN', () => {
     ]);
     expect(pie.chart.getData()[0]).toMatchObject({ type: '2', value: 0 });
     expect(pie.chart.geometries[0].elements.length).toEqual(1);
+    pie.destroy();
   });
 });
 
 describe('环图 changeData', () => {
-  const createDonut = (data) => {
+  const createDonut = (data): Pie => {
     const donut = new Pie(createDiv(), {
       angleField: 'value',
       colorField: 'type',
@@ -204,6 +209,8 @@ describe('环图 changeData', () => {
       { type: '2', value: 3 },
     ]);
     expect(donut.chart.getController('annotation').getComponents().length).toBe(3);
+
+    donut.destroy();
   });
 
   it('从数据全 0 到正常', () => {
@@ -218,5 +225,7 @@ describe('环图 changeData', () => {
       { type: '2', value: 3 },
     ]);
     expect(donut.chart.getController('annotation').getComponents().length).toBe(3);
+
+    donut.destroy();
   });
 });

--- a/__tests__/unit/plots/pie/data-spec.ts
+++ b/__tests__/unit/plots/pie/data-spec.ts
@@ -4,7 +4,7 @@ import { Pie } from '../../../../src';
 import { createDiv } from '../../../utils/dom';
 import { delay } from '../../../utils/delay';
 
-describe('饼图 数据全空', () => {
+describe('饼图 异常数据', () => {
   const data = [];
   for (let i = 0; i < 5; i++) {
     data.push({ type: `类型 ${i}`, value: 0 });
@@ -99,10 +99,7 @@ describe('饼图 数据全空', () => {
     expect(elements.length).toBe(0);
 
     await delay(500);
-    pie.update({
-      ...pie.options,
-      data,
-    });
+    pie.changeData(data);
 
     elements = pie.chart.geometries[0].elements;
     expect(every(elements, (ele) => ele.getBBox().width > 0)).toBe(true);
@@ -124,5 +121,102 @@ describe('饼图 数据全空', () => {
     expect(tooltipItems[0].value).toBe('1');
 
     pie.destroy();
+  });
+});
+
+describe('数据存在 NaN', () => {
+  const createPie = (data) => {
+    const pie = new Pie(createDiv(), {
+      angleField: 'value',
+      colorField: 'type',
+      data,
+    });
+
+    pie.render();
+    return pie;
+  };
+
+  it('初始化存在 NaN', () => {
+    const pie = createPie([
+      { type: '1', value: NaN },
+      { type: '2', value: 10 },
+    ]);
+    expect(pie.chart).toBeDefined();
+    expect(pie.chart.getData()).toEqual([{ type: '2', value: 10 }]);
+  });
+
+  it('从正常数据 change 到存在 NaN', () => {
+    const pie = createPie([{ type: '2', value: 10 }]);
+    pie.changeData([{ type: '1', value: NaN }]);
+    expect(pie.chart).toBeDefined();
+    expect(pie.options.data).toEqual([{ type: '1', value: NaN }]);
+    expect(pie.chart.getData()).toEqual([]);
+  });
+
+  it('从 [] change 到存在 NaN', () => {
+    const pie = createPie([]);
+    pie.changeData([{ type: '1', value: NaN }]);
+    expect(pie.chart).toBeDefined();
+    expect(pie.options.data).toEqual([{ type: '1', value: NaN }]);
+    expect(pie.chart.getData()).toEqual([]);
+  });
+
+  it('从存在数据 0 change 到存在 NaN', () => {
+    const pie = createPie([
+      { type: '1', value: 0 },
+      { type: '1', value: 0 },
+    ]);
+    expect(pie.chart.getData().length).toBe(2);
+    pie.changeData([{ type: '1', value: NaN }]);
+    expect(pie.chart).toBeDefined();
+    expect(pie.options.data).toEqual([{ type: '1', value: NaN }]);
+    expect(pie.chart.getData()).toEqual([]);
+
+    pie.changeData([
+      { type: '1', value: NaN },
+      { type: '2', value: 0 },
+    ]);
+    expect(pie.chart.getData()[0]).toMatchObject({ type: '2', value: 0 });
+    expect(pie.chart.geometries[0].elements.length).toEqual(1);
+  });
+});
+
+describe('环图 changeData', () => {
+  const createDonut = (data) => {
+    const donut = new Pie(createDiv(), {
+      angleField: 'value',
+      colorField: 'type',
+      data,
+      innerRadius: 0.6,
+      annotations: [{ type: 'text', content: 'xx', position: ['min', 'max'] }],
+    });
+
+    donut.render();
+    return donut;
+  };
+
+  it('normal', () => {
+    const donut = createDonut([]);
+    expect(donut.chart.getController('annotation').getComponents().length).toBe(3);
+
+    donut.changeData([
+      { type: '1', value: 1 },
+      { type: '2', value: 3 },
+    ]);
+    expect(donut.chart.getController('annotation').getComponents().length).toBe(3);
+  });
+
+  it('从数据全 0 到正常', () => {
+    const donut = createDonut([
+      { type: '1', value: 0 },
+      { type: '2', value: 0 },
+    ]);
+    expect(donut.chart.getController('annotation').getComponents().length).toBe(3);
+
+    donut.changeData([
+      { type: '1', value: 1 },
+      { type: '2', value: 3 },
+    ]);
+    expect(donut.chart.getController('annotation').getComponents().length).toBe(3);
   });
 });

--- a/__tests__/unit/plots/pie/index-spec.ts
+++ b/__tests__/unit/plots/pie/index-spec.ts
@@ -1,4 +1,5 @@
 import { Pie } from '../../../../src';
+import { DEFAULT_OPTIONS } from '../../../../src/plots/pie/contants';
 import { POSITIVE_NEGATIVE_DATA } from '../../../data/common';
 import { createDiv } from '../../../utils/dom';
 
@@ -166,5 +167,9 @@ describe('pie', () => {
     expect(pie.chart.getController('tooltip').getTooltipCfg().shared).toBe(false);
 
     pie.destroy();
+  });
+
+  it('defaultOptions 保持从 constants 中获取', () => {
+    expect(Pie.getDefaultOptions()).toEqual(DEFAULT_OPTIONS);
   });
 });

--- a/__tests__/unit/plots/pie/index-spec.ts
+++ b/__tests__/unit/plots/pie/index-spec.ts
@@ -20,6 +20,9 @@ describe('pie', () => {
     });
 
     pie.render();
+    expect(pie.type).toBe('pie');
+    // @ts-ignore
+    expect(pie.getDefaultOptions()).toBe(Pie.getDefaultOptions());
 
     const geometry = pie.chart.geometries[0];
     const elements = geometry.elements;

--- a/__tests__/unit/plots/pie/statistic-spec.ts
+++ b/__tests__/unit/plots/pie/statistic-spec.ts
@@ -1,5 +1,6 @@
 import { Chart } from '@antv/g2';
 import { Pie, PieOptions } from '../../../../src';
+import { DEFAULT_OPTIONS } from '../../../../src/plots/pie/contants';
 import { POSITIVE_NEGATIVE_DATA } from '../../../data/common';
 import { delay } from '../../../utils/delay';
 import { createDiv } from '../../../utils/dom';
@@ -299,6 +300,22 @@ describe('中心文本 - 指标卡', () => {
     // @ts-ignore
     expect(htmlAnnotations[0].style.width).toEqual('500px');
     expect(htmlAnnotations[0].getBoundingClientRect().width).toEqual(600);
+  });
+
+  it('statistic 默认继承 defaultOptions', () => {
+    pie.update({ statistic: null });
+    expect(pie.chart.ele.querySelectorAll('.g2-html-annotation').length).toBe(0);
+
+    pie.update({ statistic: {} });
+    expect(pie.chart.ele.querySelectorAll('.g2-html-annotation').length).toBe(2);
+    expect(pie.options.statistic).toEqual({});
+    setTimeout(() => {
+      // @ts-ignore
+      const annotations = pie.chart.ele.querySelectorAll('.g2-html-annotation') as HTMLDivElement[];
+      expect(annotations[0].style.fontSize).toEqual(DEFAULT_OPTIONS.statistic.title.fontSize);
+      expect(annotations[1].style.color).toEqual(DEFAULT_OPTIONS.statistic.content.color);
+      expect(annotations[1].style).toMatchObject(DEFAULT_OPTIONS.statistic.content);
+    }, 0);
   });
 
   afterEach(() => {

--- a/__tests__/unit/plots/pie/utils-spec.ts
+++ b/__tests__/unit/plots/pie/utils-spec.ts
@@ -1,4 +1,4 @@
-import { adaptOffset, getTotalValue } from '../../../../../src/plots/pie/utils';
+import { adaptOffset, getTotalValue, isAllZero, processIllegalData } from '../../../../src/plots/pie/utils';
 
 describe('utils of pie plot', () => {
   const data = [
@@ -57,5 +57,29 @@ describe('utils of pie plot', () => {
     expect(parseFloat(adaptOffset('outer', '-30%') as string)).not.toBeLessThan(0);
     expect(adaptOffset('spider', '30%')).toBe('30%');
     expect(adaptOffset('spider', NaN)).toBe(NaN);
+  });
+
+  it('过滤非法数据', () => {
+    const data = [{ type: '1', value: 0 }];
+    expect(processIllegalData(data, 'value')).toEqual(data);
+    data.push({ type: '2', value: 1 });
+    expect(processIllegalData(data, 'value')).toEqual(data);
+    data.push({ type: '3', value: null });
+    expect(processIllegalData(data, 'value')).toEqual(data);
+    data.push({ type: '4', value: undefined });
+    expect(processIllegalData(data, 'value')).toEqual(data.slice(0, 3));
+    data.push({ type: '5', value: NaN });
+    expect(processIllegalData(data, 'value')).toEqual(data.slice(0, 3));
+  });
+
+  it('判断是否全 0', () => {
+    const data = [{ type: '1', value: 0 }];
+    expect(isAllZero(data, 'value')).toBe(true);
+    data.push({ type: '2', value: 0 });
+    expect(isAllZero(data, 'value')).toBe(true);
+    data.push({ type: '3', value: null });
+    expect(isAllZero(data, 'value')).toBe(false);
+    data.push({ type: '4', value: undefined });
+    expect(isAllZero(data, 'value')).toBe(false);
   });
 });

--- a/examples/dynamic-plots/basic/demo/dynamic-pie.ts
+++ b/examples/dynamic-plots/basic/demo/dynamic-pie.ts
@@ -1,0 +1,33 @@
+import { Pie } from '@antv/g2plot';
+
+const data = [
+  { type: '分类一', value: 27 },
+  { type: '分类二', value: 25 },
+  { type: '分类三', value: 18 },
+  { type: '分类四', value: 15 },
+  { type: '分类五', value: 10 },
+  { type: '其他', value: 5 },
+];
+
+const piePlot = new Pie('container', {
+  appendPadding: 10,
+  data,
+  angleField: 'value',
+  colorField: 'type',
+  radius: 0.9,
+  label: {
+    type: 'inner',
+    offset: '-30%',
+    content: ({ percent }) => `${(percent * 100).toFixed(0)}%`,
+    style: {
+      fontSize: 14,
+      textAlign: 'center',
+    },
+  },
+  interactions: [{ type: 'element-active' }],
+});
+
+piePlot.render();
+setInterval(() => {
+  piePlot.changeData(data.map((d) => ({ ...d, value: d.value * Math.random() })));
+}, 1200);

--- a/examples/dynamic-plots/basic/demo/meta.json
+++ b/examples/dynamic-plots/basic/demo/meta.json
@@ -35,6 +35,14 @@
         "en": "Gauge updating with dynamic"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*O2aDSImbWDgAAAAAAAAAAAAAARQnAQ"
+    },
+    {
+      "filename": "dynamic-pie.ts",
+      "title": {
+        "zh": "动态更新的饼图",
+        "en": "Pie updating with dynamic"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/JQXEkyg2Rm/dongtaigengxinshuju-pie-after.gif"
     }
   ]
 }

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -27,6 +27,31 @@ const SOURCE_ATTRIBUTE_NAME = 'data-chart-source-type';
  * 所有 plot 的基类
  */
 export abstract class Plot<O extends PickOptions> extends EE {
+  /**
+   * 获取默认的 options 配置项
+   * 每个组件都可以复写
+   */
+  static getDefaultOptions(): any {
+    return {
+      renderer: 'canvas',
+      xAxis: {
+        nice: true,
+        label: {
+          autoRotate: false,
+          autoHide: { type: 'equidistance', cfg: { minGap: 6 } },
+        },
+      },
+      yAxis: {
+        nice: true,
+        label: {
+          autoHide: true,
+          autoRotate: false,
+        },
+      },
+      animation: true,
+    };
+  }
+
   /** plot 类型名称 */
   public abstract readonly type: string = 'base';
   /** plot 的 schema 配置 */
@@ -111,24 +136,7 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * 每个组件都可以复写
    */
   protected getDefaultOptions(): any {
-    return {
-      renderer: 'canvas',
-      xAxis: {
-        nice: true,
-        label: {
-          autoRotate: false,
-          autoHide: { type: 'equidistance', cfg: { minGap: 6 } },
-        },
-      },
-      yAxis: {
-        nice: true,
-        label: {
-          autoHide: true,
-          autoRotate: false,
-        },
-      },
-      animation: true,
-    };
+    return Plot.getDefaultOptions();
   }
 
   /**

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -1,9 +1,9 @@
-import { every, filter, isFunction, isString, isNil, get, isArray, isNumber } from '@antv/util';
+import { isFunction, isString, isNil, get, isArray, isNumber } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
-import { flow, LEVEL, log, template, transformLabel, deepAssign, renderStatistic } from '../../utils';
-import { adaptOffset, getTotalValue } from './utils';
+import { flow, template, transformLabel, deepAssign, renderStatistic } from '../../utils';
+import { adaptOffset, getTotalValue, processIllegalData, isAllZero } from './utils';
 import { PieOptions } from './types';
 
 /**
@@ -15,13 +15,9 @@ function geometry(params: Params<PieOptions>): Params<PieOptions> {
   const { data, angleField, colorField, color, pieStyle } = options;
 
   // 处理不合法的数据
-  let processData = filter(data, (d) => typeof d[angleField] === 'number' || isNil(d[angleField]));
+  let processData = processIllegalData(data, angleField);
 
-  // 打印异常数据情况
-  log(LEVEL.WARN, processData.length === data.length, 'illegal data existed in chart data.');
-
-  const allZero = every(processData, (d) => d[angleField] === 0);
-  if (allZero) {
+  if (isAllZero(processData, angleField)) {
     // 数据全 0 处理，调整 position 映射
     const percentageField = '$$percentage$$';
     processData = processData.map((d) => ({ ...d, [percentageField]: 1 / processData.length }));
@@ -170,9 +166,14 @@ function label(params: Params<PieOptions>): Params<PieOptions> {
  * statistic 中心文本配置
  * @param params
  */
-function statistic(params: Params<PieOptions>): Params<PieOptions> {
+export function pieAnnotation(params: Params<PieOptions>): Params<PieOptions> {
   const { chart, options } = params;
   const { innerRadius, statistic, angleField, colorField, meta } = options;
+  // 先清空标注，再重新渲染
+  chart.getController('annotation').clear(true);
+
+  // 先进行其他 annotations，再去渲染统计文本
+  flow(annotation())(params);
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
@@ -221,9 +222,8 @@ export function adaptor(params: Params<PieOptions>) {
     (args) => tooltip(adaptorTooltipOptions(args)),
     label,
     state,
-    annotation(),
     /** 指标卡中心文本 放在下层 */
-    statistic,
+    pieAnnotation,
     interaction,
     animation
   )(params);

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -3,6 +3,7 @@ import { Params } from '../../core/adaptor';
 import { legend, tooltip, interaction, animation, theme, state, annotation } from '../../adaptor/common';
 import { interval } from '../../adaptor/geometries';
 import { flow, template, transformLabel, deepAssign, renderStatistic } from '../../utils';
+import { DEFAULT_OPTIONS } from './contants';
 import { adaptOffset, getTotalValue, processIllegalData, isAllZero } from './utils';
 import { PieOptions } from './types';
 
@@ -177,7 +178,7 @@ export function pieAnnotation(params: Params<PieOptions>): Params<PieOptions> {
 
   /** 中心文本 指标卡 */
   if (innerRadius && statistic) {
-    let { title, content } = statistic;
+    let { title, content } = deepAssign({}, DEFAULT_OPTIONS.statistic, statistic);
     if (title !== false) {
       title = deepAssign({}, { formatter: (datum) => (datum ? datum[colorField] : '总计') }, title);
     }

--- a/src/plots/pie/contants.ts
+++ b/src/plots/pie/contants.ts
@@ -1,0 +1,46 @@
+import { Plot } from '../../core/plot';
+import { deepAssign } from '../../utils';
+
+export const DEFAULT_OPTIONS = deepAssign({}, Plot.getDefaultOptions(), {
+  legend: {
+    position: 'right',
+  },
+  tooltip: {
+    shared: false,
+    showTitle: false,
+    showMarkers: false,
+  },
+  label: {
+    layout: { type: 'limit-in-plot', cfg: { action: 'ellipsis' } },
+  },
+  /** 饼图样式, 不影响暗黑主题 */
+  pieStyle: {
+    stroke: 'white',
+    lineWidth: 1,
+  },
+  /** 饼图中心文本默认样式 */
+  statistic: {
+    title: {
+      style: { fontWeight: 300, color: '#4B535E', textAlign: 'center', fontSize: '20px', lineHeight: 1 },
+    },
+    content: {
+      style: {
+        fontWeight: 'bold',
+        color: 'rgba(44,53,66,0.85)',
+        textAlign: 'center',
+        fontSize: '32px',
+        lineHeight: 1,
+      },
+    },
+  },
+  /** 默认关闭 text-annotation 动画 */
+  theme: {
+    components: {
+      annotation: {
+        text: {
+          animate: false,
+        },
+      },
+    },
+  },
+});

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -1,14 +1,22 @@
 import { Plot } from '../../core/plot';
-import { deepAssign } from '../../utils';
 import { Adaptor } from '../../core/adaptor';
+import { adaptor, pieAnnotation } from './adaptor';
+import { DEFAULT_OPTIONS } from './contants';
 import { PieOptions } from './types';
 import { isAllZero, processIllegalData } from './utils';
-import { adaptor, pieAnnotation } from './adaptor';
 import './interactions';
 
 export { PieOptions };
 
 export class Pie extends Plot<PieOptions> {
+  /**
+   * 获取 饼图 默认配置项
+   * @static 供外部使用
+   */
+  static getDefaultOptions(): Partial<PieOptions> {
+    return DEFAULT_OPTIONS;
+  }
+
   /** 图表类型 */
   public type: string = 'pie';
 
@@ -34,52 +42,10 @@ export class Pie extends Plot<PieOptions> {
   }
 
   /**
-   * 获取 饼图 默认配置项
+   * 获取 饼图 默认配置项, 供 base 获取
    */
   protected getDefaultOptions(): Partial<PieOptions> {
-    return deepAssign({}, super.getDefaultOptions(), {
-      legend: {
-        position: 'right',
-      },
-      tooltip: {
-        shared: false,
-        showTitle: false,
-        showMarkers: false,
-      },
-      label: {
-        layout: { type: 'limit-in-plot', cfg: { action: 'ellipsis' } },
-      },
-      /** 饼图样式, 不影响暗黑主题 */
-      pieStyle: {
-        stroke: 'white',
-        lineWidth: 1,
-      },
-      /** 饼图中心文本默认样式 */
-      statistic: {
-        title: {
-          style: { fontWeight: 300, color: '#4B535E', textAlign: 'center', fontSize: '20px', lineHeight: 1 },
-        },
-        content: {
-          style: {
-            fontWeight: 'bold',
-            color: 'rgba(44,53,66,0.85)',
-            textAlign: 'center',
-            fontSize: '32px',
-            lineHeight: 1,
-          },
-        },
-      },
-      /** 默认关闭 text-annotation 动画 */
-      theme: {
-        components: {
-          annotation: {
-            text: {
-              animate: false,
-            },
-          },
-        },
-      },
-    });
+    return Pie.getDefaultOptions();
   }
 
   /**

--- a/src/plots/pie/utils.ts
+++ b/src/plots/pie/utils.ts
@@ -1,5 +1,7 @@
-import { each, isString } from '@antv/util';
-import { Data } from '../../../types';
+import { each, every, filter, isString } from '@antv/util';
+import { LEVEL, log } from '../../utils';
+import { Data } from '../../types';
+import { PieOptions } from './types';
 
 /**
  * 获取总计值
@@ -37,4 +39,30 @@ export function adaptOffset(type: string, offset?: string | number): string | nu
     default:
       return offset;
   }
+}
+
+/**
+ * 处理不合法的数据(过滤 非数值型 和 NaN，保留 null)
+ * @param data
+ * @param angleField
+ */
+export function processIllegalData(data: PieOptions['data'], angleField: string) {
+  const processData = filter(data, (d) => {
+    const v = d[angleField];
+    return (typeof v === 'number' && !isNaN(v)) || v === null;
+  });
+
+  // 打印异常数据情况
+  log(LEVEL.WARN, processData.length === data.length, 'illegal data existed in chart data.');
+
+  return processData;
+}
+
+/**
+ * 判断数据是否全部为 0
+ * @param data
+ * @param angleField
+ */
+export function isAllZero(data: PieOptions['data'], angleField: string): boolean {
+  return every(data, (d) => d[angleField] === 0);
 }


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fix: 修复中心统计文本更新为false，再更新为显示，样式丢失. closed: https://github.com/ant-design/ant-design-charts/issues/430
- [x] fix: 饼图数据存在 NaN 时，浏览器崩溃
- [x] feat: 饼图支持动态更新数据
- [x] feat: 饼图支持通过 `Pie.getDefauletOptions()` 获取默认配置项
- [x] add / modify test cases
- [x] documents, demos

### Screenshot

|  Before  |  After  |
|----|----|
|  ![动态更新数据-pie-before](https://user-images.githubusercontent.com/15646325/105461829-b849f000-5cc8-11eb-9e3e-5ba3f8c8280a.gif) | ![动态更新数据-pie-after](https://user-images.githubusercontent.com/15646325/105461835-bbdd7700-5cc8-11eb-8b7a-261b60667392.gif)|
|饼图中心文本从展示到隐藏再展示后，样式丢失 ||
|![](https://gw.alipayobjects.com/zos/antfincdn/lI%26kgW7%26%24J/zhongxinwenbencongyoudaowuzaidaoyou%2Cyangshidiushi.gif)|![](https://gw.alipayobjects.com/zos/antfincdn/G3sKp20YOE/zhongxinwenbencongyoudaowuzaidaoyou%2Cyangshibudiushi.gif)|
|![image](https://user-images.githubusercontent.com/15646325/105568380-ef291000-5d73-11eb-9390-232c3273dec2.png)|![image](https://user-images.githubusercontent.com/15646325/105568373-db7da980-5d73-11eb-8a31-57c5743f5239.png)|

