### PR TITLE
fix:修复 玉珏图没有考虑isStack的情况 重新计算最大值

### DIFF
--- a/__tests__/unit/plots/radial-bar/utils-spec.ts
+++ b/__tests__/unit/plots/radial-bar/utils-spec.ts
@@ -1,7 +1,13 @@
-import { getScaleMax } from '../../../../src/plots/radial-bar/utils';
+import { getScaleMax, getScaleIsStackMax } from '../../../../src/plots/radial-bar/utils';
 import { antvStar } from '../../../data/antv-star';
+import { populationMovementData as popData } from '../../../data/chord-population';
 
 const yField = 'star';
+
+const popField = {
+  yField: 'value',
+  xField: 'source',
+};
 
 describe('utils of radial-bar', () => {
   const starArr = antvStar.map((item) => item[yField]);
@@ -20,5 +26,33 @@ describe('utils of radial-bar', () => {
 
   it('getScaleMax: empty array', () => {
     expect(getScaleMax(360, yField, [])).toBe(0);
+  });
+
+
+  const popArr = popData.reduce((value, item) => {
+    const valueItem = value.find((v) => v[popField.xField] === item[popField.xField]);
+    if (valueItem) {
+      valueItem[popField.yField] += item[popField.yField];
+    } else {
+      value.push({ ...item });
+    }
+    return value;
+  }, []).map((item) => item[popField.yField]);
+
+  const isStackMaxValue = Math.max(...popArr);
+
+  it('getScaleIsStackMax: normal', () => {
+    expect(getScaleIsStackMax(360, popField.yField, popField.xField, popData)).toBe(isStackMaxValue);
+    expect(getScaleIsStackMax(-300, popField.yField, popField.xField, popData)).toBe((isStackMaxValue * 360) / 300);
+    expect(getScaleIsStackMax(660, popField.yField, popField.xField, popData)).toBe((isStackMaxValue * 360) / 300);
+  });
+
+  it('getScaleIsStackMax: existed nil value', () => {
+    expect(getScaleIsStackMax(-300, popField.yField, popField.xField, [...popData, { source: 'c', value: undefined }])).toBe((isStackMaxValue * 360) / 300);
+    expect(getScaleIsStackMax(-300, popField.yField, popField.xField, [...popData, { source: 'c', value: null }])).toBe((isStackMaxValue * 360) / 300);
+  });
+
+  it('getScaleIsStackMax: empty array', () => {
+    expect(getScaleIsStackMax(360, popField.yField, popField.xField, [])).toBe(0);
   });
 });

--- a/__tests__/unit/plots/radial-bar/utils-spec.ts
+++ b/__tests__/unit/plots/radial-bar/utils-spec.ts
@@ -28,16 +28,17 @@ describe('utils of radial-bar', () => {
     expect(getScaleMax(360, yField, [])).toBe(0);
   });
 
-
-  const popArr = popData.reduce((value, item) => {
-    const valueItem = value.find((v) => v[popField.xField] === item[popField.xField]);
-    if (valueItem) {
-      valueItem[popField.yField] += item[popField.yField];
-    } else {
-      value.push({ ...item });
-    }
-    return value;
-  }, []).map((item) => item[popField.yField]);
+  const popArr = popData
+    .reduce((value, item) => {
+      const valueItem = value.find((v) => v[popField.xField] === item[popField.xField]);
+      if (valueItem) {
+        valueItem[popField.yField] += item[popField.yField];
+      } else {
+        value.push({ ...item });
+      }
+      return value;
+    }, [])
+    .map((item) => item[popField.yField]);
 
   const isStackMaxValue = Math.max(...popArr);
 
@@ -48,8 +49,12 @@ describe('utils of radial-bar', () => {
   });
 
   it('getScaleIsStackMax: existed nil value', () => {
-    expect(getScaleIsStackMax(-300, popField.yField, popField.xField, [...popData, { source: 'c', value: undefined }])).toBe((isStackMaxValue * 360) / 300);
-    expect(getScaleIsStackMax(-300, popField.yField, popField.xField, [...popData, { source: 'c', value: null }])).toBe((isStackMaxValue * 360) / 300);
+    expect(
+      getScaleIsStackMax(-300, popField.yField, popField.xField, [...popData, { source: 'c', value: undefined }])
+    ).toBe((isStackMaxValue * 360) / 300);
+    expect(getScaleIsStackMax(-300, popField.yField, popField.xField, [...popData, { source: 'c', value: null }])).toBe(
+      (isStackMaxValue * 360) / 300
+    );
   });
 
   it('getScaleIsStackMax: empty array', () => {

--- a/src/plots/radial-bar/adaptor.ts
+++ b/src/plots/radial-bar/adaptor.ts
@@ -49,14 +49,13 @@ function geometry(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
  */
 export function meta(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
   const { options } = params;
-  const { yField, maxAngle, data } = options;
-
+  const { yField, data } = options;
   const processData = processIllegalData(data, yField);
   return flow(
     scale({
       [yField]: {
         min: 0,
-        max: getScaleMax(maxAngle, yField, processData),
+        max: getScaleMax(processData, options),
       },
     })
   )(params);

--- a/src/plots/radial-bar/adaptor.ts
+++ b/src/plots/radial-bar/adaptor.ts
@@ -4,7 +4,7 @@ import { flow, deepAssign, findGeometry, transformLabel } from '../../utils';
 import { interval, point } from '../../adaptor/geometries';
 import { processIllegalData } from '../../utils';
 import { RadialBarOptions } from './types';
-import { getScaleMax } from './utils';
+import { getScaleMax, getScaleIsStackMax } from './utils';
 
 /**
  * geometry 处理
@@ -49,13 +49,13 @@ function geometry(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
  */
 export function meta(params: Params<RadialBarOptions>): Params<RadialBarOptions> {
   const { options } = params;
-  const { yField, data } = options;
+  const { yField, xField, data, isStack, isGroup, colorField, maxAngle } = options;
   const processData = processIllegalData(data, yField);
   return flow(
     scale({
       [yField]: {
         min: 0,
-        max: getScaleMax(processData, options),
+        max: isStack && !isGroup && colorField ? getScaleIsStackMax(maxAngle, yField, xField, processData) : getScaleMax(maxAngle, yField, processData),
       },
     })
   )(params);

--- a/src/plots/radial-bar/adaptor.ts
+++ b/src/plots/radial-bar/adaptor.ts
@@ -55,7 +55,10 @@ export function meta(params: Params<RadialBarOptions>): Params<RadialBarOptions>
     scale({
       [yField]: {
         min: 0,
-        max: isStack && !isGroup && colorField ? getScaleIsStackMax(maxAngle, yField, xField, processData) : getScaleMax(maxAngle, yField, processData),
+        max:
+          isStack && !isGroup && colorField
+            ? getScaleIsStackMax(maxAngle, yField, xField, processData)
+            : getScaleMax(maxAngle, yField, processData),
       },
     })
   )(params);

--- a/src/plots/radial-bar/types.ts
+++ b/src/plots/radial-bar/types.ts
@@ -24,4 +24,8 @@ export interface RadialBarOptions extends Options, Pick<BarOptions, 'barBackgrou
   readonly colorField?: string;
   /** 类型 */
   readonly type?: string;
+  /** 叠加 */
+  readonly isStack?: boolean;
+  /** 分组 */
+  readonly isGroup?: boolean;
 }

--- a/src/plots/radial-bar/utils.ts
+++ b/src/plots/radial-bar/utils.ts
@@ -1,31 +1,7 @@
 import { Data } from '../../types';
 
-type Option = {
-  xField?: string;
-  yField?: string;
-  maxAngle?: number;
-  isStack?: boolean;
-  isGroup?: boolean;
-  colorField?: string;
-};
-
-export function getScaleMax(data: Data, option: Option): number {
-  const { xField, yField, maxAngle, isStack, isGroup, colorField } = option;
-  // 有堆叠并且没有分组 则叠加数据
-  const newData =
-    isStack && !isGroup && colorField
-      ? data.reduce((value: Data, item) => {
-          const valueItem = value.find((v) => v[xField] === item[xField]);
-          if (valueItem) {
-            valueItem[yField] += item[yField];
-          } else {
-            value.push({ ...item });
-          }
-          return value;
-        }, [])
-      : data;
-
-  const yData = newData.map((item) => item[yField]).filter((v) => v !== undefined);
+export function getScaleMax(maxAngle: number, yField: string, data: Data): number {
+  const yData = data.map((item) => item[yField]).filter((v) => v !== undefined);
   const maxValue = yData.length > 0 ? Math.max(...yData) : 0;
   const formatRadian = Math.abs(maxAngle) % 360;
   if (!formatRadian) {
@@ -33,3 +9,17 @@ export function getScaleMax(data: Data, option: Option): number {
   }
   return (maxValue * 360) / formatRadian;
 }
+
+// 获取isStack 下的最大值
+export function getScaleIsStackMax(maxAngle: number, yField: string, xField: string, data: Data) {
+  const newData: Data = [];
+  data.forEach(item => {
+    const valueItem = newData.find((v) => v[xField] === item[xField]);
+    if (valueItem) {
+      valueItem[yField] += item[yField];
+    } else {
+      newData.push({ ...item });
+    }
+  });
+  return getScaleMax(maxAngle, yField, newData);
+};

--- a/src/plots/radial-bar/utils.ts
+++ b/src/plots/radial-bar/utils.ts
@@ -1,7 +1,30 @@
 import { Data } from '../../types';
 
-export function getScaleMax(maxAngle: number, yField: string, data: Data): number {
-  const yData = data.map((item) => item[yField]).filter((v) => v !== undefined);
+type Option = {
+  xField?: string;
+  yField?: string;
+  maxAngle?: number;
+  isStack?: boolean;
+  isGroup?: boolean;
+};
+
+export function getScaleMax(data: Data, option: Option): number {
+  const { xField, yField, maxAngle, isStack, isGroup } = option;
+  // 有堆叠并且没有分组 则叠加数据
+  const newData =
+    isStack && !isGroup
+      ? data.reduce((value: Data, item) => {
+          const valueItem = value.find((v) => v[xField] === item[xField]);
+          if (valueItem) {
+            valueItem[yField] += item[yField];
+          } else {
+            value.push({ ...item });
+          }
+          return value;
+        }, [])
+      : data;
+
+  const yData = newData.map((item) => item[yField]).filter((v) => v !== undefined);
   const maxValue = yData.length > 0 ? Math.max(...yData) : 0;
   const formatRadian = Math.abs(maxAngle) % 360;
   if (!formatRadian) {

--- a/src/plots/radial-bar/utils.ts
+++ b/src/plots/radial-bar/utils.ts
@@ -13,7 +13,7 @@ export function getScaleMax(maxAngle: number, yField: string, data: Data): numbe
 // 获取isStack 下的最大值
 export function getScaleIsStackMax(maxAngle: number, yField: string, xField: string, data: Data) {
   const newData: Data = [];
-  data.forEach(item => {
+  data.forEach((item) => {
     const valueItem = newData.find((v) => v[xField] === item[xField]);
     if (valueItem) {
       valueItem[yField] += item[yField];
@@ -22,4 +22,4 @@ export function getScaleIsStackMax(maxAngle: number, yField: string, xField: str
     }
   });
   return getScaleMax(maxAngle, yField, newData);
-};
+}

--- a/src/plots/radial-bar/utils.ts
+++ b/src/plots/radial-bar/utils.ts
@@ -6,13 +6,14 @@ type Option = {
   maxAngle?: number;
   isStack?: boolean;
   isGroup?: boolean;
+  colorField?: string;
 };
 
 export function getScaleMax(data: Data, option: Option): number {
-  const { xField, yField, maxAngle, isStack, isGroup } = option;
+  const { xField, yField, maxAngle, isStack, isGroup, colorField } = option;
   // 有堆叠并且没有分组 则叠加数据
   const newData =
-    isStack && !isGroup
+    isStack && !isGroup && colorField
       ? data.reduce((value: Data, item) => {
           const valueItem = value.find((v) => v[xField] === item[xField]);
           if (valueItem) {


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x]  `玉珏图isStack的情况 重新修改获取最大值方法`

![image](https://user-images.githubusercontent.com/65594180/124880134-8ae7c900-e000-11eb-9844-2b7ecf1c5cd8.png)
