### PR TITLE
fix(animation):  动画添加回调， 可以给不同的 形状添加动画

### DIFF
--- a/__tests__/unit/plots/facet/animation-spec.ts
+++ b/__tests__/unit/plots/facet/animation-spec.ts
@@ -1,0 +1,110 @@
+import { Facet } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+
+describe('facet animation', () => {
+  const data = [
+    { type: '1', date: '2014-01', value: 1, name: 'a' },
+    { type: '1', date: '2015-01', value: 1, name: 'b' },
+    { type: '1', date: '2016-01', value: 1, name: 'c' },
+    { type: '1', date: '2017-01', value: 1, name: 'd' },
+    { type: '2', date: '2014-01', value: 1, name: 'a' },
+    { type: '2', date: '2015-01', value: 1, name: 'b' },
+    { type: '2', date: '2016-01', value: 1, name: 'a' },
+    { type: '2', date: '2017-01', value: 1, name: 'd' },
+    { type: '3', date: '2014-01', value: 1, name: 'b' },
+    { type: '4', date: '2015-01', value: 1, name: 'd' },
+    { type: '4', date: '2016-01', value: 10, name: 'b' },
+    { type: '4', date: '2017-01', value: 1, name: 'c' },
+  ];
+  const plot = new Facet(createDiv(), {
+    data,
+    type: 'rect',
+    fields: ['type'],
+    eachView: () => {
+      return {
+        geometries: [
+          { type: 'interval', xField: 'date', yField: 'value', colorField: 'name', mapping: {} },
+          { type: 'point', xField: 'date', yField: 'value', colorField: 'name', mapping: {} },
+        ],
+        animation: {
+          appear: {
+            animation: 'fade-in',
+            duration: 3500,
+          },
+          leave: {
+            animation: 'wave-in',
+            duration: 200,
+          },
+        },
+      };
+    },
+    meta: { date: { sync: true } },
+  });
+  plot.render();
+
+  it('default animation', () => {
+    const geometries = plot.chart.views[0].geometries;
+
+    expect(geometries[0].animateOption).toMatchObject({
+      appear: {
+        animation: 'fade-in',
+        duration: 3500,
+      },
+      leave: {
+        animation: 'wave-in',
+        duration: 200,
+      },
+    });
+  });
+
+  it('callback animation', () => {
+    plot.update({
+      eachView: () => {
+        return {
+          geometries: [
+            { type: 'interval', xField: 'date', yField: 'value', colorField: 'name', mapping: {} },
+            { type: 'point', xField: 'date', yField: 'value', colorField: 'name', mapping: {} },
+          ],
+          animation: (type) => ({
+            appear: {
+              animation: type === 'point' ? 'fade-in' : 'wave-in',
+              duration: 500,
+            },
+            leave: {
+              animation: type === 'interval' ? 'fade-out' : 'wave-out',
+              duration: 300,
+            },
+          }),
+        };
+      },
+    });
+
+    const geometries = plot.chart.views[0].geometries;
+
+    expect(geometries[0].animateOption).toMatchObject({
+      appear: {
+        animation: 'wave-in',
+        duration: 500,
+      },
+      leave: {
+        animation: 'fade-out',
+        duration: 300,
+      },
+    });
+
+    expect(geometries[1].animateOption).toMatchObject({
+      appear: {
+        animation: 'fade-in',
+        duration: 500,
+      },
+      leave: {
+        animation: 'wave-out',
+        duration: 300,
+      },
+    });
+  });
+
+  afterAll(() => {
+    plot.destroy();
+  });
+});

