### PR TITLE
 修复:   [BUG] 双轴图图例legend使用symbol的时候，颜色不能自动调整

### DIFF
--- a/__tests__/unit/plots/dual-axes/legend-spec.ts
+++ b/__tests__/unit/plots/dual-axes/legend-spec.ts
@@ -391,6 +391,34 @@ describe('Legend', () => {
       xField: 'date',
       yField: ['pv', 'uv'],
       legend: {
+        marker: {
+          symbol: 'diamond',
+        },
+      },
+    });
+
+    dualAxes.render();
+
+    const legendController = dualAxes.chart.getController('legend');
+    const legendComponent = legendController.getComponents()[0];
+    const cfg = legendComponent.component.cfg;
+
+    expect(cfg.items[0].marker.symbol).toBe('diamond');
+    expect(cfg.items[1].marker.symbol).toBe('diamond');
+    expect(cfg.items[0].marker.style.fill).toBe('#5B8FF9');
+    expect(cfg.items[1].marker.style.fill).toBe('#5AD8A6');
+
+    dualAxes.destroy();
+  });
+
+  it('Legend custom', () => {
+    const dualAxes = new DualAxes(createDiv('Legend custom '), {
+      width: 400,
+      height: 500,
+      data: [PV_DATA, UV_DATA],
+      xField: 'date',
+      yField: ['pv', 'uv'],
+      legend: {
         custom: true,
         layout: 'vertical',
         position: 'right',

--- a/src/plots/dual-axes/util/legend.ts
+++ b/src/plots/dual-axes/util/legend.ts
@@ -1,6 +1,6 @@
-import { reduce, get } from '@antv/util';
+import { reduce, get, isEmpty, isFunction } from '@antv/util';
 import { View, Util } from '@antv/g2';
-import { findGeometry } from '../../../utils';
+import { deepAssign, findGeometry } from '../../../utils';
 import { GeometryOption } from '../types';
 import { Legend } from '../../../types/legend';
 import { isLine } from './option';
@@ -24,7 +24,19 @@ export function getViewLegendItems(params: {
     const color = colorAttribute.values[0];
 
     const marker =
-      userMarker ||
+      (isFunction(userMarker)
+        ? userMarker
+        : !isEmpty(userMarker) &&
+          deepAssign(
+            {},
+            {
+              style: {
+                stroke: color,
+                fill: color,
+              },
+            },
+            userMarker
+          )) ||
       (isLine(geometryOption)
         ? {
             symbol: (x: number, y: number, r: number) => {


### PR DESCRIPTION
| `修复前` |   `修复后`|
| --- | --- |
|![image](https://user-images.githubusercontent.com/65594180/128685515-8e881412-d85b-43f6-8436-1b6f4775c7c6.png)|![image](https://user-images.githubusercontent.com/65594180/128685433-7dc56bc0-82f5-4f76-ade2-f331da659a60.png)|
