### PR TITLE
fix(column): 修复柱状图拆分维度为空字符串时，错误显示了 xField 作为 title 的问题

### DIFF
--- a/src/plots/column/adaptor.ts
+++ b/src/plots/column/adaptor.ts
@@ -99,7 +99,7 @@ function geometry(params: Params<ColumnOptions>): Params<ColumnOptions> {
     ? {
         formatter: (datum: Datum) => ({
           name:
-            isGroup && isStack ? `${datum[seriesField]} - ${datum[groupField]}` : datum[seriesField] || datum[xField],
+            isGroup && isStack ? `${datum[seriesField]} - ${datum[groupField]}` : datum[seriesField] ?? datum[xField],
           value: (Number(datum[yField]) * 100).toFixed(2) + '%',
         }),
         ...tooltip,


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

### Screenshot
在百分比柱状图中，如果y中拆分字段是空字符串，显示就有问题，错误的使用了 xField 作为title:

![image](https://user-images.githubusercontent.com/17964556/224648667-588ff719-5ab5-4c32-86b8-3d32ebe62c72.png)

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/17964556/224649270-3c9b7c89-e20d-46c1-b77f-1bd53ce14fd4.png)  |  ![image](https://user-images.githubusercontent.com/17964556/224648597-9caf0499-2c3e-4659-a8c1-e52d63e7081b.png)  |
