### PR TITLE
fix(heatmap): 修复色力图 coordinate部分配置不起效 和 配置了 refect coordinate 失效的问题

### DIFF
--- a/__tests__/unit/plots/heatmap/coordinate-spec.ts
+++ b/__tests__/unit/plots/heatmap/coordinate-spec.ts
@@ -67,4 +67,40 @@ describe('heatmap', () => {
 
     heatmap.destroy();
   });
+
+  it('coordinate reflect', () => {
+    const coordinate = {
+      type: 'polar',
+      cfg: {
+        radius: 0.85,
+        innerRadius: 0.2,
+      },
+      actions: [['scale', 0.5, -1]],
+    } as any;
+
+    const heatmap = new Heatmap(createDiv('custom axis'), {
+      width: 400,
+      height: 300,
+      data: semanticBasicHeatmapData,
+      xField: 'name',
+      yField: 'day',
+      colorField: 'sales',
+      shape: 'circle',
+      coordinate,
+      reflect: 'x',
+    });
+
+    heatmap.render();
+
+    // @ts-ignore
+    expect(heatmap.chart.options.coordinate).toMatchObject({
+      ...coordinate,
+      actions: [
+        ['scale', 0.5, -1],
+        ['reflect', 'x'],
+      ],
+    });
+
+    heatmap.destroy();
+  });
 });

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -51,12 +51,12 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             shape &&
             (sizeField
               ? (dautm) => {
-                  const field = data.map((row) => row[sizeField]);
-                  let { min, max } = meta?.[sizeField] || {};
-                  min = isNumber(min) ? min : Math.min(...field);
-                  max = isNumber(max) ? max : Math.max(...field);
-                  return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
-                }
+                const field = data.map((row) => row[sizeField]);
+                let { min, max } = meta?.[sizeField] || {};
+                min = isNumber(min) ? min : Math.min(...field);
+                max = isNumber(max) ? max : Math.max(...field);
+                return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
+              }
               : () => [shape, 1, checkedSizeRatio]),
           color: color || (colorField && chart.getTheme().sequenceColors.join('-')),
           style: heatmapStyle,
@@ -168,16 +168,16 @@ function label(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
 function coordinate(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
   const { chart, options } = params;
   const { coordinate, reflect } = options;
-
+  let coordinateController;
   if (coordinate) {
-    chart.coordinate({
+    coordinateController = chart.coordinate({
+      ...coordinate,
       type: coordinate.type || 'rect',
-      cfg: coordinate.cfg,
     });
   }
 
   if (reflect) {
-    chart.coordinate().reflect(reflect);
+    (coordinateController || chart.coordinate()).reflect(reflect);
   }
 
   return params;

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -51,12 +51,12 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             shape &&
             (sizeField
               ? (dautm) => {
-                  const field = data.map((row) => row[sizeField]);
-                  let { min, max } = meta?.[sizeField] || {};
-                  min = isNumber(min) ? min : Math.min(...field);
-                  max = isNumber(max) ? max : Math.max(...field);
-                  return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
-                }
+                const field = data.map((row) => row[sizeField]);
+                let { min, max } = meta?.[sizeField] || {};
+                min = isNumber(min) ? min : Math.min(...field);
+                max = isNumber(max) ? max : Math.max(...field);
+                return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
+              }
               : () => [shape, 1, checkedSizeRatio]),
           color: color || (colorField && chart.getTheme().sequenceColors.join('-')),
           style: heatmapStyle,
@@ -169,10 +169,10 @@ function coordinate(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
   const { chart, options } = params;
   const { coordinate, reflect } = options;
 
-  const coordinateOption = coordinate ?? { type: 'rect', actions: [] };
+  const coordinateOption = deepAssign({ actions: [] }, coordinate ?? { type: 'rect' });
 
   if (reflect) {
-    coordinateOption.actions.push(['reflect', reflect]);
+    coordinateOption.actions?.push?.(['reflect', reflect]);
   }
 
   chart.coordinate(coordinateOption);

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -51,12 +51,12 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             shape &&
             (sizeField
               ? (dautm) => {
-                const field = data.map((row) => row[sizeField]);
-                let { min, max } = meta?.[sizeField] || {};
-                min = isNumber(min) ? min : Math.min(...field);
-                max = isNumber(max) ? max : Math.max(...field);
-                return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
-              }
+                  const field = data.map((row) => row[sizeField]);
+                  let { min, max } = meta?.[sizeField] || {};
+                  min = isNumber(min) ? min : Math.min(...field);
+                  max = isNumber(max) ? max : Math.max(...field);
+                  return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
+                }
               : () => [shape, 1, checkedSizeRatio]),
           color: color || (colorField && chart.getTheme().sequenceColors.join('-')),
           style: heatmapStyle,

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -171,10 +171,7 @@ function coordinate(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
 
   let coordinateController;
   if (coordinate) {
-    coordinateController = chart.coordinate({
-      ...coordinate,
-      type: coordinate.type || 'rect',
-    });
+    coordinateController = chart.coordinate(coordinate);
   }
 
   if (reflect) {

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -51,12 +51,12 @@ function geometry(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
             shape &&
             (sizeField
               ? (dautm) => {
-                const field = data.map((row) => row[sizeField]);
-                let { min, max } = meta?.[sizeField] || {};
-                min = isNumber(min) ? min : Math.min(...field);
-                max = isNumber(max) ? max : Math.max(...field);
-                return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
-              }
+                  const field = data.map((row) => row[sizeField]);
+                  let { min, max } = meta?.[sizeField] || {};
+                  min = isNumber(min) ? min : Math.min(...field);
+                  max = isNumber(max) ? max : Math.max(...field);
+                  return [shape, (get(dautm, sizeField) - min) / (max - min), checkedSizeRatio];
+                }
               : () => [shape, 1, checkedSizeRatio]),
           color: color || (colorField && chart.getTheme().sequenceColors.join('-')),
           style: heatmapStyle,
@@ -168,6 +168,7 @@ function label(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
 function coordinate(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
   const { chart, options } = params;
   const { coordinate, reflect } = options;
+
   let coordinateController;
   if (coordinate) {
     coordinateController = chart.coordinate({

--- a/src/plots/heatmap/adaptor.ts
+++ b/src/plots/heatmap/adaptor.ts
@@ -169,14 +169,13 @@ function coordinate(params: Params<HeatmapOptions>): Params<HeatmapOptions> {
   const { chart, options } = params;
   const { coordinate, reflect } = options;
 
-  let coordinateController;
-  if (coordinate) {
-    coordinateController = chart.coordinate(coordinate);
-  }
+  const coordinateOption = coordinate ?? { type: 'rect', actions: [] };
 
   if (reflect) {
-    (coordinateController || chart.coordinate()).reflect(reflect);
+    coordinateOption.actions.push(['reflect', reflect]);
   }
+
+  chart.coordinate(coordinateOption);
 
   return params;
 }


### PR DESCRIPTION
- [x] 修复色力图 coordinate部分配置不起效 
- [x] 配置了 refect coordinate 失效的问题

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/65594180/180410159-e7b94076-59e4-4b53-bf74-e46f128b19d7.png)|  ![image.png](https://p1-juejin.byteimg.com/tos-cn-i-k3u1fbpfcp/9e64759c661749bd9a2f33b8ab464ddb~tplv-k3u1fbpfcp-watermark.image?) |
