### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ $ git checkout -b branch-name
 # Run the test after you finish your modification. Add new test cases or change old ones if you feel necessary
 $ npm test
 
-# If your modification pass the tests, congradulations it's time to push your work back to us. Notice that the commit message should be wirtten in the following format.
+# If your modification pass the tests, congradulations it's time to push your work back to us. Notice that the commit message should be written in the following format.
 $ git add . # git add -u to delete files
 $ git commit -m "fix(role): role.use must xxx"
 $ git push origin branch-name
@@ -32,7 +32,7 @@ $ git push origin branch-name
 
 Then you can create a Pull Request at [g2plot](https:// github.com/antvis/g2plot/pulls).
 
-No one can garantee how much will be remembered about certain PR after some time. To make sure we can easily recap what happened previously, please provide the following information in your PR.
+No one can guarantee how much will be remembered about certain PR after some time. To make sure we can easily recap what happened previously, please provide the following information in your PR.
 
 1. Need: What function you want to achieve (Generally, please point out which issue is related).
 2. Updating Reason: Different with issue. Briefly describe your reason and logic about why you need to make such modification.
@@ -79,7 +79,7 @@ Use succinct words to describe what did you do { in the } commit change.
 
 （4）body
 
-Feel free to add more content in the body, if you { think } subject is not self-explanatory enough, such as what it is the purpose or reasone of you commit.
+Feel free to add more content in the body, if you { think } subject is not self-explanatory enough, such as what it is the purpose or reason of you commit.
 
 （5）footer
 

--- a/docs/api/options/interactions.en.md
+++ b/docs/api/options/interactions.en.md
@@ -40,7 +40,7 @@ more details about action, got to see [G2 | interaction feedback](https://g2.ant
 | element-single-highlight | 用于设置和取消图表元素的 highlight ，只允许单个元素 highlight。高亮的时候会取消当前激活元素之外的元素的高亮态 | <tag color="green" text="Element">Element</tag> |
 | element-filter| 图表元素的过滤，支持来自图例（分类和连续）、坐标轴文本的触发 | <tag color="green" text="Element">Element</tag> | 
 
-### Assembel interacions
+### Assembel interactions
 
 #### element-link (chart elements of the same colors)
 

--- a/docs/api/plots/liquid.en.md
+++ b/docs/api/plots/liquid.en.md
@@ -66,13 +66,13 @@ function shape(x: number, y: number, width: number, height: number) {
 
 <description>**optional** _Outline_</description>
 
-The ouline configure for liquid plot, includes:
+The outline configure for liquid plot, includes:
 
 | Properties | Type              | Desc                                          |
 | ---------- | ----------------- | --------------------------------------------- |
-| border     | _number_          | border width of ouline, default 2px           |
-| distance   | _number_          | distance between ouline and wave, default 0px |
-| style      | _OutlineStyleCfg_ | the style configure of ouline                 |
+| border     | _number_          | border width of outline, default 2px           |
+| distance   | _number_          | distance between outline and wave, default 0px |
+| style      | _OutlineStyleCfg_ | the style configure of outline                 |
 
 The style configure of outline for liquid plot, includes:
 

--- a/docs/common/interactions.en.md
+++ b/docs/common/interactions.en.md
@@ -1,4 +1,4 @@
-#### Add interacions
+#### Add interactions
 
 Usage:
 


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- docs/api/options/interactions.en.md
- docs/api/plots/liquid.en.md
- docs/common/interactions.en.md

Fixes:
- Should read `outline` rather than `ouline`.
- Should read `interactions` rather than `interacions`.
- Should read `written` rather than `wirtten`.
- Should read `reason` rather than `reasone`.
- Should read `guarantee` rather than `garantee`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md