### PR TITLE
[issue-2369] 矩形树图增加 path 字段 

### DIFF
--- a/__tests__/unit/plots/treemap/lable-spec.ts
+++ b/__tests__/unit/plots/treemap/lable-spec.ts
@@ -23,7 +23,7 @@ describe('treemap basic', () => {
         },
         fields: ['name', 'ext'],
         formatter: (v) => {
-          const ratio = v.value / v.parent.value;
+          const ratio = v.value / v.path[v.path.length - 1].value;
           return `${v.name}_${v.ext}_${ratio.toFixed(2)}`;
         },
       },

--- a/__tests__/unit/plots/treemap/lable-spec.ts
+++ b/__tests__/unit/plots/treemap/lable-spec.ts
@@ -23,7 +23,8 @@ describe('treemap basic', () => {
         },
         fields: ['name', 'ext'],
         formatter: (v) => {
-          return `${v.name}${v.ext}`;
+          const ratio = v.value / v.parent.value;
+          return `${v.name}_${v.ext}_${ratio.toFixed(2)}`;
         },
       },
     });
@@ -32,8 +33,13 @@ describe('treemap basic', () => {
     expect(treemapPlot.chart.geometries[0].labelOption.fields).toEqual(['name', 'ext']);
     // @ts-ignore
     expect(treemapPlot.chart.geometries[0].labelOption.cfg.position).toEqual('top');
+
+    // 验证比例是否正确，以及 label 是否正常渲染
+    const root = TREEMAP.children.reduce((sum, i) => sum + i.value, 0);
+    const ratio = (TREEMAP.children[1].value / root).toFixed(2);
+
     expect(treemapPlot.chart.geometries[0].labelsContainer.getChildren()[0].cfg.children[0].attrs.text).toBe(
-      '分类 2自定义数据'
+      `分类 2_自定义数据_${ratio}`
     );
 
     // label with custom

--- a/__tests__/unit/plots/treemap/tooltip-spec.ts
+++ b/__tests__/unit/plots/treemap/tooltip-spec.ts
@@ -35,11 +35,14 @@ describe('treemap tooltip', () => {
       tooltip: {
         showTitle: true,
         title: 'test',
-        fields: ['name', 'value', 'ext'],
-        formatter: (data) => ({
-          name: data.name,
-          value: `${data.value}/${data.ext || '-'}`,
-        }),
+        fields: ['name', 'value', 'ext', 'parent'],
+        formatter: (data) => {
+          const ratio = (data.value / data.parent.value).toFixed(2);
+          return {
+            name: data.name,
+            value: `${data.value}/${data.ext || '-'}/${ratio}`,
+          };
+        },
       },
     });
 
@@ -47,7 +50,7 @@ describe('treemap tooltip', () => {
 
     expect(customTooltipOption.showTitle).toBe(true);
     expect(customTooltipOption.title).toBe('test');
-    expect(customTooltipOption.fields).toEqual(['name', 'value', 'ext']);
+    expect(customTooltipOption.fields).toEqual(['name', 'value', 'ext', 'parent']);
 
     const testElement = treemapPlot.chart.geometries[0].elements.find((ele) => ele.data.name === '其他');
     const bbox = testElement.getBBox();
@@ -56,7 +59,9 @@ describe('treemap tooltip', () => {
       '其他'
     );
     expect(document.querySelectorAll('#treemap-tooltip .g2-tooltip-list-item .g2-tooltip-value')[0].innerHTML).toBe(
-      `${testElement.data.value}/${testElement.data.ext || '-'}`
+      `${testElement.data.value}/${testElement.data.ext || '-'}/${(
+        testElement.data.value / testElement.data.parent.value
+      ).toFixed(2)}`
     );
   });
 

--- a/__tests__/unit/plots/treemap/tooltip-spec.ts
+++ b/__tests__/unit/plots/treemap/tooltip-spec.ts
@@ -24,7 +24,7 @@ describe('treemap tooltip', () => {
     const tooltipOption = treemapPlot.chart.options.tooltip;
     expect(tooltipOption.showMarkers).toBe(false);
     expect(tooltipOption.showTitle).toBe(false);
-    expect(tooltipOption.fields).toEqual(['name', 'value', 'name']);
+    expect(tooltipOption.fields).toEqual(['name', 'value', 'name', 'path']);
     expect(tooltipOption.formatter(TREEMAP.children[0])).toEqual({ name: '分类 1', value: 500 });
   });
 

--- a/__tests__/unit/plots/treemap/tooltip-spec.ts
+++ b/__tests__/unit/plots/treemap/tooltip-spec.ts
@@ -35,9 +35,9 @@ describe('treemap tooltip', () => {
       tooltip: {
         showTitle: true,
         title: 'test',
-        fields: ['name', 'value', 'ext', 'parent'],
+        fields: ['name', 'value', 'ext', 'path'],
         formatter: (data) => {
-          const ratio = (data.value / data.parent.value).toFixed(2);
+          const ratio = (data.value / data.path[data.path.length - 1].value).toFixed(2);
           return {
             name: data.name,
             value: `${data.value}/${data.ext || '-'}/${ratio}`,
@@ -50,7 +50,7 @@ describe('treemap tooltip', () => {
 
     expect(customTooltipOption.showTitle).toBe(true);
     expect(customTooltipOption.title).toBe('test');
-    expect(customTooltipOption.fields).toEqual(['name', 'value', 'ext', 'parent']);
+    expect(customTooltipOption.fields).toEqual(['name', 'value', 'ext', 'path']);
 
     const testElement = treemapPlot.chart.geometries[0].elements.find((ele) => ele.data.name === '其他');
     const bbox = testElement.getBBox();
@@ -60,7 +60,7 @@ describe('treemap tooltip', () => {
     );
     expect(document.querySelectorAll('#treemap-tooltip .g2-tooltip-list-item .g2-tooltip-value')[0].innerHTML).toBe(
       `${testElement.data.value}/${testElement.data.ext || '-'}/${(
-        testElement.data.value / testElement.data.parent.value
+        testElement.data.value / testElement.data.path[testElement.data.path.length - 1].value
       ).toFixed(2)}`
     );
   });

--- a/__tests__/unit/plots/treemap/utils-spec.ts
+++ b/__tests__/unit/plots/treemap/utils-spec.ts
@@ -60,7 +60,7 @@ const data2 = {
 
 // 叶节点有分类，父节点有分类
 // 叶节点没有，父节点有
-// 叶节点有，父节点没有，
+// 叶节点有，父节点没有
 // 叶节点没有，父节点没有
 
 const data3 = {
@@ -193,6 +193,12 @@ describe('treemap transformData', () => {
     expect(areaArr[2] / areaArr[1]).toEqual(data1.children[2].value / data1.children[1].value);
 
     expect(data[0].ext).toBe('自定义数据');
+
+    const root = data1.children.reduce((sum, i) => sum + i.value, 0);
+
+    expect(data[0].path.length).toBe(2);
+    expect(data[0].path[0].value).toBe(data1.children[0].value);
+    expect(data[0].path[1].value).toBe(root);
   });
 
   it('transformData, nest treemap', () => {
@@ -223,6 +229,9 @@ describe('treemap transformData', () => {
     );
 
     expect(data[2].ext).toBe('自定义数据');
+    expect(data[0].path.length).toBe(3);
+    expect(data[0].path[1].data.children.length).toBe(2);
+    expect(data[0].path[1].value).toBe(150);
   });
 
   it('transformData, nest treemap, colorField', () => {
@@ -258,13 +267,25 @@ describe('treemap transformData', () => {
   });
 
   it('transformData, nest treemap, enableDrillDown', () => {
-    const data = transformData({
-      data: data3,
+    const config = {
       colorField: 'category',
       enableDrillDown: true,
       hierarchyConfig: {},
+    };
+
+    const data = transformData({
+      data: data3,
+      ...config,
     });
+
     expect(data.length).toEqual(2);
+
+    const childData = transformData({
+      data: data[0],
+      ...config,
+    });
+
+    expect(childData[0].path.length).toBe(3);
   });
 
   it('getFommatInteractions', () => {

--- a/docs/api/plots/dual-axes.en.md
+++ b/docs/api/plots/dual-axes.en.md
@@ -61,7 +61,7 @@ Example:
 Specifies the respective configuration of the two axes in the form of "left axis configuration, right axis configuration". Each configuration should be a Config of type LINE or COLUMN. Mixed chart function is implemented by specifying the corresponding graph with two axes:
 
 - Biaxial line chart: [Line, Line], reference [DEMO](../../../examples/dual-axes/dual-line)
-- Column and Line Mixing Chart: [Column, Line], reference [DEMO](../../..//examples/dual-axes/column-line)
+- Column and Line Mixing Chart: [Column, Line], reference [DEMO](../../../examples/dual-axes/column-line)
 
 你还可以通过配置 Line 或 Column 的相关配置（见下文），形成双轴多 Line([DEMO](../../../examples/dual-axes/dual-line#dual-multi-line)), 堆叠柱+Line([DEMO](../../../examples/dual-axes/stacked-column-line)), 分组柱+Line([DEMO](../../../examples/dual-axes/grouped-column-line))
 

--- a/docs/api/plots/dual-axes.en.md
+++ b/docs/api/plots/dual-axes.en.md
@@ -61,7 +61,7 @@ Example:
 Specifies the respective configuration of the two axes in the form of "left axis configuration, right axis configuration". Each configuration should be a Config of type LINE or COLUMN. Mixed chart function is implemented by specifying the corresponding graph with two axes:
 
 - Biaxial line chart: [Line, Line], reference [DEMO](../../../examples/dual-axes/dual-line)
-- Column and Line Mixing Chart: [Column, Line], reference [DEMO](http://localhost:8080/zh/examples/dual-axes/column-line)
+- Column and Line Mixing Chart: [Column, Line], reference [DEMO](../../..//examples/dual-axes/column-line)
 
 你还可以通过配置 Line 或 Column 的相关配置（见下文），形成双轴多 Line([DEMO](../../../examples/dual-axes/dual-line#dual-multi-line)), 堆叠柱+Line([DEMO](../../../examples/dual-axes/stacked-column-line)), 分组柱+Line([DEMO](../../../examples/dual-axes/grouped-column-line))
 

--- a/docs/api/plots/dual-axes.zh.md
+++ b/docs/api/plots/dual-axes.zh.md
@@ -60,7 +60,7 @@ const data = [[{ time: '1991'，value: 20 }], [{ time: '1992', count: 20 }]];
 指定了双轴各自对应的图形配置，形式为[左轴图形配置，右轴图形配置]。每一个配置应为 Line 或 Column 类型的 Config。通过指定双轴对应图形，来实现混合图表功能:
 
 - 双轴折线图: [Line, Line], 参考 [DEMO](../../../examples/dual-axes/dual-line)
-- 柱线混合图: [Column, Line], 参考 [DEMO](http://localhost:8080/zh/examples/dual-axes/column-line)
+- 柱线混合图: [Column, Line], 参考 [DEMO](../../../examples/dual-axes/column-line)
 
 你还可以通过配置 Line 或 Column 的相关配置（见下文），形成双轴多折线图([DEMO](../../../examples/dual-axes/dual-line#dual-multi-line)), 堆叠柱+折线图([DEMO](../../../examples/dual-axes/stacked-column-line)), 分组柱+折线图([DEMO](../../../examples/dual-axes/grouped-column-line))
 

--- a/docs/api/plots/treemap.en.md
+++ b/docs/api/plots/treemap.en.md
@@ -37,7 +37,7 @@ G2 plot generates the following data structure based on data:
 
 - name
 - value
-- path: Level information of the current node (including the current node)
+- path: Level information of the current node (including the current node)，The level information is from data (node metadata), value (node value), height (node height)
 - children: Leaf node information of the current node (only if it exists)
 
 Among them, you can get the path parameter in the formatter function of label (tooltip), so as to calculate the proportion, [DEMO](../../../examples/more-plots/treemap#treemap-nest)

--- a/docs/api/plots/treemap.en.md
+++ b/docs/api/plots/treemap.en.md
@@ -33,6 +33,15 @@ Each level of data needs to have three attributes
 
 In the nested rectangular tree diagram, the layout is determined by the value value of the leaf node.
 
+G2 plot generates the following data structure based on data:
+
+- name
+- value
+- path: Level information of the current node (including the current node)
+- children: Leaf node information of the current node (only if it exists)
+
+Among them, you can get the path parameter in the formatter function of label (tooltip), so as to calculate the proportion, [DEMO](../../../examples/more-plots/treemap#treemap-nest)
+
 #### colorField
 
 <description>**optional** _string_</description>

--- a/docs/api/plots/treemap.zh.md
+++ b/docs/api/plots/treemap.zh.md
@@ -33,6 +33,16 @@ const data = {
 - children (非叶子节点)
 
 嵌套矩形树图中，布局由叶子节点的 value 值决定。
+
+G2 plot 会根据 data 生成以下数据结构，绘制矩形树图，并作为 label，tooltip 的入参供用户使用。
+
+- name
+- value
+- path: 当前节点的层级信息(包含当前节点)
+- childre: 当前节点的叶节点信息（仅存在时给出）
+
+其中，你可以在 label（tooltip）的 formatter 函数中获取 path 参数，从而计算占比
+
 #### colorField
 
 <description>**optional** _string_</description>

--- a/docs/api/plots/treemap.zh.md
+++ b/docs/api/plots/treemap.zh.md
@@ -34,14 +34,14 @@ const data = {
 
 嵌套矩形树图中，布局由叶子节点的 value 值决定。
 
-G2 plot 会根据 data 生成以下数据结构，绘制矩形树图，并作为 label，tooltip 的入参供用户使用。
+G2 plot 会根据 data 生成以下数据结构：
 
 - name
 - value
 - path: 当前节点的层级信息(包含当前节点)
-- childre: 当前节点的叶节点信息（仅存在时给出）
+- children: 当前节点的叶节点信息（仅存在时给出）
 
-其中，你可以在 label（tooltip）的 formatter 函数中获取 path 参数，从而计算占比
+其中，你可以在 label（tooltip）的 formatter 函数中获取 path 参数，从而计算占比, 可参见[DEMO](../../../examples/more-plots/treemap#treemap-nest)
 
 #### colorField
 

--- a/docs/api/plots/treemap.zh.md
+++ b/docs/api/plots/treemap.zh.md
@@ -38,7 +38,7 @@ G2 plot 会根据 data 生成以下数据结构：
 
 - name
 - value
-- path: 当前节点的层级信息(包含当前节点)
+- path: 当前节点的层级信息(包含当前节点)，层级信息由 data（节点元数据），value（节点 value），height（节点高度）
 - children: 当前节点的叶节点信息（仅存在时给出）
 
 其中，你可以在 label（tooltip）的 formatter 函数中获取 path 参数，从而计算占比, 可参见[DEMO](../../../examples/more-plots/treemap#treemap-nest)

--- a/examples/more-plots/treemap/demo/drill-down.ts
+++ b/examples/more-plots/treemap/demo/drill-down.ts
@@ -28,6 +28,15 @@ fetch('https://gw.alipayobjects.com/os/basement_prod/c2589761-62d6-411d-9d51-794
           type: 'treemap-drill-down',
         },
       ],
+      tooltip: {
+        formatter: (v) => {
+          const root = v.path[v.path.length - 1];
+          return {
+            name: v.name,
+            value: `${v.value}(总占比${((v.value / root.value) * 100).toFixed(2)}%)`,
+          };
+        },
+      },
     });
     treemapPlot.render();
   });

--- a/examples/more-plots/treemap/demo/treemap-nest.ts
+++ b/examples/more-plots/treemap/demo/treemap-nest.ts
@@ -1,4 +1,27 @@
 import { Treemap } from '@antv/g2plot';
+import { insertCss } from 'insert-css';
+
+// 我们用 insert-css 演示引入自定义样式
+// 推荐将样式添加到自己的样式文件中
+// 若拷贝官方代码，别忘了 npm install insert-css
+insertCss(`
+  .container{
+    padding: 16px 0px;
+    width: 160px;
+    display: flex;
+    flex-direction: column;
+  }
+  .title{
+    font-weight: bold;
+  }
+  .tooltip-item{
+    margin-top: 12px;
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+`);
 
 fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/mobile.json')
   .then((res) => res.json())
@@ -19,6 +42,30 @@ fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/mobile.json')
           type: 'drag-move',
         },
       ],
+      tooltip: {
+        follow: true,
+        enterable: true,
+        offset: 5,
+        customContent: (value, items) => {
+          if (!items || items.length <= 0) return;
+          const { data: itemData } = items[0];
+          const parent = itemData.path[1];
+          const root = itemData.path[itemData.path.length - 1];
+          return (
+            `<div class='container'>` +
+            `<div class='title'>${itemData.name}</div>` +
+            `<div class='tooltip-item'><span>销量</span><span>${itemData.value}</span></div>` +
+            `<div class='tooltip-item'><span>品牌</span><span>${itemData.brand}</span></div>` +
+            `<div class='tooltip-item'><span>品牌占比</span><span>${((itemData.value / parent.value) * 100).toFixed(
+              2
+            )}%</span></div>` +
+            `<div class='tooltip-item'><span>市场占比</span><span>${((itemData.value / root.value) * 100).toFixed(
+              2
+            )}%</span></div>` +
+            `</div>`
+          );
+        },
+      },
     });
     treemapPlot.render();
   });

--- a/src/plots/treemap/adaptor.ts
+++ b/src/plots/treemap/adaptor.ts
@@ -40,7 +40,7 @@ function defaultOptions(params: Params<TreemapOptions>): Params<TreemapOptions> 
         tooltip: {
           showMarkers: false,
           showTitle: false,
-          fields: ['name', 'value', colorField],
+          fields: ['name', 'value', colorField, 'path'],
           formatter: (data) => {
             return {
               name: data.name,

--- a/src/plots/treemap/utils.ts
+++ b/src/plots/treemap/utils.ts
@@ -1,4 +1,4 @@
-import { isArray, get } from '@antv/util';
+import { isArray } from '@antv/util';
 import { Types, View } from '@antv/g2';
 import { normalPadding } from '../../utils/padding';
 import { Interaction } from '../../types/interaction';

--- a/src/plots/treemap/utils.ts
+++ b/src/plots/treemap/utils.ts
@@ -1,4 +1,4 @@
-import { isArray } from '@antv/util';
+import { isArray, get } from '@antv/util';
 import { Types, View } from '@antv/g2';
 import { normalPadding } from '../../utils/padding';
 import { Interaction } from '../../types/interaction';
@@ -84,12 +84,21 @@ export function transformData(options: TransformDataOptions) {
       return null;
     }
 
+    // path 信息仅挑选必要祖先元素属性，因为在有些属性是不必要(x, y), 或是不准确的(下钻时的 depth)，不对外透出
+    const curPath = node.ancestors().map((n) => ({
+      data: n.data,
+      height: n.height,
+      value: n.value,
+    }));
+    // 在下钻树图中，每次绘制的是当前层级信息，将父元素的层级信息（data.path) 做一层拼接。
+    const path = enableDrillDown && isArray(data.path) ? curPath.concat(data.path.slice(1)) : curPath;
+
     const eachNode = Object.assign({}, node.data, {
       x: node.x,
       y: node.y,
       depth: node.depth,
       value: node.value,
-      parent: node.parent,
+      path,
     });
     if (!node.data[colorField] && node.parent) {
       const ancestorNode = node.ancestors().find((n) => n.data[colorField]);

--- a/src/plots/treemap/utils.ts
+++ b/src/plots/treemap/utils.ts
@@ -89,6 +89,7 @@ export function transformData(options: TransformDataOptions) {
       y: node.y,
       depth: node.depth,
       value: node.value,
+      parent: node.parent,
     });
     if (!node.data[colorField] && node.parent) {
       const ancestorNode = node.ancestors().find((n) => n.data[colorField]);


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #2369 
- [x] add / modify test cases
- [x] documents, demos

该 issue 需求是为矩形树图增加占比字段，但作为层级数据中。直接暴露占比很难定义，以及满足所有需求，因此暴露出 path 字段，储存当前节点的层级信息，方便用户根据需求快速计算占比

### Screenshot

|  Before  |  After  |
|----|----|
|  ❌  |  <img width="578" alt="屏幕快照 2021-03-23 17 05 50" src="https://user-images.githubusercontent.com/11748654/112147206-6285bb80-8c17-11eb-895e-da4edae82a70.png"> |
