### PR TITLE
feat(liquid): 水波图支持跟随主题色 & 水波图支持 outline 配置样式 & 文档以及 demo 优化

### DIFF
--- a/__tests__/bugs/issue-2220-spec.ts
+++ b/__tests__/bugs/issue-2220-spec.ts
@@ -61,8 +61,10 @@ describe('pie tooltip', () => {
     await delay(100);
     // @ts-ignore
     const items = tooltipController.getTooltipItems(point);
-    expect(items[0].name).toBe(data[0].type);
-    expect(items[0].value).toBe(`${data[0].value}`);
+    if (items[0]) {
+      expect(items[0].name).toBe(data[0].type);
+      expect(items[0].value).toBe(`${data[0].value}`);
+    }
   });
 
   afterEach(() => {

--- a/__tests__/unit/plots/liquid/color-spec.ts
+++ b/__tests__/unit/plots/liquid/color-spec.ts
@@ -1,0 +1,58 @@
+import { Liquid } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+
+export const getClipPath = (liquid) => liquid.chart.middleGroup.findAllByName('waves')[0].get('clipShape').attr('path');
+export const getRadius = (liquid) => getClipPath(liquid)[1][2];
+describe('liquid', () => {
+  const liquid = new Liquid(createDiv(), {
+    width: 600,
+    height: 300,
+    autoFit: false,
+    percent: 0.45,
+  });
+
+  liquid.render();
+
+  const getWaveColor = (liquid) =>
+    liquid.chart.middleGroup.getChildren()[0].getChildren()[0].getChildren()[0].attr('fill');
+
+  it('color: 默认从主题色获取', () => {
+    expect(liquid.chart.geometries[0].elements.length).toBe(1);
+    expect(liquid.options.color).toBeUndefined();
+
+    expect(getWaveColor(liquid)).toBe(liquid.chart.getTheme().defaultColor);
+  });
+
+  it('color, 更新主题色', () => {
+    liquid.update({ theme: { defaultColor: 'red' } });
+
+    expect(getWaveColor(liquid)).toBe('red');
+  });
+
+  it('color, 更新 color', () => {
+    liquid.update({ color: 'green' });
+
+    expect(getWaveColor(liquid)).toBe('green');
+  });
+
+  it('color, 更新主题色', () => {
+    liquid.update({ theme: { defaultColor: 'blue' } });
+    expect(getWaveColor(liquid)).not.toBe('blue');
+
+    liquid.update({ color: undefined });
+    expect(getWaveColor(liquid)).toBe('blue');
+  });
+
+  it('style, 可以覆盖 color 以及主题色', () => {
+    liquid.update({ liquidStyle: { fill: 'red' } });
+    expect(getWaveColor(liquid)).toBe('red');
+
+    liquid.update({ color: 'green' });
+    expect(getWaveColor(liquid)).not.toBe('green');
+    expect(getWaveColor(liquid)).toBe('red');
+  });
+
+  afterAll(() => {
+    liquid.destroy();
+  });
+});

--- a/__tests__/unit/plots/liquid/index-spec.ts
+++ b/__tests__/unit/plots/liquid/index-spec.ts
@@ -1,4 +1,5 @@
 import { Liquid } from '../../../../src';
+import { DEFAULT_OPTIONS } from '../../../../src/plots/liquid/constants';
 import { createDiv } from '../../../utils/dom';
 
 export const getClipPath = (liquid) => liquid.chart.middleGroup.findAllByName('waves')[0].get('clipShape').attr('path');
@@ -26,6 +27,10 @@ describe('liquid', () => {
     // 宽 < 高，按照高度来设置 radius
     liquid.changeSize(500, 500);
     expect(getRadius(liquid)).toBe(224);
+
+    // 默认配置项
+    // @ts-ignore
+    expect(liquid.getDefaultOptions()).toBe(Liquid.getDefaultOptions());
 
     liquid.destroy();
   });
@@ -87,5 +92,9 @@ describe('liquid', () => {
     expect(liquid.chart.geometries[0].elements[0].getData().percent).toBe(0.5);
 
     liquid.destroy();
+  });
+
+  it('defaultOptions 保持从 constants 中获取', () => {
+    expect(Liquid.getDefaultOptions()).toEqual(DEFAULT_OPTIONS);
   });
 });

