### PR TITLE
chore(action): change macos to ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: ["push", "pull_request"]
 
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 12
@@ -19,7 +19,7 @@ jobs:
           npm run lint
 
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 12

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "site:develop": "cross-env PORT=8080 gatsby develop --open -H 0.0.0.0",
     "site:build": "npm run site:clean && gatsby build --prefix-paths",
     "site:clean": "gatsby clean",
-    "site:deploy": "npm run build && npm run site:build && gh-pages -d public",
+    "site:deploy": "npm run build && npm run site:build --max-old-space-size=4096--no-warnings && gh-pages -d public",
     "fix": "eslint --ext .ts ./src ./__tests__ --fix && prettier --write ./src ./__tests__ && lint-md --fix ./examples ./docs",
     "build": "run-s clean lib dist size",
     "size": "limit-size",

--- a/package.json
+++ b/package.json
@@ -144,11 +144,11 @@
   "limit-size": [
     {
       "path": "dist/g2plot.min.js",
-      "limit": "980 Kb"
+      "limit": "985 Kb"
     },
     {
       "path": "dist/g2plot.min.js",
-      "limit": "270 Kb",
+      "limit": "275 Kb",
       "gzip": true
     }
   ],


### PR DESCRIPTION
close: #2862

### PR includes

- [x] change environment from macOS to ubuntu when `lint` or `build`
- [x] try to fix release action failed through larger space, see:  [heap-out-of-memory-javascript-crash](https://www.rockyourcode.com/gatsby.js-heap-out-of-memory-javascript-crash/)
