### PR TITLE
fix(funnel): 漏斗图转化率文本位置获取修改

### DIFF
--- a/__tests__/unit/plots/funnel/compare-spec.ts
+++ b/__tests__/unit/plots/funnel/compare-spec.ts
@@ -67,14 +67,17 @@ describe('compare funnel', () => {
           '2020Q1': PV_DATA_COMPARE.filter((item) => item.quarter === '2020Q1'),
           '2020Q2': PV_DATA_COMPARE.filter((item) => item.quarter === '2020Q2'),
         };
+        const max = {
+          '2020Q1': maxBy(origin['2020Q1'], 'pv').pv,
+          '2020Q2': maxBy(origin['2020Q2'], 'pv').pv,
+        };
 
-        const max = maxBy(PV_DATA_COMPARE, 'pv').pv;
+        const { data } = funnelView.getOptions();
 
-        const { data } = funnel.chart.getOptions();
         data.forEach((item) => {
           const originData = origin[item.quarter];
           const originIndex = originData.findIndex((jtem) => jtem.pv === item.pv);
-          const percent = item.pv / max;
+          const percent = item.pv / max[item.quarter];
           expect(item[FUNNEL_PERCENT]).toEqual(percent);
           expect(item[FUNNEL_MAPPING_VALUE]).toEqual(0.5 * percent + 0.3);
           expect(item[FUNNEL_CONVERSATION]).toEqual([get(originData, [originIndex - 1, 'pv']), item.pv]);

--- a/src/plots/funnel/adaptor.ts
+++ b/src/plots/funnel/adaptor.ts
@@ -146,7 +146,7 @@ function legend(params: Params<FunnelOptions>): Params<FunnelOptions> {
 export function interaction<O extends Pick<FunnelOptions, 'interactions'>>(params: Params<O>): Params<O> {
   const { chart, options } = params;
   // @ts-ignore
-  const { interactions, dynamicHeight, compareField } = options;
+  const { interactions, dynamicHeight } = options;
 
   each(interactions, (i: Interaction) => {
     if (i.enable === false) {
@@ -156,7 +156,7 @@ export function interaction<O extends Pick<FunnelOptions, 'interactions'>>(param
     }
   });
   // 动态高度  不进行交互操作
-  if (!dynamicHeight && !compareField) {
+  if (!dynamicHeight) {
     chart.interaction(FUNNEL_LEGEND_FILTER, {
       start: [{ ...interactionStart, arg: options }],
     });

--- a/src/plots/funnel/geometries/basic.ts
+++ b/src/plots/funnel/geometries/basic.ts
@@ -1,5 +1,5 @@
 import { Types } from '@antv/g2';
-import { isArray } from '@antv/util';
+import { isArray, get, map } from '@antv/util';
 import { flow, findGeometry } from '../../../utils';
 import { getTooltipMapping } from '../../../utils/tooltip';
 import { Params } from '../../../core/adaptor';
@@ -80,9 +80,14 @@ function transpose(params: Params<FunnelOptions>): Params<FunnelOptions> {
  * 转化率组件
  * @param params
  */
-function conversionTag(params: Params<FunnelOptions>): Params<FunnelOptions> {
-  const { options } = params;
+export function conversionTag(params: Params<FunnelOptions>): Params<FunnelOptions> {
+  const { options, chart } = params;
   const { maxSize } = options;
+
+  // 获取形状位置，再转化为需要的转化率位置
+  const dataArray = get(chart, ['geometries', '0', 'dataArray'], []);
+  const size = get(chart, ['options', 'data', 'length']);
+  const x = map(dataArray, (item) => get(item, ['0', 'nextPoints', '0', 'x']) * size - 0.5);
 
   const getLineCoordinate = (
     datum: Datum,
@@ -93,8 +98,8 @@ function conversionTag(params: Params<FunnelOptions>): Params<FunnelOptions> {
     const percent = maxSize - (maxSize - datum[FUNNEL_MAPPING_VALUE]) / 2;
     return {
       ...initLineOption,
-      start: [datumIndex - 0.5, percent],
-      end: [datumIndex - 0.5, percent + 0.05],
+      start: [x[datumIndex - 1] || datumIndex - 0.5, percent],
+      end: [x[datumIndex - 1] || datumIndex - 0.5, percent + 0.05],
     };
   };
 

--- a/src/plots/funnel/geometries/common.ts
+++ b/src/plots/funnel/geometries/common.ts
@@ -5,6 +5,8 @@ import { FUNNEL_PERCENT, FUNNEL_CONVERSATION, FUNNEL_MAPPING_VALUE } from '../co
 import { Params } from '../../../core/adaptor';
 import { FunnelOptions } from '../types';
 
+export const CONVERSION_TAG_NAME = 'CONVERSION_TAG_NAME';
+
 /**
  * 漏斗图 transform
  * @param geometry
@@ -50,14 +52,14 @@ export function conversionTagComponent(
     // @ts-ignore
     const { conversionTag, filteredData } = options;
 
-    let { data } = chart.getOptions();
-    data = filteredData || data;
+    const data = filteredData || chart.getOptions().data;
     if (conversionTag) {
       const { formatter } = conversionTag;
       data.forEach((obj, index) => {
         if (index <= 0 || Number.isNaN(obj[FUNNEL_MAPPING_VALUE])) return;
         const lineOption = getLineCoordinate(obj, index, data, {
           top: true,
+          name: CONVERSION_TAG_NAME,
           text: {
             content: isFunction(formatter) ? formatter(obj, data) : formatter,
             offsetX: conversionTag.offsetX,

--- a/src/plots/funnel/geometries/common.ts
+++ b/src/plots/funnel/geometries/common.ts
@@ -47,10 +47,11 @@ export function conversionTagComponent(
 ) {
   return function (params: Params<FunnelOptions>): Params<FunnelOptions> {
     const { chart, options } = params;
-    const { conversionTag } = options;
+    // @ts-ignore
+    const { conversionTag, filteredData } = options;
 
-    const { data } = chart.getOptions();
-
+    let { data } = chart.getOptions();
+    data = filteredData || data;
     if (conversionTag) {
       const { formatter } = conversionTag;
       data.forEach((obj, index) => {

--- a/src/plots/funnel/index.ts
+++ b/src/plots/funnel/index.ts
@@ -12,6 +12,7 @@ import {
   FUNNEL_PERCENT,
   FUNNEL_TOTAL_PERCENT,
 } from './constant';
+import './interactions';
 
 export type { FunnelOptions };
 

--- a/src/plots/funnel/interactions/funnel-conversion-tag.ts
+++ b/src/plots/funnel/interactions/funnel-conversion-tag.ts
@@ -1,0 +1,39 @@
+import { get, map } from '@antv/util';
+import { Action } from '@antv/g2';
+import { conversionTag } from '../geometries/basic';
+import { transformData } from '../geometries/common';
+import { FunnelOptions } from '../types';
+
+/**
+ * Funnel 转化率跟随 legend 变化事件
+ */
+export class ConversionTagAction extends Action {
+  private rendering = false;
+  public change(options: FunnelOptions) {
+    // 防止多次重复渲染
+    if (!this.rendering) {
+      const { seriesField } = options;
+      const { view } = this.context;
+      // 兼容分面漏斗图
+      const views = seriesField ? view.views : [view];
+      map(views, (v) => {
+        v.getController('annotation').clear(true);
+        const data = get(v, ['filteredData'], v.getOptions().data);
+
+        conversionTag({
+          chart: v,
+          options: {
+            ...options,
+            // @ts-ignore
+            filteredData: transformData(data, data, options),
+          },
+        });
+
+        v.filterData(data);
+        this.rendering = true;
+        v.render(true);
+      });
+    }
+    this.rendering = false;
+  }
+}

--- a/src/plots/funnel/interactions/index.ts
+++ b/src/plots/funnel/interactions/index.ts
@@ -1,0 +1,11 @@
+import { registerAction, registerInteraction } from '@antv/g2';
+import { ConversionTagAction } from './funnel-conversion-tag';
+
+const FUNNEL_CONVERSION_TAG = 'funnel-conversion-tag';
+export const FUNNEL_LEGEND_FILTER = 'funnel-afterrender';
+export const interactionStart = { trigger: 'afterrender', action: `${FUNNEL_CONVERSION_TAG}:change` };
+
+registerAction(FUNNEL_CONVERSION_TAG, ConversionTagAction);
+registerInteraction(FUNNEL_LEGEND_FILTER, {
+  start: [interactionStart],
+});

--- a/src/plots/funnel/types.ts
+++ b/src/plots/funnel/types.ts
@@ -1,5 +1,6 @@
 import { StyleAttr } from '../../types/attr';
 import { TextStyle, Datum, Data, AnnotationPosition, Options } from '../../types/common';
+export { Interaction } from '../../types';
 
 export type ConversionPosition = {
   start: AnnotationPosition;


### PR DESCRIPTION
- [x] 漏斗图转化率文本 afterrender 后重新修改
- [x] 漏斗图转化率文本 通过形状获取 x 位置信息
- [x]  对比漏斗图还未更改，动态不用更改
- [x] 兼容其他 annotations , 不至于全部删除 

fixed #3350 

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/65594180/190343659-e3f29a51-2632-47cd-9e6f-5dd68cc9c3d7.png)| ![image](https://user-images.githubusercontent.com/65594180/190343565-12fb193a-209d-4f2c-a680-27b32e10f5da.png)  ![image](https://user-images.githubusercontent.com/65594180/190581428-c2b4782e-288f-4437-920a-0122353266a4.png)|
