### PR TITLE
fix(base): rawFields 添加回调，对 geometry color shape 进行了区分

### DIFF
--- a/src/adaptor/geometries/base.ts
+++ b/src/adaptor/geometries/base.ts
@@ -74,10 +74,10 @@ export function getMappingField(
   tileMappingField: string;
 } {
   const { type, xField, yField, colorField, shapeField, sizeField, styleField } = o;
-  let { rawFields = [] } = o;
+  let { rawFields } = o;
 
   let fields = [];
-  rawFields = isFunction(rawFields) ? rawFields(type, field) : rawFields;
+  rawFields = (isFunction(rawFields) ? rawFields(type, field) : rawFields) || [];
 
   // 因为 color 会影响到数据分组，以及最后的图形映射。所以导致 bar 图中的 widthRatio 设置不生效
   // 所以对于 color 字段，仅仅保留 colorField 好了！ + rawFields

--- a/src/adaptor/geometries/base.ts
+++ b/src/adaptor/geometries/base.ts
@@ -1,6 +1,6 @@
 import { uniq, isFunction, isObject, isString, isNumber, isEmpty } from '@antv/util';
 import { Params } from '../../core/adaptor';
-import { ColorAttr, ShapeAttr, SizeAttr, StyleAttr, TooltipAttr, Options, Datum } from '../../types';
+import { ColorAttr, ShapeAttr, SizeAttr, StyleAttr, TooltipAttr, Options, Datum, RawFields } from '../../types';
 import { Label } from '../../types/label';
 import { State } from '../../types/state';
 import { transformLabel } from '../../utils';
@@ -43,7 +43,7 @@ export type Geometry = {
   /** tooltip 的映射字段 */
   readonly tooltipFields?: string[] | false;
   /** 其他原始字段, 用于 mapping 回调参数 */
-  readonly rawFields?: string[];
+  readonly rawFields?: RawFields;
   /** 图形映射规则 */
   readonly mapping?: MappingOptions;
   /** label 映射通道，因为历史原因导致实现略有区别 */
@@ -73,9 +73,11 @@ export function getMappingField(
   mappingFields: string[];
   tileMappingField: string;
 } {
-  const { type, xField, yField, colorField, shapeField, sizeField, styleField, rawFields = [] } = o;
+  const { type, xField, yField, colorField, shapeField, sizeField, styleField } = o;
+  let { rawFields = [] } = o;
 
   let fields = [];
+  rawFields = isFunction(rawFields) ? rawFields(type, field) : rawFields;
 
   // 因为 color 会影响到数据分组，以及最后的图形映射。所以导致 bar 图中的 widthRatio 设置不生效
   // 所以对于 color 字段，仅仅保留 colorField 好了！ + rawFields

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -249,3 +249,5 @@ export type Options = {
    */
   readonly defaultInteractions?: string[];
 };
+
+export type RawFields = string[] | ((type: string, field: 'color' | 'shape' | 'size' | 'style') => string[] | never);


### PR DESCRIPTION
-[x] rawFields 添加回调，对 geometry color shape 进行了区分 (和 G2 一样进行了区分)

|  Before  |  After  |
|----|----|
| 原先 rawFields 对 line 和 point 等统一加的分组  |  回调后可以对 line 和 point 等进行区分分组 |
| 原先 rawFields 对 color 和 shape 等统一加的分组  |  回调后可以对 color 和 shape 等进行区分分组 |

可以对 point 区分 并且不改变 line 的分组
![image](https://user-images.githubusercontent.com/65594180/179741776-81dcf90c-d06a-4bea-bc07-2f0c722c4a05.png)


fixed #3287 