### PR TITLE
docs: correct doc about `rotate`

### DIFF
--- a/docs/api/plots/gauge.en.md
+++ b/docs/api/plots/gauge.en.md
@@ -31,13 +31,13 @@ The radius of the inner ring [0-1] is calculated relative to the inner radius ra
 
 <description>**optional** _number_ _default:_ `(-7 / 6) * Math.PI`</description>
 
-The starting Angle of the disk.
+The starting angle of the disk.
 
 #### endAngle
 
 <description>**optional** _number_ _default:_ `(1 / 6) * Math.PI`</description>
 
-The termination Angle of the disk.
+The termination angle of the disk.
 
 ### Plot Style
 

--- a/docs/api/plots/pie.en.md
+++ b/docs/api/plots/pie.en.md
@@ -79,13 +79,13 @@ The inner radius of the pie chart, starting at the center of the canvas. Configu
 
 <description>**optional** _number_</description>
 
-Configure the starting Angle of the coordinate system.
+Configure the starting angle of the coordinate system.
 
 #### endAngle
 
 <description>**optional** _number_</description>
 
-Configure the end Angle of the coordinate system.
+Configure the end angle of the coordinate system.
 
 <playground rid="quarter-circle" path="pie/basic/demo/quarter-circle.ts"></playground>
 

--- a/docs/api/plots/radar.en.md
+++ b/docs/api/plots/radar.en.md
@@ -50,7 +50,7 @@ radarPlot.render();
 
 <description>**required** _string_</description>
 
-The radar map maps to the field corresponding to the circumference Angle, which is generally a classification field.
+The radar map maps to the field corresponding to the circumference angle, which is generally a classification field.
 
 #### yField
 
