### PR TITLE
fix(heatmap): 添加 meta 中的最大最小值参数 可以控制最小显示参数

### DIFF
--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -1,4 +1,4 @@
-import { get } from '@antv/util';
+import { get, isNumber } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { deepAssign, findGeometry } from '../../utils';
 import { flow, transformLabel } from '../../utils';
@@ -51,12 +51,12 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             shape &&
             (sizeField
               ? (dautm) => {
-                const field = data.map((row) => row[sizeField]);
-                let { min, max } = meta?.[sizeField] || {};
-                min = min || Math.min(...field);
-                max = max || Math.max(...field);
-                return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
-              }
+                  const field = data.map((row) => row[sizeField]);
+                  let { min, max } = meta?.[sizeField] || {};
+                  min = isNumber(min) ? min : Math.min(...field);
+                  max = isNumber(max) ? max : Math.max(...field);
+                  return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
+                }
               : () => [shape, 1, checkedSizeRatio]),
           color: color || (colorField && chart.getTheme().sequenceColors.join('-')),
           style: heatmapStyle,

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -9,7 +9,8 @@ import { HeatmapOptions } from './types';
 
 function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
   const { chart, options } = params;
-  const { data, type, xField, yField, colorField, sizeField, sizeRatio, shape, color, tooltip, heatmapStyle, meta } = options;
+  const { data, type, xField, yField, colorField, sizeField, sizeRatio, shape, color, tooltip, heatmapStyle, meta } =
+    options;
 
   chart.data(data);
   let geometryType = 'polygon';
@@ -50,12 +51,12 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             shape &&
             (sizeField
               ? (dautm) => {
-                  const field = data.map((row) => row[sizeField]);
-                  let { min, max } = meta?.[sizeField] || {};
-                  min = min || Math.min(...field);
-                  max = max || Math.max(...field);
-                  return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
-                }
+                const field = data.map((row) => row[sizeField]);
+                let { min, max } = meta?.[sizeField] || {};
+                min = min || Math.min(...field);
+                max = max || Math.max(...field);
+                return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
+              }
               : () => [shape, 1, checkedSizeRatio]),
           color: color || (colorField && chart.getTheme().sequenceColors.join('-')),
           style: heatmapStyle,

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -9,7 +9,7 @@ import { HeatmapOptions } from './types';
 
 function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
   const { chart, options } = params;
-  const { data, type, xField, yField, colorField, sizeField, sizeRatio, shape, color, tooltip, heatmapStyle } = options;
+  const { data, type, xField, yField, colorField, sizeField, sizeRatio, shape, color, tooltip, heatmapStyle, meta } = options;
 
   chart.data(data);
   let geometryType = 'polygon';
@@ -51,8 +51,9 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             (sizeField
               ? (dautm) => {
                   const field = data.map((row) => row[sizeField]);
-                  const min = Math.min(...field);
-                  const max = Math.max(...field);
+                  let { min, max } = meta?.[sizeField] || {};
+                  min = min || Math.min(...field);
+                  max = max || Math.max(...field);
                   return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
                 }
               : () => [shape, 1, checkedSizeRatio]),


### PR DESCRIPTION
- [x] 加入 meta 影响最大最小值显示


|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/65594180/177946162-bba2fa5a-dd8e-44fe-85f0-85ed666af52a.png)|  ![image](https://user-images.githubusercontent.com/65594180/177945712-d17e7b43-e4c8-4d33-b9c0-7e419d6c4d03.png)|

fixed #3170 