### PR TITLE
docs: update FAQ for liquid background

### DIFF
--- a/docs/manual/faq.en.md
+++ b/docs/manual/faq.en.md
@@ -41,4 +41,8 @@ You can use `scale.sync` and hide one of the y-axis.
 
 ### MultiView Plot of multiple-views is rename to Mix from v2.3.20
 
-More details to see [API](/en/docs/api/mix)  of Mix Plot
+More details to see [API](/en/docs/api/mix)  of Mix Plot.
+
+### Liquid cannot be with transparently or picture background
+
+Currently the abilities to support `distance` and custom `shape` options disable transparently or picture background technically.

--- a/docs/manual/faq.zh.md
+++ b/docs/manual/faq.zh.md
@@ -41,4 +41,8 @@ meta: {
 
 ### 多图层图表自 2.3.20 版本从 MultiView 更名为 Mix
 
-具体使用：可以见 Mix Plot [API](/zh/docs/api/mix) 文档
+具体使用：可以见 Mix Plot [API](/zh/docs/api/mix) 文档。
+
+### 水波图无法设置透明或者图片背景
+
+因为水波图需要支持 distance 和通过 path 来自定义 shape，所以目前没有办法设置透明或者图片背景。


### PR DESCRIPTION
在 FAQ 的地方说明了水波图不能设置带透明度和图片的背景。