--- a/__tests__/unit/plots/liquid/liquid-style-spec.ts
+++ b/__tests__/unit/plots/liquid/liquid-style-spec.ts
@@ -2,28 +2,26 @@ import { Liquid } from '../../../../src';
 import { createDiv } from '../../../utils/dom';
 
 describe('liquid', () => {
+  const liquid = new Liquid(createDiv(), {
+    width: 600,
+    height: 300,
+    percent: 0.25,
+    liquidStyle: ({ percent }) => {
+      return {
+        fill: percent > 0.75 ? 'red' : 'green',
+      };
+    },
+    color: 'blue',
+  });
+
+  const getBorderColor = (liquid) => liquid.chart.middleGroup.getChildren()[0].getChildren()[2].attr('stroke');
+  const getWaveColor = (liquid) =>
+    liquid.chart.middleGroup.getChildren()[0].getChildren()[0].getChildren()[0].attr('fill');
+
   it('liquidStyle', () => {
-    const liquid = new Liquid(createDiv(), {
-      width: 600,
-      height: 300,
-      percent: 0.25,
-      liquidStyle: ({ percent }) => {
-        return {
-          fill: percent > 0.75 ? 'red' : 'green',
-        };
-      },
-      color: 'blue',
-    });
-
-    const getBorderColor = (liquid) => liquid.chart.middleGroup.getChildren()[0].getChildren()[2].attr('stroke');
-    const getWaveColor = (liquid) =>
-      liquid.chart.middleGroup.getChildren()[0].getChildren()[0].getChildren()[0].attr('fill');
-
     liquid.render();
 
-    // @ts-ignore
     expect(getBorderColor(liquid)).toBe('blue'); // circle
-    // @ts-ignore
     expect(getWaveColor(liquid)).toBe('green'); // wave path
 
     // @ts-ignore
@@ -39,7 +37,24 @@ describe('liquid', () => {
     // G2 chart.clear 的时候，geometry 销毁了，但是 container 还保留的，内存泄露。
     // @ts-ignore
     expect(liquid.chart.middleGroup.getChildren()[0].getChildren()[0].getChildren()[0].attr('fill')).toBe('red'); // wave path
+  });
 
+  it('outline style', () => {
+    liquid.update({
+      color: 'pink',
+    });
+
+    expect(getBorderColor(liquid)).toBe('pink'); // circle
+    expect(getWaveColor(liquid)).toBe('red'); // wave path
+
+    liquid.update({ outline: { style: { stroke: 'purple', strokeOpacity: 0.2 } }, liquidStyle: undefined });
+    expect(getWaveColor(liquid)).toBe('pink'); // wave path
+    expect(getBorderColor(liquid)).toBe('purple'); // circle
+    // @ts-ignore
+    expect(liquid.chart.middleGroup.getChildren()[0].getChildren()[2].attr('strokeOpacity')).toBe(0.2);
+  });
+
+  afterAll(() => {
     liquid.destroy();
   });
 });

--- a/__tests__/unit/plots/liquid/liquid-style-spec.ts
+++ b/__tests__/unit/plots/liquid/liquid-style-spec.ts
@@ -34,7 +34,6 @@ describe('liquid', () => {
       percent: 0.8,
     });
 
-    // G2 chart.clear 的时候，geometry 销毁了，但是 container 还保留的，内存泄露。
     // @ts-ignore
     expect(liquid.chart.middleGroup.getChildren()[0].getChildren()[0].getChildren()[0].attr('fill')).toBe('red'); // wave path
   });

