### PR TITLE
feat: 饼图默认不设置 limit-in-plot ellipsis 的标签布局

### DIFF
--- a/__tests__/unit/plots/pie/label-spec.ts
+++ b/__tests__/unit/plots/pie/label-spec.ts
@@ -134,6 +134,27 @@ describe('support template string formatter', () => {
       },
     });
     labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    // 默认不内置 limit-in-plot 的布局
+    expect((labels[0] as IGroup).getChildren()[0].attr('text')).toBe('item1: 1(20.00%)');
+
+    // 添加 limit-in-plot ellipsis
+    pie.update({
+      ...pie.options,
+      label: {
+        content: '{name}: {value}({percentage})',
+        layout: [{ type: 'limit-in-plot', cfg: { action: 'ellipsis' } }],
+      },
+    });
+    labels = pie.chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as IGroup).getChildren()[0].attr('text')).toBe('item1: 1(2...');
+
+    pie.update({
+      ...pie.options,
+      label: {
+        content: '{name}: {value}({percentage})',
+      },
+    });
+    labels = pie.chart.geometries[0].labelsContainer.getChildren();
     // todo 暂时没有提供精度配置，直接粗暴返回
     expect((labels[0] as IGroup).getChildren()[0].attr('text')).toBe('item1: 1(2...');
 

--- a/examples/pie/basic/demo/label-layout.ts
+++ b/examples/pie/basic/demo/label-layout.ts
@@ -1,0 +1,27 @@
+import { Pie } from '@antv/g2plot';
+
+const data = [
+  { type: '分类一', value: 27 },
+  { type: '分类二', value: 25 },
+  { type: '分类三', value: 18 },
+  { type: '分类四', value: 15 },
+  { type: '分类五', value: 10 },
+  { type: '其他', value: 5 },
+];
+
+const piePlot = new Pie('container', {
+  appendPadding: 10,
+  data,
+  angleField: 'value',
+  colorField: 'type',
+  radius: 0.75,
+  label: {
+    type: 'spider',
+    labelHeight: 28,
+    content: '{name}\n{percentage}',
+    layout: { type: 'limit-in-plot', cfg: { action: 'ellipsis' } },
+  },
+  interactions: [{ type: 'element-selected' }, { type: 'element-active' }],
+});
+
+piePlot.render();

--- a/examples/pie/basic/demo/meta.json
+++ b/examples/pie/basic/demo/meta.json
@@ -45,6 +45,14 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*xZtSQocP4kYAAAAAAAAAAAAAARQnAQ"
     },
     {
+      "filename": "label-layout.ts",
+      "title": {
+        "zh": "饼图-标签布局：限制在 plot 内，溢出省略展示",
+        "en": "Pie label layout，auto ellipsis when out-of-plot"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*QyXPRK-URmUAAAAAAAAAAAAAARQnAQ"
+    },
+    {
       "filename": "pie-texture.ts",
       "title": {
         "en": "Pie plot fill with texture",

--- a/src/plots/pie/contants.ts
+++ b/src/plots/pie/contants.ts
@@ -13,9 +13,7 @@ export const DEFAULT_OPTIONS = deepAssign({}, Plot.getDefaultOptions(), {
     showTitle: false,
     showMarkers: false,
   },
-  label: {
-    layout: { type: 'limit-in-plot', cfg: { action: 'ellipsis' } },
-  },
+  label: {},
   /** 饼图样式, 不影响暗黑主题 */
   pieStyle: {
     stroke: 'white',


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

这是一个不兼容的 PR，如果有用户反馈，需要让其主动添加 label layout 布局，如下：
```ts
{
     label: {
         type: 'limit-in-plot', cfg: {  action: 'ellipsis'  } 
    }
}
```

### Screenshot

|  Before  |  After  |
|----|----|
|  ❌  |  ✅  |
