### PR TITLE
chore: update version to 2.4.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### 2.4.28 (2023-04-03)
+#### 2.4.29 (2023-04-03)
 
 * upgrade version of @antv/component to [0.8.33](https://github.com/antvis/component/pull/299).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2plot",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "description": "An interactive and responsive charting library",
   "keywords": [
     "chart",


### PR DESCRIPTION
应为线上版本和 package.json 的不一致，导致上一个 [PR](https://github.com/antvis/G2Plot/pull/3511) 更新版本号错误，这个 PR 修复问题。

![image](https://user-images.githubusercontent.com/49330279/229501501-06e2b06d-22e4-413c-9f63-23115970b470.png)

![image](https://user-images.githubusercontent.com/49330279/229501424-92ffdda1-f057-4fd1-9560-5d643f268dcb.png)
