### PR TITLE
refactor(tooltip): 支持y轴crosshair以及formatter等配置，添加单测

### DIFF
--- a/__tests__/unit/plots/pixel-plot/tooltip-spec.ts
+++ b/__tests__/unit/plots/pixel-plot/tooltip-spec.ts
@@ -7,28 +7,28 @@ import { tooltipInfo } from '../../../../src/pixels/mock/data';
 
 describe('pixel-line tooltip', () => {
   const div = createDiv();
-  const width = 1000,
-    height = 500,
-    padding = [40, 50, 30, 50];
+  const defaultOptions = {
+    width: 1000,
+    height: 500,
+    padding: [40, 50, 30, 50],
+    rawData: LARGE_DATA,
+    pixelData: PIXEL_DATA,
+    xField: 'date',
+    yField: 'high',
+    seriesField: 'name',
+  };
 
   it('default tooltip', () => {
     // 默认 tooltip 存在
     const plot = new PixelPlot(div, {
-      width,
-      height,
-      padding,
-      rawData: LARGE_DATA,
-      pixelData: PIXEL_DATA,
-      xField: 'date',
-      yField: 'high',
-      seriesField: 'name',
+      ...defaultOptions,
     });
 
     plot.render();
 
     // tooltip 存在
     const tooltip = plot.tooltipController.tooltip;
-    const crosshair = plot.tooltipController.crosshair;
+    const crosshair = plot.tooltipController.xCrosshair;
 
     expect(tooltip.get('type')).toBe('html');
     expect(tooltip.get('showTitle')).toBe(true);
@@ -37,17 +37,9 @@ describe('pixel-line tooltip', () => {
     plot.destroy();
   });
 
-  it('tooltip follow: false', () => {
-    // 默认 tooltip 存在
+  it('tooltip follow: false', async () => {
     const plot = new PixelPlot(div, {
-      width,
-      height,
-      padding,
-      rawData: LARGE_DATA,
-      pixelData: PIXEL_DATA,
-      xField: 'date',
-      yField: 'high',
-      seriesField: 'name',
+      ...defaultOptions,
       tooltip: {
         follow: false,
       },
@@ -57,25 +49,18 @@ describe('pixel-line tooltip', () => {
 
     // tooltip 不跟随, 且位置左上角固定
     const tooltip = plot.tooltipController.tooltip;
-    const bbox = tooltip.getBBox();
 
-    expect(bbox.x).toBe(0);
-    expect(bbox.y).toBe(0);
+    await delay(0);
+
+    expect(tooltip.get('x')).toBe(0);
+    expect(tooltip.get('y')).toBe(0);
 
     plot.destroy();
   });
 
   it('tooltip title fields', async () => {
-    // 默认 tooltip 存在
     const plot = new PixelPlot(div, {
-      width,
-      height,
-      padding,
-      rawData: LARGE_DATA,
-      pixelData: PIXEL_DATA,
-      xField: 'date',
-      yField: 'high',
-      seriesField: 'name',
+      ...defaultOptions,
       tooltip: {
         title: 'stock list',
         fields: ['date', 'high'],
@@ -86,11 +71,10 @@ describe('pixel-line tooltip', () => {
 
     // tooltip 不跟随, 且位置左上角固定
     const tooltip = plot.tooltipController.tooltip;
-    const bbox = plot.pixelBBox;
     // 触发 show 方法， title才会更新
-    plot.tooltipController.show({ x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height / 2 });
+    plot.tooltipController.show({ x: 100, y: 100 });
 
-    await delay(0);
+    await delay(10);
 
     expect(tooltip.get('title')).toBe('stock list');
     expect(div.querySelectorAll('.g2-tooltip-list-item').length).toBe(6);
@@ -111,16 +95,8 @@ describe('pixel-line tooltip', () => {
   });
 
   it('tooltip position', async () => {
-    // 默认 tooltip 存在
     const plot = new PixelPlot(div, {
-      width,
-      height,
-      padding,
-      rawData: LARGE_DATA,
-      pixelData: PIXEL_DATA,
-      xField: 'date',
-      yField: 'high',
-      seriesField: 'name',
+      ...defaultOptions,
       tooltip: {
         position: 'right',
       },
@@ -129,12 +105,140 @@ describe('pixel-line tooltip', () => {
     plot.render();
 
     const tooltip = plot.tooltipController.tooltip;
-    const bbox = plot.pixelBBox;
 
-    plot.tooltipController.show({ x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height / 2 });
+    plot.tooltipController.show({ x: 100, y: 100 });
 
     await delay(0);
     expect(tooltip.get('position')).toBe('right');
+
+    plot.destroy();
+  });
+
+  it('tooltip crosshairs', async () => {
+    // 默认 tooltip 存在
+    const plot = new PixelPlot(div, {
+      ...defaultOptions,
+      tooltip: {
+        showCrosshairs: true,
+        crosshairs: {
+          type: 'xy',
+          line: {
+            style: {
+              lineWidth: 2,
+            },
+          },
+          textBackground: {
+            padding: 10,
+            style: {
+              fill: '#fff',
+              opacity: 1,
+            },
+          },
+          text: (type) => {
+            if (type === 'x') {
+              return {
+                content: 'xxx',
+              };
+            } else if (type === 'y') {
+              return {
+                content: 'yyy',
+              };
+            }
+          },
+        },
+      },
+    });
+
+    plot.render();
+
+    plot.tooltipController.show({ x: 100, y: 100 });
+
+    await delay(0);
+
+    const xCrosshair = plot.tooltipController.xCrosshair;
+    const yCrosshair = plot.tooltipController.yCrosshair;
+
+    expect(xCrosshair.get('line').style.lineWidth).toBe(2);
+    expect(xCrosshair.get('textBackground').padding).toBe(10);
+    expect(yCrosshair.get('textBackground').style.fill).toBe('#fff');
+    expect(yCrosshair.get('textBackground').style.opacity).toBe(1);
+
+    expect(xCrosshair.get('text').content).toBe('xxx');
+    expect(yCrosshair.get('text').content).toBe('yyy');
+    plot.destroy();
+  });
+
+  it('tooltip marker', async () => {
+    // 默认 tooltip 存在
+    const plot = new PixelPlot(div, {
+      ...defaultOptions,
+      tooltip: {
+        showMarkers: true,
+        marker: {
+          fill: 'red',
+          stroke: '#eee',
+          lineWidth: 10,
+        },
+      },
+    });
+
+    plot.render();
+
+    plot.tooltipController.show({ x: 100, y: 100 });
+
+    await delay(0);
+
+    const tooltipMarkerGroup = plot.tooltipController.tooltipMarkerGroup;
+
+    expect(tooltipMarkerGroup.get('children')[0].get('attrs').fill).toBe('red');
+    expect(tooltipMarkerGroup.get('children')[0].get('attrs').stroke).toBe('#eee');
+    expect(tooltipMarkerGroup.get('children')[0].get('attrs').lineWidth).toBe(10);
+
+    plot.destroy();
+  });
+
+  it('tooltip customContent', async () => {
+    const plot = new PixelPlot(div, {
+      ...defaultOptions,
+      tooltip: {
+        customContent: (title, data) => {
+          return `<div class="g2-tooltip">${title}</div>`;
+        },
+      },
+    });
+
+    plot.render();
+
+    plot.tooltipController.show({ x: 100, y: 100 });
+
+    await delay(0);
+
+    expect((div.querySelectorAll('.g2-tooltip')[0] as HTMLElement).innerText).toBe(
+      `${plot.tooltipController.tooltip.get('title')}`
+    );
+
+    plot.destroy();
+  });
+
+  it('tooltip formatter', async () => {
+    const plot = new PixelPlot(div, {
+      ...defaultOptions,
+      tooltip: {
+        formatter: (datum) => {
+          return { name: datum.name, value: datum.value + '万' };
+        },
+      },
+    });
+
+    plot.render();
+
+    plot.tooltipController.show({ x: 100, y: 100 });
+
+    await delay(0);
+
+    expect((div.querySelectorAll('.g2-tooltip-value')[0] as HTMLElement).innerText).toBe(
+      `${plot.tooltipController.getTooltipInfo()[0]['data']['high']}万`
+    );
 
     plot.destroy();
   });

--- a/src/pixels/constant.ts
+++ b/src/pixels/constant.ts
@@ -7,9 +7,21 @@ export const DEFAULT_OPTIONS = {
   xAxis: {},
   yAxis: {},
   tooltip: {
-    fields: [],
-    showTitle: true,
-    offset: 20,
     follow: true,
+    offset: 20,
+    showTitle: true,
+    showContent: true,
+    showCrosshairs: true,
+    showMarkers: true,
+    crosshairs: {
+      type: 'x',
+      text: false,
+      line: {
+        style: {
+          stroke: '#999',
+          lineWidth: 0.5,
+        },
+      },
+    },
   },
 };

--- a/src/pixels/index.ts
+++ b/src/pixels/index.ts
@@ -17,18 +17,18 @@ export class PixelPlot extends CanvasPlot<PixelPlotOptions> {
    * 暂时把图表所需组件放置在子类中
    */
   protected initComponents() {
-    this.tooltipController = new TooltipController(this);
     this.axisController = new AxisController(this);
+    this.tooltipController = new TooltipController(this);
   }
 
   protected renderComponents() {
-    if (this.tooltipController) this.tooltipController.render();
     if (this.axisController) this.axisController.render();
+    if (this.tooltipController) this.tooltipController.render();
   }
 
   protected updateComponents() {
-    if (this.tooltipController) this.tooltipController.update();
     if (this.axisController) this.axisController.update();
+    if (this.tooltipController) this.tooltipController.update();
   }
 
   /**

--- a/src/pixels/mock/data.ts
+++ b/src/pixels/mock/data.ts
@@ -1,3 +1,4 @@
+// 高亮的三条线的基于x的数据，至少需要返回原始数据
 export const tooltipInfo = [
   {
     x: 100,
@@ -15,6 +16,6 @@ export const tooltipInfo = [
     x: 100,
     y: 150,
     color: '#FAA219',
-    data: { date: '2003-01-24', high: 12.2, open: 48, name: 'as.er.txt' },
+    data: { date: '2003-01-24', high: 42.2, open: 48, name: 'as.er.txt' },
   },
 ];


### PR DESCRIPTION
新增配置：
- [x] formatter
- [x] showCrosshairs
- [x] showMarkers
- [x] marker 
- [x] crosshairs
- [x] showContent
- [x] customItems 

已经支持配置：
 follow
 offset
 position
 showTitle
 title
 fields
 customContent

### Screenshot
