### PR TITLE
fix(chord): 和弦图支持展示节点 tooltip & 修复动画效果不生效

### DIFF
--- a/__tests__/unit/plots/chord/index-spec.ts
+++ b/__tests__/unit/plots/chord/index-spec.ts
@@ -1,6 +1,7 @@
 import { Datum, Chord } from '../../../../src';
 import { createDiv } from '../../../utils/dom';
 import { populationMovementData } from '../../../data/chord-population';
+import { DEFAULT_OPTIONS } from '../../../../src/plots/chord/constant';
 
 describe('chord', () => {
   it('chord', () => {
@@ -13,6 +14,10 @@ describe('chord', () => {
     });
 
     chord.render();
+
+    expect(chord.type).toBe('chord');
+    // @ts-ignore
+    expect(chord.getDefaultOptions()).toEqual(DEFAULT_OPTIONS);
 
     // nodeStyle 默认值
     expect(chord.options.nodeStyle).toEqual({
@@ -36,7 +41,7 @@ describe('chord', () => {
     // edge
     expect(chord.chart.views[0].geometries[0].type).toBe('edge');
     expect(chord.chart.views[0].geometries[0].data.length).toBe(13);
-    expect(chord.chart.views[0].geometries[0].data[0]).toEqual({
+    expect(chord.chart.views[0].geometries[0].data[0]).toMatchObject({
       source: '北京',
       target: '天津',
       value: 30,
@@ -47,7 +52,7 @@ describe('chord', () => {
     // node
     expect(chord.chart.views[1].geometries[0].type).toBe('polygon');
     expect(chord.chart.views[1].geometries[0].data.length).toBe(8);
-    expect(chord.chart.views[1].geometries[0].data[0]).toEqual({
+    expect(chord.chart.views[1].geometries[0].data[0]).toMatchObject({
       id: 0,
       name: '北京',
       x: [0.00625, 0.24959442595673875, 0.24959442595673875, 0.00625],
@@ -62,15 +67,6 @@ describe('chord', () => {
     expect(chord.chart.views[1].geometries[0].labelsContainer.getChildByIndex(0).cfg.children[0].attr('text')).toBe(
       '北京'
     );
-
-    // tooltip
-    const edgeView = chord.chart.views[0];
-    const edgeElementIdx = edgeView.getData().findIndex((d) => d.source === '北京' && d.target === '天津');
-    const element = edgeView.geometries[0].elements[edgeElementIdx];
-    const path = element.shape.attr('path');
-    chord.chart.showTooltip({ x: path[0][1], y: path[0][2] });
-    expect(document.querySelector('.g2-tooltip-name').textContent).toBe('北京 -> 天津');
-    expect(document.querySelector('.g2-tooltip-value').textContent).toBe('30');
 
     chord.destroy();
   });
@@ -113,5 +109,9 @@ describe('chord', () => {
     });
 
     chord.destroy();
+  });
+
+  it('defaultOptions 保持从 constant 中获取', () => {
+    expect(Chord.getDefaultOptions()).toEqual(DEFAULT_OPTIONS);
   });
 });

--- a/__tests__/unit/plots/chord/tooltip-spec.ts
+++ b/__tests__/unit/plots/chord/tooltip-spec.ts
@@ -1,0 +1,32 @@
+import { Datum, Chord } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { populationMovementData } from '../../../data/chord-population';
+
+describe('chord tooltips', () => {
+  it('chord', () => {
+    const div = createDiv();
+    const chord = new Chord(div, {
+      height: 500,
+      autoFit: false,
+      data: populationMovementData,
+      sourceField: 'source',
+      targetField: 'target',
+      weightField: 'value',
+    });
+
+    chord.render();
+    // tooltip
+    const edgeView = chord.chart.views[0];
+    const edgeElementIdx = edgeView.getData().findIndex((d) => d.source === '北京' && d.target === '天津');
+    const element = edgeView.geometries[0].elements[edgeElementIdx];
+    const path = element.shape.attr('path');
+    chord.chart.showTooltip({ x: path[0][1] - 2, y: path[0][2] - 4 });
+
+    expect(div.querySelector('.g2-tooltip-name').textContent).toBe('北京 -> 天津');
+    expect(div.querySelector('.g2-tooltip-value').textContent).toBe('30');
+  });
+
+  afterAll(() => {
+    // chord.destroy();
+  });
+});

--- a/__tests__/unit/plots/chord/tooltip-spec.ts
+++ b/__tests__/unit/plots/chord/tooltip-spec.ts
@@ -1,32 +1,35 @@
-import { Datum, Chord } from '../../../../src';
+import { Chord } from '../../../../src';
 import { createDiv } from '../../../utils/dom';
 import { populationMovementData } from '../../../data/chord-population';
 
 describe('chord tooltips', () => {
-  it('chord', () => {
-    const div = createDiv();
-    const chord = new Chord(div, {
-      height: 500,
-      autoFit: false,
-      data: populationMovementData,
-      sourceField: 'source',
-      targetField: 'target',
-      weightField: 'value',
-    });
+  const div = createDiv();
+  const plot = new Chord(div, {
+    height: 500,
+    autoFit: false,
+    data: populationMovementData,
+    sourceField: 'source',
+    targetField: 'target',
+    weightField: 'value',
+  });
 
-    chord.render();
+  plot.render();
+
+  it('chord', () => {
     // tooltip
-    const edgeView = chord.chart.views[0];
+    const edgeView = plot.chart.views[0];
     const edgeElementIdx = edgeView.getData().findIndex((d) => d.source === '北京' && d.target === '天津');
     const element = edgeView.geometries[0].elements[edgeElementIdx];
     const path = element.shape.attr('path');
-    chord.chart.showTooltip({ x: path[0][1] - 2, y: path[0][2] - 4 });
+    plot.chart.showTooltip({ x: path[0][1] - 2, y: path[0][2] - 4 });
 
     expect(div.querySelector('.g2-tooltip-name').textContent).toBe('北京 -> 天津');
     expect(div.querySelector('.g2-tooltip-value').textContent).toBe('30');
+    // @ts-ignore
+    expect(plot.chart.views[1].options.tooltip).not.toBe(false);
   });
 
   afterAll(() => {
-    // chord.destroy();
+    plot.destroy();
   });
 });

--- a/__tests__/unit/utils/geometry-spec.ts
+++ b/__tests__/unit/utils/geometry-spec.ts
@@ -1,5 +1,10 @@
 import { Chart } from '@antv/g2';
-import { findGeometry, getAllElements, getAllElementsRecursively } from '../../../src/utils';
+import {
+  findGeometry,
+  getAllElements,
+  getAllElementsRecursively,
+  getAllGeometriesRecursively,
+} from '../../../src/utils';
 import { createDiv } from '../../utils/dom';
 
 const div = createDiv();
@@ -68,6 +73,47 @@ describe('geometry', () => {
     chart.render();
 
     expect(getAllElementsRecursively(chart).length).toBe(6);
+
+    chart.destroy();
+  });
+  it('get geometries recursively', () => {
+    const chart = new Chart({
+      container: div,
+    });
+
+    const view1 = chart.createView();
+    view1.data(DATA);
+
+    view1.line().position('x*y');
+    view1.interval().position('x*y');
+
+    const view2 = chart.createView();
+    view2.data(DATA);
+
+    view2.line().position('x*y');
+    view2.interval().position('x*y');
+    view2.point().position('x*y');
+
+    chart.render();
+
+    expect(getAllGeometriesRecursively(chart).length).toBe(5);
+
+    const view3 = chart.createView();
+
+    view3.data(DATA);
+    view3.line().position('x*y');
+    view3.interval().position('x*y');
+
+    chart.render();
+
+    expect(getAllGeometriesRecursively(chart).length).toBe(7);
+
+    chart.data(DATA);
+    chart.interval().position('x*y');
+
+    chart.render();
+
+    expect(getAllGeometriesRecursively(chart).length).toBe(8);
 
     chart.destroy();
   });

--- a/examples/relation-plots/chord/demo/custom-tooltip.ts
+++ b/examples/relation-plots/chord/demo/custom-tooltip.ts
@@ -1,0 +1,43 @@
+import { Chord } from '@antv/g2plot';
+
+const DATA = [
+  { source: '北京', target: '天津', value: 30 },
+  { source: '北京', target: '上海', value: 80 },
+  { source: '北京', target: '河北', value: 46 },
+  { source: '北京', target: '辽宁', value: 49 },
+  { source: '北京', target: '黑龙江', value: 69 },
+  { source: '北京', target: '吉林', value: 19 },
+  { source: '天津', target: '河北', value: 62 },
+  { source: '天津', target: '辽宁', value: 82 },
+  { source: '天津', target: '上海', value: 16 },
+  { source: '上海', target: '黑龙江', value: 16 },
+  { source: '河北', target: '黑龙江', value: 76 },
+  { source: '河北', target: '内蒙古', value: 24 },
+  { source: '内蒙古', target: '北京', value: 32 },
+];
+
+const chord = new Chord('container', {
+  data: DATA,
+  sourceField: 'source',
+  targetField: 'target',
+  weightField: 'value',
+  tooltip: {
+    fields: ['name', 'source', 'target', 'value', 'isNode'],
+    showContent: true,
+    formatter: (datum) => {
+      const { isNode, name, source, target, value } = datum;
+      if (isNode) {
+        return {
+          name: `${name}(源权重)`,
+          value: DATA.filter((d) => d.source === name).reduce((a, b) => a + b.value, 0),
+        };
+      }
+      return {
+        name: `${source} -> ${target}`,
+        value,
+      };
+    },
+  },
+});
+
+chord.render();

--- a/examples/relation-plots/chord/demo/meta.json
+++ b/examples/relation-plots/chord/demo/meta.json
@@ -12,6 +12,16 @@
       },
 
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*LjN9Sqfo6nsAAAAAAAAAAAAAARQnAQ"
-    }     
+    }
+    ,
+    {
+      "filename": "custom-tooltip.ts",
+      "title": {
+        "zh": "和弦图 - 自定义 tooltip",
+        "en": "chord"
+      },
+
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*LjN9Sqfo6nsAAAAAAAAAAAAAARQnAQ"
+    }  
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,11 +98,11 @@ export type { HeatmapOptions } from './plots/heatmap';
 export { Box } from './plots/box';
 export type { BoxOptions } from './plots/box';
 
-// 小提琴图及类型定义
+// 小提琴图及类型定义 | author by [YiSiWang](https://github.com/YiSiWang), [visiky](https://github.com/visiky)
 export { Violin } from './plots/violin';
 export type { ViolinOptions } from './plots/violin';
 
-// K线图及类型定义 | author by [jhwong](https://github.com/jinhuiWong)
+// K线图及类型定义 | author by [jhwong](https://github.com/jinhuiWong), [visiky](https://github.com/visiky)
 export { Stock } from './plots/stock';
 export type { StockOptions } from './plots/stock';
 
@@ -110,7 +110,7 @@ export type { StockOptions } from './plots/stock';
 export { Funnel, FUNNEL_CONVERSATION_FIELD } from './plots/funnel';
 export type { FunnelOptions } from './plots/funnel';
 
-// 水波图及类型定义 | author by [CarisL](https://github.com/CarisL), [hustcc](https://github.com/hustcc)
+// 水波图及类型定义 | author by [CarisL](https://github.com/CarisL), [hustcc](https://github.com/hustcc), [pearmini](https://github.com/pearmini)
 export { Liquid } from './plots/liquid';
 export type { LiquidOptions } from './plots/liquid';
 
@@ -118,7 +118,7 @@ export type { LiquidOptions } from './plots/liquid';
 export { Bullet } from './plots/bullet';
 export type { BulletOptions } from './plots/bullet';
 
-// 旭日图及类型定义 | author by [lxfu1](https://github.com/lxfu1)
+// 旭日图及类型定义 | author by [lxfu1](https://github.com/lxfu1), [visiky](https://github.com/visiky)
 export { Sunburst } from './plots/sunburst';
 export type { SunburstOptions } from './plots/sunburst';
 

--- a/src/plots/chord/adaptor.ts
+++ b/src/plots/chord/adaptor.ts
@@ -1,9 +1,11 @@
-import { interaction, animation, theme, state } from '../../adaptor/common';
+import { Geometry } from '@antv/g2';
+import { each } from '@antv/util';
+import { interaction, theme, state } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
 import { flow, pick } from '../../utils';
 import { polygon, edge } from '../../adaptor/geometries';
 import { chordLayout } from '../../utils/transform/chord';
-import { transformDataToNodeLinkData } from '../../utils/data';
+import { getAllGeometriesRecursively, transformDataToNodeLinkData } from '../../utils';
 import { ChordOptions } from './types';
 import { X_FIELD, Y_FIELD, NODE_COLOR_FIELD, EDGE_COLOR_FIELD } from './constant';
 
@@ -161,6 +163,25 @@ function edgeGeometry(params: Params<ChordOptions>): Params<ChordOptions> {
     chart: edgeView,
     options: edgeOptions,
   });
+  return params;
+}
+
+function animation(params: Params<ChordOptions>): Params<ChordOptions> {
+  const { chart, options } = params;
+  const { animation } = options;
+
+  // 同时设置整个 view 动画选项
+  if (typeof animation === 'boolean') {
+    chart.animate(animation);
+  } else {
+    chart.animate(true);
+  }
+
+  // 所有的 Geometry 都使用同一动画（各个图形如有区别，自行覆盖）
+  each(getAllGeometriesRecursively(chart), (g: Geometry) => {
+    g.animate(animation);
+  });
+
   return params;
 }
 

--- a/src/plots/chord/constant.ts
+++ b/src/plots/chord/constant.ts
@@ -1,3 +1,4 @@
+import { get } from '@antv/util';
 import { Datum } from '../../types';
 
 export const X_FIELD = 'x';
@@ -31,7 +32,13 @@ export const DEFAULT_OPTIONS = {
     },
   },
   tooltip: {
-    fields: ['source', 'target', 'value'],
+    showTitle: false,
+    showMarkers: false,
+    fields: ['source', 'target', 'value', 'isNode'],
+    // 内置：node 不显示 tooltip (业务层自行处理)，edge 显示 tooltip
+    showContent: (items) => {
+      return !get(items, [0, 'data', 'isNode']);
+    },
     formatter: (datum: Datum) => {
       const { source, target, value } = datum;
       return {

--- a/src/plots/chord/types.ts
+++ b/src/plots/chord/types.ts
@@ -15,6 +15,11 @@ export interface ChordOptions extends Omit<Options, 'xField' | 'yField' | 'xAxis
    */
   readonly weightField: string;
   /**
+   * 附加的 源字段
+   */
+  readonly rawFields?: string[];
+
+  /**
    * 数据
    */
   readonly data: Data;

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -39,3 +39,20 @@ export function getAllElementsRecursively(view: View): Element[] {
     getAllElements(view)
   );
 }
+
+/**
+ * 递归获取 View 的 所有 geometries, 包括 View 的子 View
+ */
+export function getAllGeometriesRecursively(view: View): Geometry[] {
+  if (get(view, ['views', 'length'], 0) <= 0) {
+    return view.geometries;
+  }
+
+  return reduce(
+    view.views,
+    (ele: Geometry[], subView: View) => {
+      return ele.concat(subView.geometries);
+    },
+    view.geometries
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@ export { pick } from './pick';
 export { template } from './template';
 export { log, invariant, LEVEL } from './invariant';
 export { getContainerSize } from './dom';
-export { findGeometry, getAllElements, getAllElementsRecursively } from './geometry';
+export * from './geometry';
 export { findViewById, getViews, getSiblingViews } from './view';
 export { transformLabel } from './label';
 export { getSplinePath } from './path';


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #2525
        - 【组件】tooltip 支持展示节点信息，默认不显示 & 增加自定义节点 tooltip 信息的 demo
        - 【动画】支持 'wave-in'，'zoom-in'，"scale-in-x"，'scale-in-y' 等动画效果
- [x] add / modify test cases
- [x] documents, demos

### Screenshot

|  Before  |  After  |
|----|----|
|  ❌  |  ![image](https://user-images.githubusercontent.com/15646325/121766508-dbe0da80-cb84-11eb-95b1-daa90619fc0e.png) |
