### PR TITLE
feat(sankey): support `null` to represent loss.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 2.4.17 (2022-05-24)
+
+##### New Features
+
+* **sankey:**  sankey support not to display node and edge which is null ([89a4a14b](https://github.com/antvis/G2plot/commit/89a4a14b547b406c84cbeb6fc0b5b85290b3e929))
+
 #### 2.4.16 (2022-04-22)
 
 ##### Chores

--- a/__tests__/unit/plots/sankey/index-spec.ts
+++ b/__tests__/unit/plots/sankey/index-spec.ts
@@ -202,4 +202,25 @@ describe('sankey', () => {
     sankey.destroy();
     removeDom(dom);
   });
+
+  it('new Sankey({...}) supports not to display null.', () => {
+    const DATA = [
+      { source: 'a', target: null, value: 9 },
+      { source: 'a', target: 'b', value: 40 },
+    ];
+
+    const sankey = new Sankey(createDiv(), {
+      data: DATA,
+      sourceField: 'source',
+      targetField: 'target',
+      weightField: 'value',
+    });
+
+    sankey.render();
+
+    expect(sankey.chart.views[0].geometries[0].elements.length).toBe(1);
+    expect(sankey.chart.views[1].geometries[0].elements.length).toBe(2);
+
+    sankey.destroy();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2plot",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "description": "An interactive and responsive charting library",
   "keywords": [
     "chart",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const version = '2.4.16';
+export const version = '2.4.17';
 
 // G2 自定义能力透出
 import * as G2 from '@antv/g2';

--- a/src/plots/sankey/layout.ts
+++ b/src/plots/sankey/layout.ts
@@ -150,25 +150,38 @@ export function sankeyLayout(
   const layoutData: SankeyLayoutOutputData = sankeyProcessor(data);
 
   // post process (x, y), etc.
-  layoutData.nodes.forEach((node) => {
-    const { x0, x1, y0, y1 } = node;
-    /* points
-     * 3---2
-     * |   |
-     * 0---1
-     */
-    node.x = [x0, x1, x1, x0];
-    node.y = [y0, y0, y1, y1];
-  });
+  const nodes = layoutData.nodes
+    .map((node) => {
+      const { x0, x1, y0, y1 } = node;
+      /* points
+       * 3---2
+       * |   |
+       * 0---1
+       */
+      node.x = [x0, x1, x1, x0];
+      node.y = [y0, y0, y1, y1];
 
-  layoutData.links.forEach((edge) => {
-    const { source, target } = edge;
-    const sx = source.x1;
-    const tx = target.x0;
-    edge.x = [sx, sx, tx, tx];
-    const offset = edge.width / 2;
-    edge.y = [edge.y0 + offset, edge.y0 - offset, edge.y1 + offset, edge.y1 - offset];
-  });
+      return node;
+    })
+    .filter((node) => {
+      return node.name !== null;
+    });
 
-  return layoutData;
+  const links = layoutData.links
+    .map((edge) => {
+      const { source, target } = edge;
+      const sx = source.x1;
+      const tx = target.x0;
+      edge.x = [sx, sx, tx, tx];
+      const offset = edge.width / 2;
+      edge.y = [edge.y0 + offset, edge.y0 - offset, edge.y1 + offset, edge.y1 - offset];
+
+      return edge;
+    })
+    .filter((edge) => {
+      const { source, target } = edge;
+      return source.name !== null && target.name !== null;
+    });
+
+  return { nodes, links };
 }


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [x] add / modify test cases
- [ ] documents, demos

### Screenshot

```ts
import { Sankey } from '@antv/g2plot';

const DATA = [
  { source: '首次打开', target: '首页 UV', value: 160 },
  { source: '结果页', target: '首页 UV', value: 40 },
  { source: '验证页', target: '首页 UV', value: 10 },
  { source: '我的', target: '首页 UV', value: 10 },
  { source: '朋友', target: '首页 UV', value: 8 },
  { source: null, target: '首页 UV', value: 27 },
  { source: '首页 UV', target: '理财', value: 30 },
  { source: '首页 UV', target: '扫一扫', value: 40 },
  { source: '首页 UV', target: '服务', value: 35 },
  { source: '首页 UV', target: '蚂蚁森林', value: 25 },
  { source: '首页 UV', target: '跳失', value: 10 },
  { source: '首页 UV', target: '借呗', value: 30 },
  { source: '首页 UV', target: '花呗', value: 40 },
  { source: '首页 UV', target: null, value: 45 },
];

const sankey = new Sankey('container', {
  data: DATA,
  sourceField: 'source',
  targetField: 'target',
  weightField: 'value',
  nodeWidthRatio: 0.008,
  nodePaddingRatio: 0.03,
});

sankey.render();
```

|  Before  |  After  |
|----|----|
|  <img width="631" alt="image" src="https://user-images.githubusercontent.com/15646325/169966226-84f3d590-0196-442d-807a-ad54f016234c.png">  |  <img width="494" alt="image" src="https://user-images.githubusercontent.com/15646325/169966015-db617fe7-a7d9-4a09-8f95-bd7c95d5b67d.png">|
