### PR TITLE
fix: 锁 remark-mdx 版本修复启动报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "monaco-editor": "0.21.3",
     "@babel/plugin-transform-spread": "7.12.1",
     "@babel/standalone": "7.12.6",
-    "d3-array": "2.12.1"
+    "d3-array": "2.12.1",
+    "remark-mdx": "1.6.22"
   }
 }


### PR DESCRIPTION
#### 改动说明
remark-mdx 新版本采用 ESM 方式引入。锁定旧版本可以解决问题。
参考：https://github.com/doczjs/docz/issues/1674