@@ -76,13 +76,13 @@ The radius of the radar map, starting at the center of the drawing area (not inc
 
 <description>**optional** _number_ _default:_ `(Math.PI * 0) / 180`</description>
 
-The starting Angle of the disk.
+The starting angle of the disk.
 
 #### endAngle
 
 <description>**optional** _number_ _default:_ `(Math.PI * 180) / 180`</description>
 
-The termination Angle of the disk.
+The termination angle of the disk.
 
 `markdown:docs/common/color.en.md`
 

--- a/docs/api/plots/radial-bar.en.md
+++ b/docs/api/plots/radial-bar.en.md
@@ -39,13 +39,13 @@ InnerRadius of Polar coordinate. Value can be: (0, 1]
 
 <description>**optional** _number_ _default:_ `-Math.PI / 2`</description>
 
-Configure the starting Angle of the coordinate system.
+Configure the starting angle of the coordinate system.
 
 #### endAngle
 
 <description>**optional** _number_ _default:_ `Math.PI / 2 * 3`</description>
 
-Configure the end Angle of the coordinate system.
+Configure the end angle of the coordinate system.
 
 <playground path="more-plots/radial-bar/demo/line.ts" rid="startAngle-endAngle"></playground>
 

--- a/docs/api/plots/rose.en.md
+++ b/docs/api/plots/rose.en.md
@@ -105,13 +105,13 @@ The radius of the hollow circle inside the rose is the same as radius.
 
 <description>**optional** _number_ _default:_ `(Math.PI * 0) / 180`</description>
 
-The starting Angle of the disk.
+The starting angle of the disk.
 
 #### endAngle
 
 <description>**optional** _number_ _default:_ `(Math.PI * 180) / 180`</description>
 
-The termination Angle of the disk.
+The termination angle of the disk.
 
 `markdown:docs/common/color.en.md`
 

--- a/docs/api/plots/word-cloud.en.md
+++ b/docs/api/plots/word-cloud.en.md
@@ -61,8 +61,8 @@ The return value is of the following type:
 | y          | _number_           | Vertical coordinates of the current text   |
 | font       | _string_           | Font of text                               |
 | weight     | _number \| string_ | Text weight                                |
-| size       | _numberg_          | The font size of the text                  |
-| rotate     | _numberg_          | The rotation Angle of the text             |
+| size       | _number_          | The font size of the text                  |
+| rotate     | _number_          | The rotation angle of the text             |
 
 #### timeInterval
 
@@ -97,7 +97,7 @@ Set the style of each word.
 | padding       | _number \| function_             | 1         | The padding of the box for each word, default to 1. The bigger the words, the bigger the space between them. |
 | fontSize      | _number[] \| number \| function_ | [20, 60]  | The range of font sizes, such as [10, 20], means that the minimum font is 10 and the maximum font is 20      |
 | rotation      | _number[] \| number \| function_ | [0, 90]   | Rotation minimum and maximum angles by default [0, 90]                                                       |
-| rotationSteps | _number_                         | 2         | Rotate the actual number of steps, the larger the rotation Angle may be smaller, default is 2                |
+| rotationSteps | _number_                         | 2         | Rotate the actual number of steps, the larger the rotation angle may be smaller, default is 2                |
 
 Above, some properties can be set to a function that takes the following parameters:
 

--- a/docs/api/plots/word-cloud.zh.md
+++ b/docs/api/plots/word-cloud.zh.md
@@ -61,8 +61,8 @@ order: 8
 | y        | _number_           | 当前文本的纵向坐标 |
 | font     | _string_           | 文本的字体         |
 | weight   | _number \| string_ | 文本的字重         |
-| size     | _numberg_          | 文本的字体大小     |
-| rotate   | _numberg_          | 文本的旋转角度     |
+| size     | _number_          | 文本的字体大小     |
+| rotate   | _number_          | 文本的旋转角度     |
 
 #### timeInterval
 

--- a/docs/common/axis.en.md
+++ b/docs/common/axis.en.md
@@ -47,7 +47,7 @@ Configurations related to axis label. Set this to `null` to prevent the axis lab
 | ------------ | -------------------------------------------------------- | ------- | --------------------------------------------------------- |
 | style        | _[ShapeAttrs](/en/docs/api/graphic-style)_               | -       | Axis label text graphic property style                    |
 | offset       | _number_                                                 | -       | Axis label offset                                         |
-| rotate       | _number_                                                 | -       | Axis label text rotation Angle                            |
+| rotate       | _number_                                                 | -       | Axis label text rotation angle                            |
 | autoRotate   | _boolean \|avoidCallback_                                                 | `true`  | Whether to rotate automatically, default true             |
 | autoHide     | _boolean \|avoidCallback \| { type:string,cfg?:AxisLabelAutoHideCfg }_                | `false` | Whether to hide it automatically, default to false        |
 | autoEllipsis | _boolean_                                                | `false` | Whether to ellipsis label when overflow, default to false |

--- a/docs/common/label.en.md
+++ b/docs/common/label.en.md
@@ -9,9 +9,9 @@
 | content    | _string \| IGroup \| IShape \| GeometryLabelContentCallback_ | Text content that is displayed, if not declared, is displayed according to the value of the first field participating in the mapping                             |
 | style      | _ShapeAttrs_                                                       | Label text graphic property style                                                                                                                                |
 | autoRotate | _string_                                                     | Whether to rotate automatically, default true                                                                                                                    |
-| rotate     | _number_                                                     | Text rotation Angle                                                                                                                                              |
+| rotate     | _number_                                                     | Text rotation angle, unit is radian, clockwise rotation                                                                                                                                              |
 | labelLine  | _null_ \| _boolean_ \| _LabelLineCfg_                               | Used to set the style property of the text connector. NULL indicates that it is not displayed.                                                                   |
-| labelEmit  | _boolean_                                                    | Only applies to text in polar coordinates, indicating whether the text is radially displayed according to the Angle. True means on and false means off           |
+| labelEmit  | _boolean_                                                    | Only applies to text in polar coordinates, indicating whether the text is radially displayed according to the angle. True means on and false means off           |
 | layout     | _'overlap' \| 'fixedOverlap' \| 'limitInShape'_              | Text layout type, support a variety of layout function combination.                                                                                              |
 | position   | _'top' \| 'bottom' \| 'middle' \| 'left' \| 'right'_         | Specifies the position of the current Label relative to the current graphic   (💡 Attention: Only works for **column plot** and **bar plot**, which geometry is interval)                                                                                   |
 | animate    | _boolean \| AnimateOption_                                   | Animation configuration.                                                                                                                                         |
@@ -35,8 +35,7 @@ Example code:
       fill: 'red',
       opacity: 0.6,
       fontSize: 24
-    },
-    rotate: true
+    }
   }
 }
 ```

--- a/docs/common/label.zh.md
+++ b/docs/common/label.zh.md
@@ -9,7 +9,7 @@
 | content      | _string \| IGroup \| IShape \| GeometryLabelContentCallback_ | 展示的文本内容，如果不声明则按照参与映射的第一字段的值进行显示                             |
 | style        | _ShapeAttrs_                                                     | label 文本图形属性样式                                                                     |
 | autoRotate   | _string_                                                     | 是否自动旋转，默认 true                                                                    |
-| rotate       | _number_                                                     | 文本旋转角度                                                                               |
+| rotate       | _number_                                                     | 文本旋转角度，弧度制。顺时针旋转。                                                                               |
 | labelLine    | _null_ \| _boolean_ \| _LabelLineCfg_                                   | 用于设置文本连接线的样式属性，null 表示不展示。                                            |
 | labelEmit    | _boolean_                                                    | 只对极坐标下的文本生效，表示文本是否按照角度进行放射状显示，true 表示开启，false 表示关闭  |
 | layout       | _'overlap' \| 'fixedOverlap' \| 'limitInShape'_              | 文本布局类型，支持多种布局函数组合使用。                                                   |
@@ -35,8 +35,7 @@ type LabelLineCfg = {
       fill: 'red',
       opacity: 0.6,
       fontSize: 24
-    },
-    rotate: true
+    }
   }
 }
 ```

--- a/docs/common/statistic.en.md
+++ b/docs/common/statistic.en.md
@@ -11,7 +11,7 @@ StatisticText
 | content | _string_ | Content of the text。Priority: `customHtml` > `formatter` > `content` |
 | customHtml | _CustomHtml_ | custom content by using html，priority is higher than formatter |
 | formatter  | _Function_ | The formatted content of the text |
-| rotate     | _number_   | Rotation Angle                    |
+| rotate     | _number_   | Rotation angle                    |
 | offsetX    | _number_   | X offset                          |
 | offsetY    | _number_   | Y offset                          |
 


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [x] documents, demos

### Description
![Screen Shot 2021-11-04 at 9 46 59 AM](https://user-images.githubusercontent.com/20318608/140243748-6cbcbf27-9219-48a0-a969-5cb37378cca3.png)

In the [doc](https://g2plot.antv.vision/zh/docs/api/components/axis), type for `rotate` is number. However in example code, `rotate` is `boolean`. Indeed `rotate` does support `boolean` value, casue [`Math.sin`](https://github.com/antvis/gl-matrix/blob/master/src/gl-matrix/mat3.js#L420) will convert `boolean` to `number`. But add `boolean` for `rotate` would cause many type definition changes in numbers of reposetories

So I thinks for the time being, we can remove `rotate: true` in doc, so the user would not be confused.
