### PR TITLE
docs(funnel): 漏斗图转化率信息组件文档 api 补全

### DIFF
--- a/docs/api/plots/funnel.en.md
+++ b/docs/api/plots/funnel.en.md
@@ -62,7 +62,7 @@ Whether the height is dynamic. When set to `true`, the height of each elemnet in
 
 the max size of graphic，is between 0 and 1, default 1。
 
-Tip: when set dynamicHeight to be true, this field is invalid 
+Tip: when set dynamicHeight to be true, this field is invalid
 
 #### minSize
 
@@ -70,7 +70,7 @@ Tip: when set dynamicHeight to be true, this field is invalid
 
 the min size of graphic，is between 0 and 1, default 0。
 
-Tip: when set dynamicHeight to be true, this field is invalid 
+Tip: when set dynamicHeight to be true, this field is invalid
 
 #### funnelStyle
 
@@ -96,7 +96,16 @@ Graphic style of funnel. You can either pass in the 'shapeStyle' structure direc
 
 Configure the conversion rate component.
 
-Defalut: `{offsetX: 10, offsetY: 0, formatter: (datum) => '转化率' + datum.$$percentage$$ * 100 + '%',}`。
+Defalut: `{offsetX: 10, offsetY: 0, formatter: (datum) => '转化率' + datum[Funnel.PERCENT_FIELD] * 100 + '%',}`。
+
+| Properties | Type                                                 | Description            |
+| ---------- | ---------------------------------------------------- | ---------------------- |
+| offsetX    | _number_                                             | x 偏移量               |
+| offsetY    | _number_                                             | y 偏移量               |
+| style      | _ShapeAttrs \| false_                                | Text style             |
+| formatter  | _string \| ((datum?: Datum, data?: Data) => string)_ | Text content formatter |
+
+Please refer to the style configuration [ShapeAttrs](/en/docs/api/graphic-style)
 
 `markdown:docs/common/color.en.md`
 
@@ -126,11 +135,11 @@ Funnel plot provides static properties, makes it easy to use.
 
 #### Static variables
 
-| Field | Description |
-| --- | --- |
-| `CONVERSATION_FIELD` | The corresponding value of this field is an array, stores the current and previous values of the funnel, for example, [263, 151], from which the user can calculate the conversion rate |
-| `PERCENT_FIELD` | The corresponding value of this field represents the `conversion percentage` between current value and previous value |
-| `TOTAL_PERCENT_FIELD` | The corresponding value of this field represents the percentage of total conversion rate |
+| Field                 | Description                                                                                                                                                                             |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONVERSATION_FIELD`  | The corresponding value of this field is an array, stores the current and previous values of the funnel, for example, [263, 151], from which the user can calculate the conversion rate |
+| `PERCENT_FIELD`       | The corresponding value of this field represents the `conversion percentage` between current value and previous value                                                                   |
+| `TOTAL_PERCENT_FIELD` | The corresponding value of this field represents the percentage of total conversion rate                                                                                                |
 
 **Example:**
 
@@ -173,4 +182,5 @@ import { FUNNEL_CONVERSATION_FIELD } from '@antv/g2plot';
 ```
 
 <!-- 直接 三级导航展开 -->
+
 `markdown:docs/common/annotations.zh.md`

--- a/docs/api/plots/funnel.zh.md
+++ b/docs/api/plots/funnel.zh.md
@@ -96,7 +96,16 @@ order: 9
 
 配置转化率组件。
 
-默认配置：`{offsetX: 10, offsetY: 0, formatter: (datum) => '转化率' + datum.$$percentage$$ * 100 + '%',}`。
+默认配置：`{offsetX: 10, offsetY: 0, formatter: (datum) => '转化率' + datum[Funnel.PERCENT_FIELD] * 100 + '%',}`。
+
+| 配置项    | 类型                                                 | 功能描述         |
+| --------- | ---------------------------------------------------- | ---------------- |
+| offsetX   | _number_                                             | x 偏移量         |
+| offsetY   | _number_                                             | y 偏移量         |
+| style     | _ShapeAttrs \| false_                                | 文本字体样式配置 |
+| formatter | _string \| ((datum?: Datum, data?: Data) => string)_ | 文本内容格式化   |
+
+样式配置类型请参考 [绘图属性](/zh/docs/api/graphic-style)
 
 `markdown:docs/common/color.zh.md`
 
@@ -126,11 +135,11 @@ order: 9
 
 #### 静态变量
 
-| 字段 key 值 | 说明 |
-| --- | --- |
-| `CONVERSATION_FIELD` | 该字段对应数值为数组，存储漏斗当前和上一项值，例如 [263, 151], 用户可由此计算转化率 |
-| `PERCENT_FIELD` | 该字段对应数值代表的是当前数值和上一项值的转化率百分比 |
-| `TOTAL_PERCENT_FIELD` | 该字段对应数值代表的总转化率百分比 |
+| 字段 key 值           | 说明                                                                                |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| `CONVERSATION_FIELD`  | 该字段对应数值为数组，存储漏斗当前和上一项值，例如 [263, 151], 用户可由此计算转化率 |
+| `PERCENT_FIELD`       | 该字段对应数值代表的是当前数值和上一项值的转化率百分比                              |
+| `TOTAL_PERCENT_FIELD` | 该字段对应数值代表的总转化率百分比                                                  |
 
 **使用示例：**
 
@@ -174,4 +183,5 @@ import { FUNNEL_CONVERSATION_FIELD } from '@antv/g2plot';
 ```
 
 <!-- 直接 三级导航展开 -->
+
 `markdown:docs/common/annotations.zh.md`


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #2872
- [ ] add / modify test cases
- [x] documents, demos

虽然 conventionTag 应该命名为 conversionRate, 文本字体样式应该通过 `text.style` 配置，但是....暂时不做不兼容处理了
