### PR TITLE
perf(word-cloud):  add willReadFrequently option when canvas getContext

### DIFF
--- a/src/utils/transform/word-cloud.ts
+++ b/src/utils/transform/word-cloud.ts
@@ -403,11 +403,14 @@ function tagCloud() {
 
   function getContext(canvas: HTMLCanvasElement) {
     canvas.width = canvas.height = 1;
-    const ratio = Math.sqrt(canvas.getContext('2d')!.getImageData(0, 0, 1, 1).data.length >> 2);
+    const ratio = Math.sqrt(
+      (canvas.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D)!.getImageData(0, 0, 1, 1).data
+        .length >> 2
+    );
     canvas.width = (cw << 5) / ratio;
     canvas.height = ch / ratio;
 
-    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+    const context = canvas.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D;
     context.fillStyle = context.strokeStyle = 'red';
     context.textAlign = 'center';
     return { context, ratio };


### PR DESCRIPTION
使用词云图时，若更新数据或者更改图表的尺寸会触发浏览器警告:
```
Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: <URL>
```
在 `canvas.getContext` 时，增加这个配置可以避免这个警告，优化部分性能。
