### PR TITLE
fix(Liquid): should render wave only when percent > 0

### DIFF
--- a/src/plots/liquid/adaptor.ts
+++ b/src/plots/liquid/adaptor.ts
@@ -44,6 +44,7 @@ function geometry(params: Params<LiquidOptions>): Params<LiquidOptions> {
   const geometry = ext.geometry as Geometry;
   const { background } = chart.getTheme();
   const customInfo: CustomInfo = {
+    percent,
     radius,
     outline,
     wave,

--- a/src/plots/liquid/shapes/liquid.ts
+++ b/src/plots/liquid/shapes/liquid.ts
@@ -389,7 +389,7 @@ registerShape('interval', 'liquid-fill-gauge', {
     const cy = 0.5;
 
     const { customInfo } = cfg;
-    const { radius: radio, shape, shapeStyle, background, animation } = customInfo as CustomInfo;
+    const { percent, radius: radio, shape, shapeStyle, background, animation } = customInfo as CustomInfo;
     const outline: LiquidOptions['outline'] = customInfo.outline;
     const wave: LiquidOptions['wave'] = customInfo.wave;
     const { border, distance } = outline;
@@ -428,32 +428,35 @@ registerShape('interval', 'liquid-fill-gauge', {
       });
     }
 
-    // 2. 绘制一个波
-    const waves = container.addGroup({
-      name: 'waves',
-    });
+    // 比例大于 0 时才绘制水波
+    if (percent > 0) {
+      // 2. 绘制一个波
+      const waves = container.addGroup({
+        name: 'waves',
+      });
 
-    // 3. 波对应的 clip 裁剪形状
-    const clipPath = waves.setClip({
-      type: 'path',
-      attrs: {
-        path: shapePath,
-      },
-    });
+      // 3. 波对应的 clip 裁剪形状
+      const clipPath = waves.setClip({
+        type: 'path',
+        attrs: {
+          path: shapePath,
+        },
+      });
 
-    // 4. 绘制波形
-    addWaterWave(
-      center.x,
-      center.y,
-      1 - (cfg.points[1] as Point).y,
-      waveCount,
-      waveAttrs,
-      waves,
-      clipPath,
-      radius * 2,
-      waveLength,
-      animation
-    );
+      // 4. 绘制波形
+      addWaterWave(
+        center.x,
+        center.y,
+        1 - (cfg.points[1] as Point).y,
+        waveCount,
+        waveAttrs,
+        waves,
+        clipPath,
+        radius * 2,
+        waveLength,
+        animation
+      );
+    }
 
     // 5. 绘制一个 distance 宽的 border
     container.addShape('path', {

--- a/src/plots/liquid/types.ts
+++ b/src/plots/liquid/types.ts
@@ -88,6 +88,7 @@ export interface LiquidOptions extends Omit<Options, 'data'> {
  * @title 水波图自定义 的 customInfo
  */
 export type CustomInfo = {
+  percent?: LiquidOptions['percent'];
   radius?: LiquidOptions['radius'];
   outline?: LiquidOptions['outline'];
   wave?: LiquidOptions['wave'];


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] `percent` 大于 0 时才绘制水波，避免为 0 时仍然能看到波峰，容易误导用户。
- [ ] add / modify test cases
- [ ] documents, demos

### Screenshot

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/14918822/216010075-6d5112e1-e520-4c84-af45-6efbd8f60ecb.png) |  ![image](https://user-images.githubusercontent.com/14918822/216009658-cadce0c6-4507-4b83-b892-6d143de337e7.png)  |
| ![image](https://user-images.githubusercontent.com/14918822/216010172-00f32296-de59-4f77-b067-9773c4fe503d.png) | ![image](https://user-images.githubusercontent.com/14918822/216009893-3948d697-22a9-4d96-85ed-e66ec7415d1e.png) |
