### PR TITLE
feat(scatter): 散点图支持多图例（color、shape、size）

### DIFF
--- a/__tests__/bugs/issue-2122-spec.ts
+++ b/__tests__/bugs/issue-2122-spec.ts
@@ -2,7 +2,7 @@ import { BidirectionalBar } from '../../src';
 import { createDiv } from '../utils/dom';
 
 describe('#2122', () => {
-  it('数据为空', async () => {
+  it('数据为空', () => {
     const plot = new BidirectionalBar(createDiv(), {
       data: [],
       width: 400,

--- a/__tests__/unit/plots/scatter/color-spec.ts
+++ b/__tests__/unit/plots/scatter/color-spec.ts
@@ -55,4 +55,66 @@ describe('scatter', () => {
 
     scatter.destroy();
   });
+
+  const scatter = new Scatter(createDiv(), {
+    width: 400,
+    height: 300,
+    appendPadding: 10,
+    data: [
+      { x: 10, y: 10, type: 'one', city: 'beijing' },
+      { x: 40, y: 10, type: 'two', city: 'beijing' },
+      { x: 50, y: 10, type: 'one', city: 'hangzhou' },
+      { x: 60, y: 10, type: 'two', city: 'hangzhou' },
+      { x: 40, y: 10, type: 'three', city: 'hangzhou' },
+    ],
+    xField: 'x',
+    yField: 'y',
+    colorField: 'type',
+    shapeField: 'city',
+    color: ['#e764ff', '#2b0033'],
+    shape: ['circle', 'square'],
+  });
+
+  scatter.render();
+
+  it('color mapping with shape mapping', () => {
+    const geometry = scatter.chart.geometries[0];
+    const elements = geometry.elements;
+
+    // @ts-ignore
+    expect(geometry.attributeOption.color.values.length).toBe(2);
+    expect(elements.length).toBe(5);
+    expect(elements[0].getModel().color).not.toBe('red');
+    expect(elements[0].getModel().color).toBe('#e764ff');
+    expect(elements[0].shape.attr('fill')).toBe('#e764ff');
+    expect(elements[0].getModel().shape).toBe('circle');
+    expect(elements[2].getModel().shape).toBe('square');
+  });
+
+  it('color mapping with shape mapping, colorAttr is callback', () => {
+    scatter.update({
+      color: ({ type }) => {
+        return type === 'three' ? 'red' : undefined;
+      },
+    });
+    const geometry = scatter.chart.geometries[0];
+    const elements = geometry.elements;
+
+    expect(elements.length).toBe(5);
+    expect(elements[4].shape.attr('fill')).toBe('red');
+    expect(elements[0].shape.attr('fill')).toBe(scatter.chart.getTheme().colors10[0]);
+    expect(elements[0].getModel().shape).toBe('circle');
+    expect(elements[2].getModel().shape).toBe('square');
+  });
+
+  it('color mapping with shape mapping, legends', () => {
+    const legendController = scatter.chart.getController('legend');
+    expect(legendController.getComponents().length).toBe(2);
+    expect(legendController.getComponents()[0].component.get('items').length).toBe(3);
+    expect(legendController.getComponents()[1].component.get('items').length).toBe(2);
+  });
+
+  afterAll(() => {
+    scatter.destroy();
+  });
 });

--- a/__tests__/unit/plots/scatter/legend-spec.ts
+++ b/__tests__/unit/plots/scatter/legend-spec.ts
@@ -197,4 +197,37 @@ describe('scatter', () => {
 
     scatter.destroy();
   });
+
+  it('sizeLegend: sizeLegend * sizeField * true', () => {
+    const scatter = new Scatter(createDiv(), {
+      width: 400,
+      height: 300,
+      appendPadding: 10,
+      data,
+      xField: 'weight',
+      yField: 'height',
+      shapeField: 'gender',
+      size: [2, 8],
+      sizeField: 'weight',
+      color: ['red', 'blue'],
+      colorField: 'gender',
+      xAxis: {
+        nice: true,
+      },
+      sizeLegend: {},
+    });
+
+    scatter.render();
+    const legendController = scatter.chart.getController('legend');
+    // @ts-ignore
+    const {
+      // @ts-ignore
+      option: { weight, height, gender },
+    } = legendController;
+    expect(weight).toBeTruthy();
+    expect(height).toBe(false);
+    expect(gender).toBeUndefined();
+
+    scatter.destroy();
+  });
 });

--- a/examples/scatter/scatter/demo/mapping-color-and-shape.ts
+++ b/examples/scatter/scatter/demo/mapping-color-and-shape.ts
@@ -1,0 +1,41 @@
+import { Scatter } from '@antv/g2plot';
+import { uniq } from '@antv/util';
+
+fetch('https://gw.alipayobjects.com/os/antfincdn/rc7SYiIq8Z/scatter-color-shape.json')
+  .then((data) => data.json())
+  .then((data) => {
+    const plot = new Scatter('container', {
+      appendPadding: 10,
+      data: [],
+    });
+
+    plot.update({
+      data,
+      xField: 'x',
+      yField: 'y',
+      colorField: 'city',
+      shapeField: 'area',
+      sizeField: 'value',
+      size: [4, 8],
+      color: ({ city }) => {
+        // 推荐业务自己传入主题色，不需要从 chart 中获取
+        const { colors10 } = plot.chart.getTheme();
+        // custom colorMapping function
+        const idx = data.map((d) => d.city).indexOf(city);
+        return colors10[idx + 1];
+      },
+      shape: ({ area }) => {
+        const shapes = ['circle', 'square', 'triangle', 'hexagon', 'diamond', 'bowtie'];
+        const idx = uniq(data.map((d) => d.area)).indexOf(area);
+        return shapes[idx] || 'circle';
+      },
+      yAxis: {
+        nice: true,
+        line: {
+          style: {
+            stroke: '#aaa',
+          },
+        },
+      },
+    });
+  });

--- a/examples/scatter/scatter/demo/meta.json
+++ b/examples/scatter/scatter/demo/meta.json
@@ -13,6 +13,14 @@
       "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/kRFIJ2OlFs/FE726B54-2352-47F5-AAF9-B17D281CE513.png"
     },
     {
+      "filename": "mapping-color-and-shape.ts",
+      "title": {
+        "zh": "散点图颜色和形状映射",
+        "en": "The color and shape mapping of scatter plot"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/xqD9bPVmaU/4ecbc1e7-ebf0-4777-ad7b-7190a4db51e9.png"
+    },
+    {
       "filename": "label.ts",
       "title": {
         "zh": "散点图图形标签",

--- a/src/plots/scatter/adaptor.ts
+++ b/src/plots/scatter/adaptor.ts
@@ -120,16 +120,14 @@ function axis(params: Params<ScatterOptions>): Params<ScatterOptions> {
  */
 function legend(params: Params<ScatterOptions>): Params<ScatterOptions> {
   const { chart, options } = params;
-  const { legend, colorField, shapeField, sizeField } = options;
-  // legend 没有指定时根据 shapeField 和 colorField 来设置默认值
+  const { legend, colorField, shapeField, shapeLegend, sizeField, sizeLegend } = options;
+
   const showLegend = isBoolean(legend) ? legend : legend || !!(shapeField || colorField);
+
   if (showLegend) {
     colorField && chart.legend(colorField, legend);
-    shapeField && chart.legend(shapeField, legend);
-    // 隐藏连续图例
-    if (sizeField) {
-      chart.legend(sizeField, false);
-    }
+    shapeField && chart.legend(shapeField, shapeLegend ? deepAssign({}, legend, shapeLegend) : legend);
+    sizeField && chart.legend(sizeField, sizeLegend ? deepAssign({}, legend, sizeLegend) : false);
   } else {
     chart.legend(false);
   }

--- a/src/plots/scatter/adaptor.ts
+++ b/src/plots/scatter/adaptor.ts
@@ -124,7 +124,8 @@ function legend(params: Params<ScatterOptions>): Params<ScatterOptions> {
   // legend 没有指定时根据 shapeField 和 colorField 来设置默认值
   const showLegend = isBoolean(legend) ? legend : legend || !!(shapeField || colorField);
   if (showLegend) {
-    chart.legend(colorField || shapeField, legend);
+    colorField && chart.legend(colorField, legend);
+    shapeField && chart.legend(shapeField, legend);
     // 隐藏连续图例
     if (sizeField) {
       chart.legend(sizeField, false);

--- a/src/plots/scatter/types.ts
+++ b/src/plots/scatter/types.ts
@@ -7,6 +7,7 @@ import {
   StyleAttr,
   ShapeAttr,
   SizeAttr,
+  Legend,
 } from '../../types';
 
 interface Labels extends Omit<TextOption, 'position'> {
@@ -48,10 +49,14 @@ export interface ScatterOptions extends Options {
   readonly sizeField?: string;
   /** 散点图大小 */
   readonly size?: SizeAttr;
+  /** 散点图大小 legend 配置, 如果没有，默认取通用 legend */
+  readonly sizeLegend?: Legend;
   /** 点形状映射对应的数据字段名 */
   readonly shapeField?: string;
   /** 散点图形状 */
   readonly shape?: ShapeAttr;
+  /** 散点图图例 legend 配置, 如果没有，默认取通用 legend */
+  readonly shapeLegend?: Legend;
   /** 散点图样式 */
   readonly pointStyle?: StyleAttr;
   /** 点颜色映射对应的数据字段名 */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './state';
 export * from './attr';
 export * from './statistic';
 export * from './meta';
+export * from './legend';


### PR DESCRIPTION
### PR includes

- [x] feat: 支持多图例
- [x] feat: 增加 shapeLegend、sizeLegend 作为形状图例与尺寸图例的单独配置项，会与 legend 合并
- [x] add test cases
- [x] demos: 增加散点图颜色和形状映射

### Screenshot

|  Before  |  After  |
|----|----|
|  ❌  |![image](https://user-images.githubusercontent.com/4312407/111744546-5ec80100-88c6-11eb-9344-11cb2c82d3e9.png)|
