### PR TITLE
fix: g2plot.antv.vision & antv-g2plot.gitee.io auto direct

### DIFF
--- a/site/.dumi/global.ts
+++ b/site/.dumi/global.ts
@@ -13,6 +13,6 @@ if (window) {
   require('antd/lib/alert/style/index.css');
 }
 
-if (location.origin === 'g2plot.antv.vision' || location.origin === 'antv-g2plot.gitee.io') {
+if (location.host === 'g2plot.antv.vision' || location.host === 'antv-g2plot.gitee.io') {
   (window as any).location.href = location.href.replace(location.origin, 'https://g2plot.antv.antgroup.com');
 }


### PR DESCRIPTION
- 修复 g2plot.antv.vision & antv-g2plot.gitee.io 无法自动跳转到 g2plot.antv.antgroup.com 上