### PR TITLE
fix(bullet): 子弹图 添加单数值range/measures 、 多 target 数据修改兼容

### DIFF
--- a/__tests__/unit/plots/bullet/data-spec.ts
+++ b/__tests__/unit/plots/bullet/data-spec.ts
@@ -116,7 +116,7 @@ describe('bullet*data*transfrom', () => {
       {
         title: '数学',
         ranges: 100,
-        rKey: 'ranges',
+        rKey: 'ranges_0',
       },
       {
         title: '数学',

--- a/__tests__/unit/plots/bullet/data-spec.ts
+++ b/__tests__/unit/plots/bullet/data-spec.ts
@@ -100,6 +100,38 @@ describe('bullet*data*transfrom', () => {
     expect(ds).toEqual(transDS);
   });
 
+  it('data*one', () => {
+    const bulletData = [{ title: '数学', ranges: 100, measures: 20, target: 90 }];
+    // 校验数据转换
+    const { ds } = transformData({
+      data: bulletData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+
+    // 转化为的数据应该为
+    const transDS = [
+      {
+        title: '数学',
+        ranges: 100,
+        rKey: 'ranges',
+      },
+      {
+        title: '数学',
+        measures: 20,
+        mKey: 'measures', // 只有一个数据
+      },
+      {
+        title: '数学',
+        target: 90,
+        tKey: 'target',
+      },
+    ];
+    expect(ds).toEqual(transDS);
+  });
+
   it('data*transfrom*modify', () => {
     const bulletData = [{ title: 'antv', subTitle: 'g2', count: [30, 50, 100, 150], measures: [20, 30], target: 85 }];
     // 校验数据转换

--- a/__tests__/unit/plots/bullet/data-spec.ts
+++ b/__tests__/unit/plots/bullet/data-spec.ts
@@ -48,6 +48,58 @@ describe('bullet*data*transfrom', () => {
     expect(ds).toEqual(transDS);
   });
 
+  it('data*moretarget', () => {
+    const bulletData = [{ title: '数学', ranges: [30, 50, 100], measures: [20], target: [90, 85, 66] }];
+    // 校验数据转换
+    const { ds } = transformData({
+      data: bulletData,
+      measureField: 'measures',
+      rangeField: 'ranges',
+      targetField: 'target',
+      xField: 'title',
+    });
+
+    // 转化为的数据应该为
+    const transDS = [
+      {
+        title: '数学',
+        ranges: 30,
+        rKey: 'ranges_0',
+      },
+      {
+        title: '数学',
+        ranges: 20,
+        rKey: 'ranges_1',
+      },
+      {
+        title: '数学',
+        ranges: 50,
+        rKey: 'ranges_2',
+      },
+      {
+        title: '数学',
+        measures: 20,
+        mKey: 'measures', // 只有一个数据
+      },
+      {
+        title: '数学',
+        target: 66,
+        tKey: 'target_0',
+      },
+      {
+        title: '数学',
+        target: 85,
+        tKey: 'target_1',
+      },
+      {
+        title: '数学',
+        target: 90,
+        tKey: 'target_2',
+      },
+    ];
+    expect(ds).toEqual(transDS);
+  });
+
   it('data*transfrom*modify', () => {
     const bulletData = [{ title: 'antv', subTitle: 'g2', count: [30, 50, 100, 150], measures: [20, 30], target: 85 }];
     // 校验数据转换

--- a/src/plots/bullet/utils.ts
+++ b/src/plots/bullet/utils.ts
@@ -32,15 +32,25 @@ export function transformData(options: BulletOptions): TransformData {
         [measureField]: d,
       });
     });
+
     // 构建 title * target
-    item[targetField].sort((a: number, b: number) => a - b);
-    item[targetField].forEach((d: number, i: number) => {
-      ds.push({
-        tKey: item[targetField].length > 1 ? `${targetField}_${i}` : `${targetField}`, // 一个数据就不带索引了
-        [xField]: xField ? item[xField] : String(index),
-        [targetField]: d,
+    if (Array.isArray(item[targetField])) {
+      item[targetField].sort((a: number, b: number) => a - b);
+      item[targetField].forEach((d: number, i: number) => {
+        ds.push({
+          tKey: item[targetField].length > 1 ? `${targetField}_${i}` : `${targetField}`, // 一个数据就不带索引了
+          [xField]: xField ? item[xField] : String(index),
+          [targetField]: d,
+        });
       });
-    });
+    } else {
+      ds.push({
+        tKey: `${targetField}`,
+        [xField]: xField ? item[xField] : String(index),
+        [targetField]: item[targetField],
+      });
+    }
+
     // 为了取最大值和最小值，先存储
     scales.push(item[rangeField], item[measureField], item[targetField]);
   });

--- a/src/plots/bullet/utils.ts
+++ b/src/plots/bullet/utils.ts
@@ -15,23 +15,40 @@ export function transformData(options: BulletOptions): TransformData {
   const scales: number[] = [];
   data.forEach((item: any, index: number) => {
     // 构建 title * range
-    item[rangeField].sort((a: number, b: number) => a - b);
-    item[rangeField].forEach((d: number, i: number) => {
-      const range = i === 0 ? d : item[rangeField][i] - item[rangeField][i - 1];
-      ds.push({
-        rKey: `${rangeField}_${i}`,
-        [xField]: xField ? item[xField] : String(index), // 没有xField就用索引
-        [rangeField]: range,
+    if (Array.isArray(item[rangeField])) {
+      item[rangeField].sort((a: number, b: number) => a - b);
+      item[rangeField].forEach((d: number, i: number) => {
+        const range = i === 0 ? d : item[rangeField][i] - item[rangeField][i - 1];
+        ds.push({
+          rKey: `${rangeField}_${i}`,
+          [xField]: xField ? item[xField] : String(index), // 没有xField就用索引
+          [rangeField]: range,
+        });
       });
-    });
-    // 构建 title * measure
-    item[measureField].forEach((d: number, i: number) => {
+    } else {
       ds.push({
-        mKey: item[measureField].length > 1 ? `${measureField}_${i}` : `${measureField}`, // 一个数据就不带索引了
+        rKey: `${rangeField}`,
         [xField]: xField ? item[xField] : String(index),
-        [measureField]: d,
+        [rangeField]: item[rangeField],
       });
-    });
+    }
+
+    // 构建 title * measure
+    if (Array.isArray(item[measureField])) {
+      item[measureField].forEach((d: number, i: number) => {
+        ds.push({
+          mKey: item[measureField].length > 1 ? `${measureField}_${i}` : `${measureField}`, // 一个数据就不带索引了
+          [xField]: xField ? item[xField] : String(index),
+          [measureField]: d,
+        });
+      });
+    } else {
+      ds.push({
+        mKey: `${measureField}`, // 一个数据就不带索引了
+        [xField]: xField ? item[xField] : String(index),
+        [measureField]: item[measureField],
+      });
+    }
 
     // 构建 title * target
     if (Array.isArray(item[targetField])) {

--- a/src/plots/bullet/utils.ts
+++ b/src/plots/bullet/utils.ts
@@ -15,58 +15,37 @@ export function transformData(options: BulletOptions): TransformData {
   const scales: number[] = [];
   data.forEach((item: any, index: number) => {
     // 构建 title * range
-    if (Array.isArray(item[rangeField])) {
-      item[rangeField].sort((a: number, b: number) => a - b);
-      item[rangeField].forEach((d: number, i: number) => {
-        const range = i === 0 ? d : item[rangeField][i] - item[rangeField][i - 1];
-        ds.push({
-          rKey: `${rangeField}_${i}`,
-          [xField]: xField ? item[xField] : String(index), // 没有xField就用索引
-          [rangeField]: range,
-        });
-      });
-    } else {
+    const rangeFields = [item[rangeField]].flat();
+    rangeFields.sort((a: number, b: number) => a - b);
+    rangeFields.forEach((d: number, i: number) => {
+      const range = i === 0 ? d : rangeFields[i] - rangeFields[i - 1];
       ds.push({
-        rKey: `${rangeField}`,
-        [xField]: xField ? item[xField] : String(index),
-        [rangeField]: item[rangeField],
+        rKey: rangeFields.length > 1 ? `${rangeField}_${i}` : `${rangeField}`, // 一个数据就不带索引了
+        [xField]: xField ? item[xField] : String(index), // 没有xField就用索引
+        [rangeField]: range,
       });
-    }
+    });
 
     // 构建 title * measure
-    if (Array.isArray(item[measureField])) {
-      item[measureField].forEach((d: number, i: number) => {
-        ds.push({
-          mKey: item[measureField].length > 1 ? `${measureField}_${i}` : `${measureField}`, // 一个数据就不带索引了
-          [xField]: xField ? item[xField] : String(index),
-          [measureField]: d,
-        });
-      });
-    } else {
+    const measureFields = [item[measureField]].flat();
+    measureFields.forEach((d: number, i: number) => {
       ds.push({
-        mKey: `${measureField}`, // 一个数据就不带索引了
+        mKey: measureFields.length > 1 ? `${measureField}_${i}` : `${measureField}`, // 一个数据就不带索引了
         [xField]: xField ? item[xField] : String(index),
-        [measureField]: item[measureField],
+        [measureField]: d,
       });
-    }
+    });
 
     // 构建 title * target
-    if (Array.isArray(item[targetField])) {
-      item[targetField].sort((a: number, b: number) => a - b);
-      item[targetField].forEach((d: number, i: number) => {
-        ds.push({
-          tKey: item[targetField].length > 1 ? `${targetField}_${i}` : `${targetField}`, // 一个数据就不带索引了
-          [xField]: xField ? item[xField] : String(index),
-          [targetField]: d,
-        });
-      });
-    } else {
+    const targetFields = [item[targetField]].flat();
+    targetFields.sort((a: number, b: number) => a - b);
+    targetFields.forEach((d: number, i: number) => {
       ds.push({
-        tKey: `${targetField}`,
+        tKey: targetFields.length > 1 ? `${targetField}_${i}` : `${targetField}`, // 一个数据就不带索引了
         [xField]: xField ? item[xField] : String(index),
-        [targetField]: item[targetField],
+        [targetField]: d,
       });
-    }
+    });
 
     // 为了取最大值和最小值，先存储
     scales.push(item[rangeField], item[measureField], item[targetField]);

--- a/src/plots/bullet/utils.ts
+++ b/src/plots/bullet/utils.ts
@@ -5,6 +5,18 @@ type TransformData = {
   max: number;
   ds: any[];
 };
+
+/**
+ * 获取分类字段 key 值 一个分类值的时候， 返回非索引 key 值，在 tooltip 不做索引区分
+ * @param values 数据量
+ * @param field 指标字段
+ * @param index 索引
+ * @returns string
+ */
+function getSeriesFieldKey(values: number[], field: string, index: number): string {
+  return values.length > 1 ? `${field}_${index}` : `${field}`;
+}
+
 /**
  * bullet 处理数据
  * @param options
@@ -15,33 +27,33 @@ export function transformData(options: BulletOptions): TransformData {
   const scales: number[] = [];
   data.forEach((item: any, index: number) => {
     // 构建 title * range
-    const rangeFields = [item[rangeField]].flat();
-    rangeFields.sort((a: number, b: number) => a - b);
-    rangeFields.forEach((d: number, i: number) => {
-      const range = i === 0 ? d : rangeFields[i] - rangeFields[i - 1];
+    const rangeValues = [item[rangeField]].flat();
+    rangeValues.sort((a: number, b: number) => a - b);
+    rangeValues.forEach((d: number, i: number) => {
+      const range = i === 0 ? d : rangeValues[i] - rangeValues[i - 1];
       ds.push({
-        rKey: rangeFields.length > 1 ? `${rangeField}_${i}` : `${rangeField}`, // 一个数据就不带索引了
+        rKey: `${rangeField}_${i}`,
         [xField]: xField ? item[xField] : String(index), // 没有xField就用索引
         [rangeField]: range,
       });
     });
 
     // 构建 title * measure
-    const measureFields = [item[measureField]].flat();
-    measureFields.forEach((d: number, i: number) => {
+    const measureValues = [item[measureField]].flat();
+    measureValues.forEach((d: number, i: number) => {
       ds.push({
-        mKey: measureFields.length > 1 ? `${measureField}_${i}` : `${measureField}`, // 一个数据就不带索引了
+        mKey: getSeriesFieldKey(measureValues, measureField, i),
         [xField]: xField ? item[xField] : String(index),
         [measureField]: d,
       });
     });
 
     // 构建 title * target
-    const targetFields = [item[targetField]].flat();
-    targetFields.sort((a: number, b: number) => a - b);
-    targetFields.forEach((d: number, i: number) => {
+    const targetValues = [item[targetField]].flat();
+    targetValues.sort((a: number, b: number) => a - b);
+    targetValues.forEach((d: number, i: number) => {
       ds.push({
-        tKey: targetFields.length > 1 ? `${targetField}_${i}` : `${targetField}`, // 一个数据就不带索引了
+        tKey: getSeriesFieldKey(targetValues, targetField, i),
         [xField]: xField ? item[xField] : String(index),
         [targetField]: d,
       });

--- a/src/plots/bullet/utils.ts
+++ b/src/plots/bullet/utils.ts
@@ -33,10 +33,13 @@ export function transformData(options: BulletOptions): TransformData {
       });
     });
     // 构建 title * target
-    ds.push({
-      tKey: `${targetField}`,
-      [xField]: xField ? item[xField] : String(index),
-      [targetField]: item[targetField],
+    item[targetField].sort((a: number, b: number) => a - b);
+    item[targetField].forEach((d: number, i: number) => {
+      ds.push({
+        tKey: item[targetField].length > 1 ? `${targetField}_${i}` : `${targetField}`, // 一个数据就不带索引了
+        [xField]: xField ? item[xField] : String(index),
+        [targetField]: d,
+      });
     });
     // 为了取最大值和最小值，先存储
     scales.push(item[rangeField], item[measureField], item[targetField]);

--- a/src/plots/bullet/utils.ts
+++ b/src/plots/bullet/utils.ts
@@ -50,7 +50,6 @@ export function transformData(options: BulletOptions): TransformData {
 
     // 构建 title * target
     const targetValues = [item[targetField]].flat();
-    targetValues.sort((a: number, b: number) => a - b);
     targetValues.forEach((d: number, i: number) => {
       ds.push({
         tKey: getSeriesFieldKey(targetValues, targetField, i),


### PR DESCRIPTION
### PR includes

- [x]  color.target 颜色可以配置数组和方法
- [x] buttetStyle.target 可以配置回调
- [x]  range/measures 可以配置单个数值
 

|  Before  |  After  |
| --- | --- |
| 更改前 range 和 measures 只能传入数组，不然报错 ，target 的颜色color 不起作用  |更改后 range 和 measures 支持单个数值， target 的颜色配置起效果 |
|  ![image](https://user-images.githubusercontent.com/65594180/171344506-f548a496-b49b-44a9-af17-d67a66ae5545.png)  |  ![image](https://user-images.githubusercontent.com/65594180/171345974-2f677dfa-7ce6-4774-85aa-a8fe04d2aab1.png) |
 