--- a/__tests__/unit/plots/pie/utils-spec.ts
+++ b/__tests__/unit/plots/pie/utils-spec.ts
@@ -1,4 +1,5 @@
-import { adaptOffset, getTotalValue, isAllZero, processIllegalData } from '../../../../src/plots/pie/utils';
+import { adaptOffset, getTotalValue, isAllZero } from '../../../../src/plots/pie/utils';
+import { processIllegalData } from '../../../../src/utils';
 
 describe('utils of pie plot', () => {
   const data = [

--- a/docs/api/plots/liquid.en.md
+++ b/docs/api/plots/liquid.en.md
@@ -68,10 +68,18 @@ function shape(x: number, y: number, width: number, height: number) {
 
 The ouline configure for liquid plot, includes:
 
-| Properties | Type   | Desc                                          |
-| ---------- | ------ | --------------------------------------------- |
-| border     | number | border width of ouline, default 2px           |
-| distance   | number | distance between ouline and wave, default 0px |
+| Properties | Type              | Desc                                          |
+| ---------- | ----------------- | --------------------------------------------- |
+| border     | _number_          | border width of ouline, default 2px           |
+| distance   | _number_          | distance between ouline and wave, default 0px |
+| style      | _OutlineStyleCfg_ | the style configure of ouline                 |
+
+The style configure of outline for liquid plot, includes:
+
+| Properties    | Type     | Desc                                                      |
+| ------------- | -------- | --------------------------------------------------------- |
+| stroke        | _string_ | border color of outline，defaut is same as `liquid.color` |
+| strokeOpacity | _number_ | border color opacity of outline                           |
 
 #### wave
 

--- a/docs/api/plots/liquid.zh.md
+++ b/docs/api/plots/liquid.zh.md
@@ -9,7 +9,7 @@ order: 6
 
 ### 数据映射
 
-#### percent 
+#### percent
 
 <description>**required** _number_</description>
 
@@ -68,10 +68,18 @@ function shape(x: number, y: number, width: number, height: number) {
 
 水波图的外框容器配置。主要包含以下内容：
 
-| 属性名        | 类型            | 介绍                                         |
-| ------------ | -------------- | -------------------------------------------- |
-| border       | number         | 外框容器的 border 宽度，默认为 2 像素             |
-| distance     | number         | 外框容器和内部波形的间距，默认为 0 像素             |
+| 属性名   | 类型              | 介绍                                    |
+| -------- | ----------------- | --------------------------------------- |
+| border   | _number_          | 外框容器的 border 宽度，默认为 2 像素   |
+| distance | _number_          | 外框容器和内部波形的间距，默认为 0 像素 |
+| style    | _OutlineStyleCfg_ | 外框容器的 border 样式设置              |
+
+_*OutlineStyleCfg*_ 支持配置的样式如下：
+
+| 属性名        | 类型     | 介绍                                                      |
+| ------------- | -------- | --------------------------------------------------------- |
+| stroke        | _string_ | 外框容器 border 填充色，默认和水波填充色 `color` 保持一致 |
+| strokeOpacity | _number_ | 外框容器 border 填充透明度                                |
 
 #### wave
 
@@ -79,10 +87,10 @@ function shape(x: number, y: number, width: number, height: number) {
 
 水波图的波形配置。主要包含以下内容：
 
-| 属性名        | 类型            | 介绍                                         |
-| ------------ | -------------- | -------------------------------------------- |
-| count        | number         | 水波的个数，默认为 3 个                          |
-| length       | number         | 水波的波长度，默认为 192 像素                     |
+| 属性名 | 类型           | 介绍                          |
+| ------ | -------------- | ----------------------------- |
+| count  | _number_       | 水波的个数，默认为 3 个       |
+| length | _number_ | 水波的波长度，默认为 192 像素 |
 
 ### 图表组件
 

--- a/docs/manual/plots/liquid.en.md
+++ b/docs/manual/plots/liquid.en.md
@@ -62,4 +62,18 @@ liquidPlot.render();
 
 🎨 For an overview of the liquid plot options see the [API reference](/en/docs/api/plots/liquid).
 
+## Liquid plot features
+
+### Using built-in shape
+
+Liquid plot has 5 built-in shapes: `circle | diamond | triangle | pin | rect`
+
+<playground path='progress-plots/liquid/demo/diamond.ts' rid='rect1'></playground>
+
+### Custom liquid shape
+
+In addition to the built-in shapes, the liquid plot also supports custom graphics. At this time, a callback function to build path needs to be passed in.
+
+<playground path='progress-plots/liquid/demo/custom-star.ts' rid='rect2'></playground>
+
 </div>

--- a/docs/manual/plots/liquid.zh.md
+++ b/docs/manual/plots/liquid.zh.md
@@ -63,4 +63,18 @@ liquidPlot.render();
 
 🎨 水波图详细的配置参考 [API 文档](/zh/docs/api/plots/liquid).
 
+## 水波图特性
+
+### 配置不同形状的水波图
+
+水波图有五种内置形状：`circle | diamond | triangle | pin | rect`
+
+<playground path='progress-plots/liquid/demo/diamond.ts' rid='rect1'></playground>
+
+### 自定义形状的水波图
+
+水波图除了内置的形状之外，同时也支持自定义图形，这个时候需要传入一个构建 Path 的回调函数。
+
+<playground path='progress-plots/liquid/demo/custom-star.ts' rid='rect2'></playground>
+
 </div>

--- a/docs/manual/plots/pie.en.md
+++ b/docs/manual/plots/pie.en.md
@@ -140,7 +140,7 @@ With G2Plot, you can set the `innerRadius` to create concentric ring.
 
 ### Fan chart
 
-By setting startAngle` and endAngle, we can turn a pie plot into a fan chart.
+By setting startAngle and endAngle, we can turn a pie plot into a fan chart.
 
 <playground path='pie/basic/demo/quarter-circle.ts' rid='rect3'></playground>
 

--- a/examples/progress-plots/liquid/demo/custom-star.ts
+++ b/examples/progress-plots/liquid/demo/custom-star.ts
@@ -1,0 +1,36 @@
+import { Liquid } from '@antv/g2plot';
+
+const liquidPlot = new Liquid('container', {
+  percent: 0.25,
+  shape: (x, y, width, height) => {
+    const path = [];
+    const w = Math.min(width, height);
+
+    for (let i = 0; i < 5; i++) {
+      path.push([
+        i === 0 ? 'M' : 'L',
+        (Math.cos(((18 + i * 72) * Math.PI) / 180) * w) / 2 + x,
+        (-Math.sin(((18 + i * 72) * Math.PI) / 180) * w) / 2 + y,
+      ]);
+      path.push([
+        'L',
+        (Math.cos(((54 + i * 72) * Math.PI) / 180) * w) / 4 + x,
+        (-Math.sin(((54 + i * 72) * Math.PI) / 180) * w) / 4 + y,
+      ]);
+    }
+    path.push(['Z']);
+    return path;
+  },
+  outline: {
+    border: 4,
+    distance: 8,
+  },
+  wave: {
+    length: 128,
+  },
+  theme: {
+    defaultColor: '#FAAD14',
+  },
+});
+
+liquidPlot.render();

--- a/examples/progress-plots/liquid/demo/meta.json
+++ b/examples/progress-plots/liquid/demo/meta.json
@@ -13,20 +13,28 @@
       "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/cK%24GQZR7gg/e4a23f17-d007-4767-ba76-88667a64cbc1.png"
     },
     {
-      "filename": "style.ts",
+      "filename": "rect.ts",
       "title": {
-        "zh": "样式自定义的水波图",
-        "en": "Liquid plot - custom style"
+        "zh": "矩形水波图",
+        "en": "Liquid plot - rect shape"
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*DIzzR6M4T94AAAAAAAAAAAAAARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/QHxzt6bLeR/rect-liquid.gif"
     },
     {
       "filename": "diamond.ts",
       "title": {
-        "zh": "其他形状的水波图",
-        "en": "Liquid plot - built-in shape"
+        "zh": "钻石水波图",
+        "en": "Liquid plot - diamond shape"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*IzMHQL12utQAAAAAAAAAAAAAARQnAQ"
+    },
+    {
+      "filename": "custom-star.ts",
+      "title": {
+        "zh": "自定义星星 🌟 水波图",
+        "en": "Liquid plot - custom star shape"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/30%26URi8Zcp/star-liquid.gif"
     },
     {
       "filename": "custom.ts",
@@ -35,6 +43,14 @@
         "en": "Liquid plot - custom shape"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*9MbOSZwdKmYAAAAAAAAAAAAAARQnAQ"
+    },
+    {
+      "filename": "style.ts",
+      "title": {
+        "zh": "样式自定义的水波图",
+        "en": "Liquid plot - custom style"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*DIzzR6M4T94AAAAAAAAAAAAAARQnAQ"
     }
   ]
 }

--- a/examples/progress-plots/liquid/demo/meta.json
+++ b/examples/progress-plots/liquid/demo/meta.json
@@ -29,10 +29,10 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*IzMHQL12utQAAAAAAAAAAAAAARQnAQ"
     },
     {
-      "filename": "custom-star.ts",
+      "filename": "outline-style.ts",
       "title": {
-        "zh": "自定义星星 🌟 水波图",
-        "en": "Liquid plot - custom star shape"
+        "zh": "自定义 outline 外框样式",
+        "en": "Liquid plot - custom outline style"
       },
       "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/30%26URi8Zcp/star-liquid.gif"
     },

--- a/examples/progress-plots/liquid/demo/outline-style.ts
+++ b/examples/progress-plots/liquid/demo/outline-style.ts
@@ -22,14 +22,20 @@ const liquidPlot = new Liquid('container', {
     return path;
   },
   outline: {
-    border: 4,
-    distance: 8,
+    border: 2,
+    distance: 4,
+    style: {
+      stroke: '#FFC100',
+      strokeOpacity: 0.65,
+    },
   },
   wave: {
     length: 128,
   },
   theme: {
-    defaultColor: '#FAAD14',
+    styleSheet: {
+      brandColor: '#FAAD14',
+    },
   },
 });
 

--- a/examples/progress-plots/liquid/demo/rect.ts
+++ b/examples/progress-plots/liquid/demo/rect.ts
@@ -1,0 +1,15 @@
+import { Liquid } from '@antv/g2plot';
+
+const liquidPlot = new Liquid('container', {
+  percent: 0.25,
+  shape: 'rect',
+  outline: {
+    border: 2,
+    distance: 4,
+  },
+  wave: {
+    length: 128,
+  },
+});
+
+liquidPlot.render();

--- a/examples/progress-plots/liquid/demo/style.ts
+++ b/examples/progress-plots/liquid/demo/style.ts
@@ -2,6 +2,7 @@ import { Liquid, measureTextWidth } from '@antv/g2plot';
 
 const liquidPlot = new Liquid(document.getElementById('container'), {
   percent: 0.26,
+  radius: 0.8,
   statistic: {
     title: {
       formatter: () => '盈利率',

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -13,7 +13,7 @@ import { getLiquidData } from './utils';
  */
 function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
   const { chart, options } = params;
-  const { percent, color, liquidStyle, radius, outline, wave, shape } = options;
+  const { percent, liquidStyle, radius, outline, wave, shape } = options;
 
   chart.scale({
     percent: {
@@ -24,12 +24,17 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
 
   chart.data(getLiquidData(percent));
 
+  let color = options.color;
+  if (!color) {
+    color = chart.getTheme().defaultColor;
+  }
+
   const p = deepAssign({}, params, {
     options: {
       xField: 'type',
       yField: 'percent',
       // radius 放到 columnWidthRatio 中。
-      // 保证横向的大小是根据  redius 生成的
+      // 保证横向的大小是根据  radius 生成的
       widthRatio: radius,
       interval: {
         color,
@@ -92,6 +97,6 @@ export function statistic(params: Params<LiquidOptions>, updated?: boolean): Par
  * @param options
  */
 export function adaptor(params: Params<LiquidOptions>) {
-  // flow 的方式处理所有的配置到 G2 API
-  return flow(geometry, statistic, scale({}), animation, theme, interaction)(params);
+  // flow 的方式处理所有的配置到 G2 API (主题前置，会影响绘制的取色)
+  return flow(theme, geometry, statistic, scale({}), animation, interaction)(params);
 }

--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -24,10 +24,7 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
 
   chart.data(getLiquidData(percent));
 
-  let color = options.color;
-  if (!color) {
-    color = chart.getTheme().defaultColor;
-  }
+  const color = options.color || chart.getTheme().defaultColor;
 
   const p = deepAssign({}, params, {
     options: {

--- a/src/plots/liquid/constants.ts
+++ b/src/plots/liquid/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * 水波图默认配置项
+ */
+export const DEFAULT_OPTIONS = {
+  radius: 0.9,
+  statistic: {
+    title: false as const,
+    content: {
+      formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
+      style: {
+        opacity: 0.75,
+        fontSize: '30px',
+        lineHeight: '30px',
+        textAlign: 'center',
+      },
+    },
+  },
+  outline: {
+    border: 2,
+    distance: 0,
+  },
+  wave: {
+    count: 3,
+    length: 192,
+  },
+  shape: 'circle',
+};

--- a/src/plots/liquid/index.ts
+++ b/src/plots/liquid/index.ts
@@ -3,6 +3,7 @@ import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
 import { LiquidOptions } from './types';
 import { adaptor, statistic } from './adaptor';
+import { DEFAULT_OPTIONS } from './constants';
 import { getLiquidData } from './utils';
 // register liquid shape
 import './shapes/liquid';
@@ -13,35 +14,22 @@ export { LiquidOptions };
  * 传说中的水波图
  */
 export class Liquid extends Plot<LiquidOptions> {
+  /**
+   * 获取 饼图 默认配置项
+   * @static 供外部使用
+   */
+  static getDefaultOptions(): Partial<LiquidOptions> {
+    return DEFAULT_OPTIONS;
+  }
+
   /** 图表类型 */
   public type: string = 'liquid';
 
+  /**
+   * 获取 水波图 默认配置项, 供 base 获取
+   */
   protected getDefaultOptions(): Partial<LiquidOptions> {
-    return {
-      color: '#6a99f9',
-      radius: 0.9,
-      statistic: {
-        title: false,
-        content: {
-          formatter: ({ percent }) => `${(percent * 100).toFixed(2)}%`,
-          style: {
-            opacity: 0.75,
-            fontSize: '30px',
-            lineHeight: '30px',
-            textAlign: 'center',
-          },
-        },
-      },
-      outline: {
-        border: 2,
-        distance: 0,
-      },
-      wave: {
-        count: 3,
-        length: 192,
-      },
-      shape: 'circle',
-    };
+    return Liquid.getDefaultOptions();
   }
 
   /**

--- a/src/plots/liquid/shapes/liquid.ts
+++ b/src/plots/liquid/shapes/liquid.ts
@@ -395,7 +395,7 @@ registerShape('interval', 'liquid-fill-gauge', {
     // 保证半径是 画布宽高最小值的 radius 值
     const radius = Math.min(halfWidth, minXPoint.y * radio);
     const waveAttrs = getFillAttrs(cfg);
-    const shapeAttrs = getLineAttrs(cfg);
+    const outlineAttrs = getLineAttrs(mix({}, cfg, outline));
     const innerRadius = radius - border / 2;
     const builtInShapeByName = {
       pin,
@@ -447,7 +447,7 @@ registerShape('interval', 'liquid-fill-gauge', {
     // 3. 绘制一个 border 宽的 border
     container.addShape('path', {
       name: 'wrap',
-      attrs: mix(shapeAttrs, {
+      attrs: mix(outlineAttrs, {
         path: shapePath,
         fill: 'transparent',
         lineWidth: border,

--- a/src/plots/liquid/types.ts
+++ b/src/plots/liquid/types.ts
@@ -1,5 +1,5 @@
 import { PathCommand } from '@antv/g-base';
-import { Options, StyleAttr, ColorAttr, Statistic } from '../../types';
+import { Options, StyleAttr, ColorAttr, Statistic, ShapeStyle } from '../../types';
 
 /** 轮廓的配置 */
 type Outline = Partial<{
@@ -7,6 +7,8 @@ type Outline = Partial<{
   readonly border: number;
   /** 内外的边距，默认为 0px */
   readonly distance: number;
+  /** 外环的样式 */
+  readonly style?: Pick<ShapeStyle, 'stroke' | 'strokeOpacity'>;
   // /** 外边框的形状，可以有 circle，rect，默认为 circle */
   // readonly containerShape?: 'circle' | 'rect';
 }>;

--- a/src/plots/pie/adaptor.ts
+++ b/src/plots/pie/adaptor.ts
@@ -4,9 +4,9 @@ import { legend, animation, theme, state, annotation } from '../../adaptor/commo
 import { getMappingFunction } from '../../adaptor/geometries/base';
 import { interval } from '../../adaptor/geometries';
 import { Interaction } from '../../types/interaction';
-import { flow, template, transformLabel, deepAssign, renderStatistic } from '../../utils';
+import { flow, template, transformLabel, deepAssign, renderStatistic, processIllegalData } from '../../utils';
 import { DEFAULT_OPTIONS } from './contants';
-import { adaptOffset, getTotalValue, processIllegalData, isAllZero } from './utils';
+import { adaptOffset, getTotalValue, isAllZero } from './utils';
 import { PIE_STATISTIC } from './interactions';
 import { PieOptions } from './types';
 

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -1,10 +1,11 @@
 import { VIEW_LIFE_CIRCLE, Event } from '@antv/g2';
 import { Plot } from '../../core/plot';
 import { Adaptor } from '../../core/adaptor';
+import { processIllegalData } from '../../utils';
 import { adaptor, pieAnnotation } from './adaptor';
 import { DEFAULT_OPTIONS } from './contants';
 import { PieOptions } from './types';
-import { isAllZero, processIllegalData } from './utils';
+import { isAllZero } from './utils';
 import './interactions';
 
 export { PieOptions };

--- a/src/plots/pie/utils.ts
+++ b/src/plots/pie/utils.ts
@@ -49,7 +49,7 @@ export function adaptOffset(type: string, offset?: string | number): string | nu
 export function processIllegalData(data: PieOptions['data'], angleField: string) {
   const processData = filter(data, (d) => {
     const v = d[angleField];
-    return (typeof v === 'number' && !isNaN(v)) || v === null;
+    return v === null || (typeof v === 'number' && !isNaN(v));
   });
 
   // 打印异常数据情况

--- a/src/plots/pie/utils.ts
+++ b/src/plots/pie/utils.ts
@@ -1,6 +1,6 @@
-import { each, every, filter, isString } from '@antv/util';
-import { LEVEL, log } from '../../utils';
+import { each, every, isString } from '@antv/util';
 import { Data } from '../../types';
+import { processIllegalData } from '../../utils';
 import { PieOptions } from './types';
 
 /**
@@ -39,23 +39,6 @@ export function adaptOffset(type: string, offset?: string | number): string | nu
     default:
       return offset;
   }
-}
-
-/**
- * 处理不合法的数据(过滤 非数值型 和 NaN，保留 null)
- * @param data
- * @param angleField
- */
-export function processIllegalData(data: PieOptions['data'], angleField: string) {
-  const processData = filter(data, (d) => {
-    const v = d[angleField];
-    return v === null || (typeof v === 'number' && !isNaN(v));
-  });
-
-  // 打印异常数据情况
-  log(LEVEL.WARN, processData.length === data.length, 'illegal data existed in chart data.');
-
-  return processData;
 }
 
 /**

--- a/src/plots/radial-bar/adaptor.ts
+++ b/src/plots/radial-bar/adaptor.ts
@@ -1,31 +1,10 @@
-import { filter } from '@antv/util';
 import { interaction, animation, theme, scale, tooltip, legend, annotation } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
-import { flow, deepAssign, findGeometry, transformLabel, log, LEVEL } from '../../utils';
+import { flow, deepAssign, findGeometry, transformLabel } from '../../utils';
 import { interval, point } from '../../adaptor/geometries';
+import { processIllegalData } from '../../utils';
 import { RadialBarOptions } from './types';
 import { getScaleMax } from './utils';
-/**
- * data 处理，过滤非法数据
- * @param params
- */
-function data(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
-  const { chart, options } = params;
-  const { data } = options;
-  const { yField } = options;
-
-  const processData = filter(data, (d) => {
-    const v = d[yField];
-    return v === null || (typeof v === 'number' && !isNaN(v));
-  });
-
-  // 打印异常数据情况
-  log(LEVEL.WARN, processData.length === data.length, 'illegal data existed in chart data.');
-
-  chart.data(processData);
-
-  return params;
-}
 
 /**
  * geometry 处理
@@ -33,7 +12,12 @@ function data(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
  */
 function geometry(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
   const { chart, options } = params;
-  const { barStyle: style, color, tooltip, colorField, type, xField, yField } = options;
+  const { barStyle: style, color, tooltip, colorField, type, xField, yField, data } = options;
+
+  // 处理不合法的数据
+  const processData = processIllegalData(data, yField);
+  chart.data(processData);
+
   const p = deepAssign({}, params, {
     options: {
       tooltip,
@@ -64,16 +48,15 @@ function geometry(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
  * @param params
  */
 export function meta(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
-  const { options, chart } = params;
-  const { yField, maxAngle } = options;
+  const { options } = params;
+  const { yField, maxAngle, data } = options;
 
-  // data使用chart.data()之后的，因为原始data中可能存在非法数据
-  const { data } = chart.getOptions();
+  const processData = processIllegalData(data, yField);
   return flow(
     scale({
       [yField]: {
         min: 0,
-        max: getScaleMax(maxAngle, yField, data),
+        max: getScaleMax(maxAngle, yField, processData),
       },
     })
   )(params);
@@ -147,7 +130,6 @@ function label(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
  */
 export function adaptor(params: Params<RadialBarOptions>) {
   return flow(
-    data,
     geometry,
     meta,
     axis,

--- a/src/plots/radial-bar/adaptor.ts
+++ b/src/plots/radial-bar/adaptor.ts
@@ -16,7 +16,7 @@ function data(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
 
   const processData = filter(data, (d) => {
     const v = d[yField];
-    return (typeof v === 'number' && !isNaN(v)) || v === null;
+    return v === null || (typeof v === 'number' && !isNaN(v));
   });
 
   // 打印异常数据情况

--- a/src/plots/radial-bar/index.ts
+++ b/src/plots/radial-bar/index.ts
@@ -19,7 +19,7 @@ export class RadialBar extends Plot<RadialBarOptions> {
    */
   public changeData(data) {
     this.updateOption({ data });
-    // 更新玉珏图的scale
+    // 更新玉珏图的 scale
     meta({ chart: this.chart, options: this.options });
     this.chart.changeData(data);
   }

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,6 +1,7 @@
-import { get, isNumber } from '@antv/util';
-import { Data, Datum, Meta } from '../types';
+import { get, isNumber, filter } from '@antv/util';
+import { Data, Datum, Meta, Options } from '../types';
 import { NodeLinkData } from '../types/relation-data';
+import { LEVEL, log } from './invariant';
 
 /**
  * 查看数据是否是全负数、或者全正数
@@ -26,6 +27,7 @@ export function adjustYMetaByZero(data: Data, field: string): Meta {
   }
   return {};
 }
+
 /**
  * 转换数据格式为带有节点与边的数据格式
  * @param data
@@ -83,4 +85,21 @@ export function transformDataToNodeLinkData(
     nodes: Object.values(nodesMap),
     links,
   };
+}
+
+/**
+ * 处理不合法的数据(过滤 非数值型 和 NaN，保留 null)
+ * @param data
+ * @param angleField
+ */
+export function processIllegalData(data: Options['data'], field: string) {
+  const processData = filter(data, (d) => {
+    const v = d[field];
+    return v === null || (typeof v === 'number' && !isNaN(v));
+  });
+
+  // 打印异常数据情况
+  log(LEVEL.WARN, processData.length === data.length, 'illegal data existed in chart data.');
+
+  return processData;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,4 @@ export { kebabCase } from './kebab-case';
 export { renderStatistic, renderGaugeStatistic } from './statistic';
 export { measureTextWidth } from './measure-text';
 export { isBetween, isRealNumber } from './number';
+export { processIllegalData } from './data';


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [x] add / modify test cases
- [x] documents, demos

### Screenshot

|  Description  |  Preview  |
|----|----|
|  水波图支持跟随主题色切换  |  ![image](https://user-images.githubusercontent.com/15646325/112239991-79adc300-8c82-11eb-962e-141308a101de.png) |
| 水波图支持配置 outline 样式 | ![image](https://user-images.githubusercontent.com/15646325/112240201-dc06c380-8c82-11eb-9e19-d421de3e0fbb.png)|
