### PR TITLE
fix(gauge): 仪表盘 percent 0 时，数据被过滤重新添加回来

### DIFF
--- a/__tests__/bugs/issue-3262-spec.ts
+++ b/__tests__/bugs/issue-3262-spec.ts
@@ -1,0 +1,14 @@
+import { Gauge } from '../../src';
+import { createDiv } from '../utils/dom';
+
+describe('#3262', () => {
+  it('gauge percent 0', () => {
+    const gauge = new Gauge(createDiv(), {
+      percent: 0,
+    });
+
+    gauge.render();
+
+    expect(gauge.chart.views[1].getOptions().data.length).toBe(2);
+  });
+});

--- a/__tests__/unit/plots/gauge/utils-spec.ts
+++ b/__tests__/unit/plots/gauge/utils-spec.ts
@@ -10,19 +10,27 @@ describe('gauge utils to getData', () => {
 
   it('get rangeData', () => {
     expect(getRangeData(0.5, { ticks: [0, 0.3, 1] })).toEqual([
-      { [RANGE_VALUE]: 0.3, [RANGE_TYPE]: '1', [PERCENT]: 0.5 },
-      { [RANGE_VALUE]: 0.7, [RANGE_TYPE]: '2', [PERCENT]: 0.5 },
+      { [RANGE_VALUE]: 0.3, [RANGE_TYPE]: '0', [PERCENT]: 0.5 },
+      { [RANGE_VALUE]: 0.7, [RANGE_TYPE]: '1', [PERCENT]: 0.5 },
     ]);
 
     expect(getRangeData(0.5)).toEqual([
+      { [RANGE_VALUE]: 0.5, [RANGE_TYPE]: '0', [PERCENT]: 0.5 },
       { [RANGE_VALUE]: 0.5, [RANGE_TYPE]: '1', [PERCENT]: 0.5 },
-      { [RANGE_VALUE]: 0.5, [RANGE_TYPE]: '2', [PERCENT]: 0.5 },
     ]);
 
-    expect(getRangeData(-0.5)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '2', [PERCENT]: -0.5 }]);
-    expect(getRangeData(1.5)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '1', [PERCENT]: 1.5 }]);
+    expect(getRangeData(1.5)).toEqual([
+      { [RANGE_VALUE]: 1, [RANGE_TYPE]: '0', [PERCENT]: 1.5 },
+      { [RANGE_VALUE]: 0, [RANGE_TYPE]: '1', [PERCENT]: 1.5 },
+    ]);
 
-    expect(getRangeData(0)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '2', [PERCENT]: 0 }]);
-    expect(getRangeData(1)).toEqual([{ [RANGE_VALUE]: 1, [RANGE_TYPE]: '1', [PERCENT]: 1 }]);
+    expect(getRangeData(0)).toEqual([
+      { [RANGE_VALUE]: 0, [RANGE_TYPE]: '0', [PERCENT]: 0 },
+      { [RANGE_VALUE]: 1, [RANGE_TYPE]: '1', [PERCENT]: 0 },
+    ]);
+    expect(getRangeData(1)).toEqual([
+      { [RANGE_VALUE]: 1, [RANGE_TYPE]: '0', [PERCENT]: 1 },
+      { [RANGE_VALUE]: 0, [RANGE_TYPE]: '1', [PERCENT]: 1 },
+    ]);
   });
 });

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -35,7 +35,7 @@ export function getIndicatorData(percent: GaugeOptions['percent']): Data {
 export function getRangeData(percent: GaugeOptions['percent'], range?: GaugeOptions['range']): GaugeRangeData {
   const ticks = get(range, ['ticks'], []);
 
-  const clampTicks = size(ticks) ? ticks.filter((d: Datum) => !!d) : [clamp(percent, 0, 1), 1];
+  const clampTicks = size(ticks) ? uniq(ticks).filter((d: Datum) => !!d) : [clamp(percent, 0, 1), 1];
 
-  return processRangeData(uniq(clampTicks) as number[], percent);
+  return processRangeData(clampTicks as number[], percent);
 }

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -35,7 +35,7 @@ export function getIndicatorData(percent: GaugeOptions['percent']): Data {
 export function getRangeData(percent: GaugeOptions['percent'], range?: GaugeOptions['range']): GaugeRangeData {
   const ticks = get(range, ['ticks'], []);
 
-  const clampTicks = size(ticks) ? uniq(ticks).filter((d: Datum) => !!d) : [clamp(percent, 0, 1), 1];
-
+  const clampTicks = size(ticks) ? uniq(ticks) : [0, clamp(percent, 0, 1), 1];
+  !clampTicks[0] && clampTicks.shift();
   return processRangeData(clampTicks as number[], percent);
 }

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -36,6 +36,8 @@ export function getRangeData(percent: GaugeOptions['percent'], range?: GaugeOpti
   const ticks = get(range, ['ticks'], []);
 
   const clampTicks = size(ticks) ? uniq(ticks) : [0, clamp(percent, 0, 1), 1];
-  !clampTicks[0] && clampTicks.shift();
+  if (!clampTicks[0]) {
+    clampTicks.shift();
+  }
   return processRangeData(clampTicks as number[], percent);
 }

--- a/src/plots/gauge/utils.ts
+++ b/src/plots/gauge/utils.ts
@@ -10,15 +10,24 @@ import { GaugeOptions, GaugeRangeData } from './types';
  * @returns {GaugeRangeData}
  */
 export function processRangeData(range: number[], percent: GaugeOptions['percent']): GaugeRangeData {
-  return (
-    range
-      // 映射为 stack 的数据
-      .map((r: number, idx: number) => {
-        return { [RANGE_VALUE]: r - (range[idx - 1] || 0), [RANGE_TYPE]: `${idx}`, [PERCENT]: percent };
-      })
-      // 去掉 0 的数据
-      .filter((d: Datum) => !!d[RANGE_VALUE])
-  );
+  const rangeData = range
+    // 映射为 stack 的数据
+    .map((r: number, idx: number) => {
+      return { [RANGE_VALUE]: r - (range[idx - 1] || 0), [RANGE_TYPE]: `${idx}`, [PERCENT]: percent };
+    })
+    // 去掉 0 的数据
+    .filter((d: Datum) => !!d[RANGE_VALUE]);
+
+  // percent 为 0 时 重新补充
+  if (rangeData.length < 2) {
+    rangeData.unshift({
+      [RANGE_VALUE]: 0,
+      [RANGE_TYPE]: `${1}`,
+      [PERCENT]: percent,
+    });
+  }
+
+  return rangeData;
 }
 
 /**


### PR DESCRIPTION
仪表盘 percent 0 时，数据被过滤. 导致 geometry 渲染第一个 range  直接为 1 

|  Before  |  After  |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/65594180/175933713-9b2b8165-9a8b-4a48-92d8-f419c06cdff5.png)|  ![image](https://user-images.githubusercontent.com/65594180/175933767-ee1bad82-8aea-4120-ac8b-3bfc852d6e17.png) |

fixed #3262 