### PR TITLE
fix(pie): 导出 饼图内部兼容 statistic 和 生成 statistic annotations的方法

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export { Bar } from './plots/bar';
 export type { BarOptions } from './plots/bar';
 
 // 饼图及类型定义 | author by [visiky](https://github.com/visiky)
-export { Pie } from './plots/pie';
+export { Pie, transformStatisticOptions } from './plots/pie';
 export type { PieOptions } from './plots/pie';
 
 // 玫瑰图及类型定义 | author by [zhangzhonghe](https://github.com/zhangzhonghe)
@@ -177,7 +177,7 @@ export { Facet } from './plots/facet';
 export type { FacetOptions } from './plots/facet';
 
 /** 开发 adaptor 可能会用到的方法或一些工具方法，不强制使用 */
-export { flow, measureTextWidth } from './utils';
+export { flow, measureTextWidth, renderStatistic } from './utils';
 
 /** 各个 geometry 的 adaptor，可以让开发者更快的构造图形 */
 export { line, interval, area, point, polygon, schema } from './adaptor/geometries';

--- a/src/plots/pie/index.ts
+++ b/src/plots/pie/index.ts
@@ -8,6 +8,8 @@ import { PieOptions } from './types';
 import { isAllZero } from './utils';
 import './interactions';
 
+export { transformStatisticOptions } from './adaptor';
+
 export type { PieOptions };
 
 export class Pie extends Plot<PieOptions> {


### PR DESCRIPTION
- [x] 外部可以很好的交互饼图的 statistic 修改

![image](https://user-images.githubusercontent.com/65594180/179932130-d6a3ca3a-fb17-4862-8496-70c9515d2547.png)


fixed #https://github.com/ant-design/ant-design-charts/issues/1400
