### PR TITLE
fix(rose): 玫瑰图 legend 默认配置，不进行 offset 偏移

### DIFF
--- a/__tests__/unit/plots/rose/index-spec.ts
+++ b/__tests__/unit/plots/rose/index-spec.ts
@@ -51,6 +51,10 @@ describe('rose', () => {
     expect(geometry.getAdjust('stack')).toBeUndefined();
     expect(geometry.getAttribute('color')?.getFields()).toEqual(['series']);
 
+    // legend 默认不进行 offset
+    // @ts-ignore
+    expect(rose.chart.getController('legend').components[0].component.get('offsetX')).not.toBeGreaterThan(0);
+
     rose.destroy();
   });
 

--- a/src/plots/rose/constant.ts
+++ b/src/plots/rose/constant.ts
@@ -9,7 +9,6 @@ export const DEFAULT_OPTIONS = deepAssign({}, Plot.getDefaultOptions(), {
   yAxis: false,
   legend: {
     position: 'right',
-    offsetX: -10,
   },
   sectorStyle: {
     stroke: '#fff',


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed
- [ ] add / modify test cases
- [ ] documents, demos

### Screenshot

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/15646325/124713807-93260280-df33-11eb-9b9c-03d5ccb418ac.png)  |  ![image](https://user-images.githubusercontent.com/15646325/124716568-cfa72d80-df36-11eb-8323-e3d4a1f9268c.png)   |
