### PR TITLE
fix(Sankey): insufficient pass-in parameters for the callback function of edgeStyle

### DIFF
--- a/__tests__/unit/plots/sankey/adaptor-spec.ts
+++ b/__tests__/unit/plots/sankey/adaptor-spec.ts
@@ -1,0 +1,133 @@
+import { Sankey } from '../../../../src';
+import { createDiv } from '../../../utils/dom';
+
+describe('sankey adaptor', () => {
+  const mockCallback = jest.fn();
+
+  const DATA = [
+    {
+      sourceName: '低活',
+      targetName: '低活2',
+      sourceDisplayName: '低活',
+      targetDisplayName: '低活',
+      value: 1,
+    },
+    {
+      sourceName: '低活',
+      targetName: '中活2',
+      sourceDisplayName: '低活',
+      targetDisplayName: '中活',
+      value: 1,
+    },
+    {
+      sourceName: '低活',
+      targetName: '高活2',
+      sourceDisplayName: '低活',
+      targetDisplayName: '高活',
+      value: 1,
+    },
+    {
+      sourceName: '中活',
+      targetName: '低活2',
+      sourceDisplayName: '中活',
+      targetDisplayName: '低活',
+      value: 1,
+    },
+    {
+      sourceName: '中活',
+      targetName: '中活2',
+      sourceDisplayName: '中活',
+      targetDisplayName: '中活',
+      value: 1,
+    },
+    {
+      sourceName: '中活',
+      targetName: '流失2',
+      sourceDisplayName: '中活',
+      targetDisplayName: '流失',
+      value: 1,
+    },
+    {
+      sourceName: '高活',
+      targetName: '低活2',
+      sourceDisplayName: '高活',
+      targetDisplayName: '低活',
+      value: 1,
+    },
+    {
+      sourceName: '高活',
+      targetName: '高活2',
+      sourceDisplayName: '高活',
+      targetDisplayName: '高活',
+      value: 1,
+    },
+    {
+      sourceName: '沉默',
+      targetName: '高活2',
+      sourceDisplayName: '沉默',
+      targetDisplayName: '高活',
+      value: 1,
+    },
+    {
+      sourceName: '沉默',
+      targetName: '沉默2',
+      sourceDisplayName: '沉默',
+      targetDisplayName: '沉默',
+      value: 1,
+    },
+    {
+      sourceName: '流失',
+      targetName: '沉默2',
+      sourceDisplayName: '流失',
+      targetDisplayName: '沉默',
+      value: 1,
+    },
+    {
+      sourceName: '流失',
+      targetName: '流失2',
+      sourceDisplayName: '流失',
+      targetDisplayName: '流失',
+      value: 1,
+    },
+    {
+      sourceName: '低活2',
+      targetName: '低活3',
+      sourceDisplayName: '低活',
+      targetDisplayName: '低活',
+      value: 1,
+    },
+    {
+      sourceName: '低活2',
+      targetName: '中活3',
+      sourceDisplayName: '低活',
+      targetDisplayName: '中活',
+      value: 1,
+    },
+    {
+      sourceName: '低活2',
+      targetName: '高活3',
+      sourceDisplayName: '低活',
+      targetDisplayName: '高活',
+      value: 1,
+    },
+  ];
+
+  const sankey = new Sankey(createDiv(), {
+    height: 500,
+    data: DATA,
+    sourceField: 'sourceName',
+    targetField: 'targetName',
+    weightField: 'value',
+    rawFields: ['sourceDisplayName', 'targetDisplayName'],
+    edgeStyle: mockCallback,
+  });
+
+  sankey.render();
+
+  it('edgeStyle callback', () => {
+    expect(mockCallback.mock.calls[0][0].source).toBeDefined();
+    expect(mockCallback.mock.calls[0][0].target).toBeDefined();
+    expect(mockCallback.mock.calls[0][0].sourceDisplayName).toBeDefined();
+    expect(mockCallback.mock.calls[0][0].targetDisplayName).toBeDefined();
+  });
+});

--- a/src/plots/sankey/adaptor.ts
+++ b/src/plots/sankey/adaptor.ts
@@ -38,7 +38,7 @@ function defaultOptions(params: Params<SankeyOptions>): Params<SankeyOptions> {
  */
 function geometry(params: Params<SankeyOptions>): Params<SankeyOptions> {
   const { chart, options } = params;
-  const { color, nodeStyle, edgeStyle, label, tooltip, nodeState, edgeState } = options;
+  const { color, nodeStyle, edgeStyle, label, tooltip, nodeState, edgeState, rawFields = [] } = options;
 
   // 1. 组件，优先设置，因为子 view 会继承配置
   chart.legend(false);
@@ -62,6 +62,7 @@ function geometry(params: Params<SankeyOptions>): Params<SankeyOptions> {
       xField: X_FIELD,
       yField: Y_FIELD,
       seriesField: COLOR_FIELD,
+      rawFields: ['source', 'target', ...rawFields],
       edge: {
         color,
         style: edgeStyle,


### PR DESCRIPTION
### PR includes

- fix the bug that the the callback function `edgeStyle` has no sufficient parameters

Before:

Only the parameters of `name`, `x` and `y` are passed into the callback function `edgeStyle`. The value of `name` is the name of the source node. Users cannot get the name of the target node while using `edgeStyle`. The `rawFields` does not affect.

After:

The parameters of `source` and `target` are passed into the callback function `edgeStyle`. Users can get the name of the target node from `target`. The `rawFields` takes effect.
