### PR TITLE
fix(funnel): 不将 label 的 layout 的 type 设置为 interval-adjust-position

### DIFF
--- a/__tests__/unit/plots/funnel/basic-spec.ts
+++ b/__tests__/unit/plots/funnel/basic-spec.ts
@@ -79,7 +79,6 @@ describe('basic funnel', () => {
       });
 
       const geometry = funnel.chart.geometries[0];
-      expect(geometry.labelOption.cfg.layout.type).toBe('interval-adjust-position');
       const shapeFields = geometry.getAttribute('shape').getFields();
       expect(shapeFields[0]).toBe('pyramid');
     });

--- a/src/plots/funnel/geometries/basic.ts
+++ b/src/plots/funnel/geometries/basic.ts
@@ -51,15 +51,7 @@ function geometry(params: Params<FunnelOptions>): Params<FunnelOptions> {
         color,
         style: funnelStyle,
       },
-      // 使用 Interval 绘制的漏斗图，默认使用 'interval-adjust-position', 否则尖底漏斗图最后一行 label 错位
-      label: deepAssign(
-        {
-          layout: {
-            type: 'interval-adjust-position',
-          },
-        },
-        label
-      ),
+      label,
       state,
     },
   });


### PR DESCRIPTION
之前为了解决漏斗最下面一层文字无法对其的问题，将 label 的 layout type 设置为了 interval-adjust-position。但这样会出现 label:{position: 'right'} 失效的问题，所以在 G2 层修复了文字对齐的问题，不需要设置为 interval-adjust-position 了。

G2 的解决如下：https://github.com/antvis/G2/pull/3585 