### PR TITLE
fix(Chord): 修复弦图label 样式不能修改的问题

### DIFF
--- a/__tests__/bugs/issue-3200-spec.ts
+++ b/__tests__/bugs/issue-3200-spec.ts
@@ -1,0 +1,44 @@
+import { Chord } from '../../src';
+import { createDiv } from '../utils/dom';
+import { delay } from '../utils/delay';
+
+describe('#3200', () => {
+  const DATA = [
+    { source: '北京', target: '天津', value: 30 },
+    { source: '北京', target: '上海', value: 80 },
+    { source: '北京', target: '河北', value: 46 },
+    { source: '北京', target: '辽宁', value: 49 },
+    { source: '北京', target: '黑龙江', value: 69 },
+    { source: '北京', target: '吉林', value: 19 },
+    { source: '天津', target: '河北', value: 62 },
+    { source: '天津', target: '辽宁', value: 82 },
+    { source: '天津', target: '上海', value: 16 },
+    { source: '上海', target: '黑龙江', value: 16 },
+    { source: '河北', target: '黑龙江', value: 76 },
+    { source: '河北', target: '内蒙古', value: 24 },
+    { source: '内蒙古', target: '北京', value: 32 },
+  ];
+
+  const chord = new Chord(createDiv(), {
+    data: DATA,
+    sourceField: 'source',
+    targetField: 'target',
+    weightField: 'value',
+    label: {
+      style: {
+        fill: 'red',
+      },
+    },
+  });
+
+  chord.render();
+
+  it('Chord label ', async () => {
+    await delay(200);
+    const fill = chord.chart.canvas.findAllByName('label')[0]?.cfg?.children[0].attr('fill');
+
+    expect(fill).toEqual('red');
+
+    chord.destroy();
+  });
+});

--- a/src/plots/chord/constant.ts
+++ b/src/plots/chord/constant.ts
@@ -22,13 +22,13 @@ export const DEFAULT_OPTIONS = {
       const centerX = (x[0] + x[1]) / 2;
       const offsetX = centerX > 0.5 ? -4 : 4;
       return {
-        labelEmit: true,
-        style: {
-          fill: '#8c8c8c',
-        },
         offsetX,
         content: name,
       };
+    },
+    labelEmit: true,
+    style: {
+      fill: '#8c8c8c',
     },
   },
   tooltip: {


### PR DESCRIPTION
- [x] 修复 因默认 callback 回调，固定死了样式。 导致的 label style 不能生效的问题。

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/65594180/177732561-13f2e879-d8cf-4958-8bed-7ff9427c6560.png) |  ![image](https://user-images.githubusercontent.com/65594180/177732758-5722edca-d116-4148-90fe-c972cd56c340.png)|

fixed #3200 