--- a/__tests__/unit/plots/line/animation-spec.ts
+++ b/__tests__/unit/plots/line/animation-spec.ts
@@ -3,37 +3,30 @@ import { partySupport } from '../../../data/party-support';
 import { createDiv } from '../../../utils/dom';
 
 describe('line', () => {
-  it('x*y with animation', () => {
-    const line = new Line(createDiv(), {
-      width: 400,
-      height: 300,
-      data: partySupport.filter((o) => ['FF'].includes(o.type)),
-      xField: 'date',
-      yField: 'value',
-      appendPadding: 10,
-      smooth: true,
-      animation: {
-        enter: {
-          animation: 'fade-in',
-        },
-        leave: {
-          animation: 'fade-out',
-        },
+  const line = new Line(createDiv(), {
+    width: 400,
+    height: 300,
+    data: partySupport.filter((o) => ['FF'].includes(o.type)),
+    xField: 'date',
+    yField: 'value',
+    appendPadding: 10,
+    smooth: true,
+    animation: {
+      enter: {
+        animation: 'fade-in',
       },
-    });
+      leave: {
+        animation: 'fade-out',
+      },
+    },
+    point: {},
+  });
 
-    line.render();
+  line.render();
 
+  it('x*y with animation', () => {
     // 追加默认的动画配置
     expect(line.chart.geometries[0].animateOption).toEqual({
-      appear: {
-        duration: 450,
-        easing: 'easeQuadOut',
-      },
-      update: {
-        duration: 400,
-        easing: 'easeQuadInOut',
-      },
       enter: {
         duration: 400,
         easing: 'easeQuadInOut',
@@ -43,6 +36,47 @@ describe('line', () => {
         duration: 350,
         easing: 'easeQuadIn',
         animation: 'fade-out',
+      },
+      appear: {
+        duration: 450,
+        easing: 'easeQuadOut',
+      },
+      update: {
+        duration: 400,
+        easing: 'easeQuadInOut',
+      },
+    });
+  });
+
+  it('x*y with animation callback', () => {
+    line.update({
+      animation: (type) => ({
+        appear: {
+          animation: type === 'line' ? 'wave-in' : 'fade-in',
+          duration: type === 'line' ? 4500 : 1000,
+          delay: type === 'line' ? 0 : 4500,
+          easing: 'easeQuadIn',
+        },
+      }),
+    });
+
+    // 追加默认的动画配置
+    expect(line.chart.geometries[0].animateOption).toMatchObject({
+      appear: {
+        animation: 'wave-in',
+        duration: 4500,
+        delay: 0,
+        easing: 'easeQuadIn',
+      },
+    });
+
+    // 追加默认的动画配置
+    expect(line.chart.geometries[1].animateOption).toMatchObject({
+      appear: {
+        animation: 'fade-in',
+        duration: 1000,
+        delay: 4500,
+        easing: 'easeQuadIn',
       },
     });
 

--- a/__tests__/unit/plots/sankey/animation-spec.ts
+++ b/__tests__/unit/plots/sankey/animation-spec.ts
@@ -1,0 +1,67 @@
+import { Sankey } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+import { ENERGY_RELATIONS } from '../../../data/sankey-energy';
+
+describe('sankey animation', () => {
+  const sankey = new Sankey(createDiv(), {
+    height: 500,
+    data: ENERGY_RELATIONS,
+    sourceField: 'source',
+    targetField: 'target',
+    weightField: 'value',
+    animation: {
+      appear: {
+        animation: 'fade-in',
+        duration: 300,
+      },
+      leave: {
+        animation: 'fade-out',
+        duration: 350,
+      },
+    },
+  });
+
+  sankey.render();
+
+  it('sankey animation', () => {
+    expect(sankey.options.animation).toMatchObject({
+      appear: {
+        animation: 'fade-in',
+        duration: 300,
+      },
+      leave: {
+        animation: 'fade-out',
+        duration: 350,
+      },
+    });
+  });
+
+  it('sankey animation callback', () => {
+    sankey.update({
+      animation: (type) => ({
+        appear: {
+          animation: type === 'edge' ? 'wave-in' : 'fade-in',
+          duration: type === 'polygon' ? 4000 : 2000,
+        },
+      }),
+    });
+
+    const geometries = [...sankey.chart.views[0].geometries, ...sankey.chart.views[1].geometries];
+
+    expect(geometries[0].animateOption).toMatchObject({
+      appear: {
+        animation: 'wave-in',
+        duration: 2000,
+      },
+    });
+
+    expect(geometries[1].animateOption).toMatchObject({
+      appear: {
+        animation: 'fade-in',
+        duration: 4000,
+      },
+    });
+
+    sankey.destroy();
+  });
+});

--- a/src/adaptor/common.ts
+++ b/src/adaptor/common.ts
@@ -6,7 +6,7 @@ import { Interaction } from '../types/interaction';
 import { Transformations } from '../types/coordinate';
 import { Axis } from '../types/axis';
 import { AXIS_META_CONFIG_KEYS } from '../constant';
-import { pick, deepAssign } from '../utils';
+import { pick, deepAssign, addViewAnimation } from '../utils';
 
 /**
  * 通用 legend 配置, 适用于带 colorField 或 seriesField 的图表
@@ -69,17 +69,8 @@ export function animation<O extends Pick<Options, 'animation'>>(params: Params<O
   const { chart, options } = params;
   const { animation } = options;
 
-  // 同时设置整个 view 动画选项
-  if (typeof animation === 'boolean') {
-    chart.animate(animation);
-  } else {
-    chart.animate(true);
-  }
-
   // 所有的 Geometry 都使用同一动画（各个图形如有区别，自行覆盖）
-  each(chart.geometries, (g: Geometry) => {
-    g.animate(animation);
-  });
+  addViewAnimation(chart, animation);
 
   return params;
 }

--- a/src/plots/chord/adaptor.ts
+++ b/src/plots/chord/adaptor.ts
@@ -1,11 +1,9 @@
-import { Geometry } from '@antv/g2';
-import { each } from '@antv/util';
 import { interaction, theme, state } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
 import { flow, pick } from '../../utils';
 import { polygon, edge } from '../../adaptor/geometries';
 import { chordLayout } from '../../utils/transform/chord';
-import { getAllGeometriesRecursively, transformDataToNodeLinkData } from '../../utils';
+import { getAllGeometriesRecursively, transformDataToNodeLinkData, addViewAnimation } from '../../utils';
 import { ChordOptions } from './types';
 import { X_FIELD, Y_FIELD, NODE_COLOR_FIELD, EDGE_COLOR_FIELD } from './constant';
 
@@ -170,17 +168,7 @@ function animation(params: Params<ChordOptions>): Params<ChordOptions> {
   const { chart, options } = params;
   const { animation } = options;
 
-  // 同时设置整个 view 动画选项
-  if (typeof animation === 'boolean') {
-    chart.animate(animation);
-  } else {
-    chart.animate(true);
-  }
-
-  // 所有的 Geometry 都使用同一动画（各个图形如有区别，自行覆盖）
-  each(getAllGeometriesRecursively(chart), (g: Geometry) => {
-    g.animate(animation);
-  });
+  addViewAnimation(chart, animation, getAllGeometriesRecursively(chart));
 
   return params;
 }

--- a/src/plots/facet/types.ts
+++ b/src/plots/facet/types.ts
@@ -54,7 +54,7 @@ export type IView = {
   /**
    * @title animation 配置
    */
-  readonly animation?: Animation;
+  readonly animation?: Options['animation'];
   /**
    * @title tooltip 配置
    */

--- a/src/plots/facet/utils.ts
+++ b/src/plots/facet/utils.ts
@@ -1,9 +1,9 @@
-import { Geometry, View } from '@antv/g2';
+import { View } from '@antv/g2';
 import { each } from '@antv/util';
 import { geometry as geometryAdaptor } from '../../adaptor/geometries/base';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
-import { pick, deepAssign } from '../../utils';
-import { Axis, Interaction } from '../../types';
+import { pick, deepAssign, addViewAnimation } from '../../utils';
+import { Axis, Interaction, Options } from '../../types';
 import { IView } from './types';
 
 /**
@@ -74,15 +74,7 @@ export function execViewAdaptor(viewOfG2: View, options: IView): void {
   });
 
   // 7. animation (先做动画)
-  if (typeof animation === 'boolean') {
-    viewOfG2.animate(false);
-  } else {
-    viewOfG2.animate(true);
-    // 所有的 Geometry 都使用同一动画（各个图形如有区别，todo 自行覆盖）
-    each(viewOfG2.geometries, (g: Geometry) => {
-      g.animate(animation);
-    });
-  }
+  addViewAnimation(viewOfG2, animation as Options['animation']);
 
   if (tooltip) {
     // 8. tooltip

--- a/src/plots/sankey/adaptor.ts
+++ b/src/plots/sankey/adaptor.ts
@@ -2,6 +2,7 @@ import { uniq } from '@antv/util';
 import { theme } from '../../adaptor/common';
 import { Params } from '../../core/adaptor';
 import { deepAssign, findViewById, flow } from '../../utils';
+import { addViewAnimation } from '../../utils/view';
 import { polygon, edge } from '../../adaptor/geometries';
 import { transformToViewsData } from './helper';
 import { SankeyOptions } from './types';
@@ -110,19 +111,9 @@ export function animation(params: Params<SankeyOptions>): Params<SankeyOptions> 
   const { chart, options } = params;
   const { animation } = options;
 
-  // 同时设置整个 view 动画选项
-  if (typeof animation === 'boolean') {
-    chart.animate(animation);
-  } else {
-    chart.animate(true);
-  }
-
   const geometries = [...chart.views[0].geometries, ...chart.views[1].geometries];
 
-  // 所有的 Geometry 都使用同一动画（各个图形如有区别，自行覆盖）
-  geometries.forEach((g) => {
-    g.animate(animation);
-  });
+  addViewAnimation(chart, animation, geometries);
 
   return params;
 }

--- a/src/plots/violin/adaptor.ts
+++ b/src/plots/violin/adaptor.ts
@@ -1,9 +1,9 @@
-import { Geometry } from '@antv/g2';
 import { get, set, omit, each } from '@antv/util';
 import { Params } from '../../core/adaptor';
 import { interaction, theme, tooltip, annotation as baseAnnotation } from '../../adaptor/common';
 import { interval, point, violin } from '../../adaptor/geometries';
 import { flow, pick, deepAssign, findViewById } from '../../utils';
+import { addViewAnimation } from '../../utils/view';
 import { AXIS_META_CONFIG_KEYS } from '../../constant';
 import { ViolinOptions } from './types';
 import { transformViolinData } from './utils';
@@ -281,16 +281,7 @@ export function animation(params: Params<ViolinOptions>): Params<ViolinOptions> 
 
   // 所有的 Geometry 都使用同一动画（各个图形如有区别，自行覆盖）
   each(chart.views, (view) => {
-    // 同时设置整个 view 动画选项
-    if (typeof animation === 'boolean') {
-      view.animate(animation);
-    } else {
-      view.animate(true);
-    }
-
-    each(view.geometries, (g: Geometry) => {
-      g.animate(animation);
-    });
+    addViewAnimation(view, animation);
   });
 
   return params;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,4 @@
-import { Types } from '@antv/g2';
+import { Geometry, Types } from '@antv/g2';
 import { Axis } from './axis';
 import { Label } from './label';
 import { Tooltip } from './tooltip';
@@ -221,7 +221,7 @@ export type Options = {
    * @title 动画
    * @description 设置图表动画
    */
-  readonly animation?: Animation;
+  readonly animation?: Animation | ((type: string, g: Geometry) => Animation) | boolean;
   /**
    * @title 交互
    * @description 设置画布交互行为

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,5 +12,6 @@ export { kebabCase } from './kebab-case';
 export { renderStatistic, renderGaugeStatistic } from './statistic';
 export { measureTextWidth } from './measure-text';
 export { isBetween, isRealNumber } from './number';
+export { addViewAnimation } from './view';
 export * from './data';
 export * from './padding';

--- a/src/utils/view.ts
+++ b/src/utils/view.ts
@@ -1,4 +1,7 @@
-import { View } from '@antv/g2';
+import { Geometry, View, Types } from '@antv/g2';
+import { each, isFunction } from '@antv/util';
+import { Options } from '../types';
+import { Animation } from '../types/animation';
 
 /**
  * 在 Chart 中查找特定 id 的子 View
@@ -28,4 +31,34 @@ export function getViews(view: View): View[] {
  */
 export function getSiblingViews(view: View): View[] {
   return getViews(view).filter((sub) => sub !== view);
+}
+
+/**
+ * 所有的 Geometries 都使用同一动画（各个图形如有区别，自行覆盖）并添加处理动画回调
+ * @param view View
+ * @param animation 动画配置
+ */
+export function addViewAnimation(
+  view: View,
+  animation: Options['animation'],
+  geometries: Geometry<Types.ShapePoint>[] = view.geometries
+) {
+  // 同时设置整个 view 动画选项
+  if (typeof animation === 'boolean') {
+    view.animate(animation);
+  } else {
+    view.animate(true);
+  }
+
+  // 所有的 Geometry 都使用同一动画（各个图形如有区别，自行覆盖）
+  each(geometries, (g: Geometry) => {
+    let animationCfg;
+    if (isFunction(animation)) {
+      animationCfg = animation(g.type || g.shapeType, g) || true;
+    } else {
+      animationCfg = animation;
+    }
+
+    g.animate(animationCfg as Animation);
+  });
 }


### PR DESCRIPTION
- [x] 修复单一 'path'  类型动画 造成的 渲染失败的bug (点没有 path)  fixed #3141  
- [x] 添加回调 可以对不同形状添加不同的动画效果, 并且通过 延迟渲染的方式， 不同形状可以设置渲染先后
- [x] 提出公共部分的 动画添加代码 方法。

包含所有图表， 外加 特殊 图表 分面图、小提琴图、桑基图

Screenshot

|  Before  |  After  |
|----|----|
|  每一个形状都是一个动画， 并且 同时存在 point 点形状 和 'path' 动画 点时候，报错并渲染失败  ![image](https://user-images.githubusercontent.com/65594180/178224292-39b4c105-b538-48a7-adec-cb2d2704e46d.png) |  添加更多的动画 ![image](https://user-images.githubusercontent.com/65594180/178224685-8ca8bb07-2453-403a-86c5-48ac04bb58c3.png) | 
| | ![image](https://user-images.githubusercontent.com/65594180/178224716-40fb9347-2666-45e1-ab71-12bc48176bf0.png) |



