### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ $ git checkout -b branch-name
 # Run the test after you finish your modification. Add new test cases or change old ones if you feel necessary
 $ npm test
 
-# If your modification pass the tests, congradulations it's time to push your work back to us. Notice that the commit message should be written in the following format.
+# If your modification pass the tests, congratulations it's time to push your work back to us. Notice that the commit message should be written in the following format.
 $ git add . # git add -u to delete files
 $ git commit -m "fix(role): role.use must xxx"
 $ git push origin branch-name
@@ -104,7 +104,7 @@ BREAKING CHANGE:
   Breaks foo.bar api, foo.baz should be used instead
 ```
 
-Look at [these files](https:// docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more detials.
+Look at [these files](https:// docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more details.
 
 ## Release
 

--- a/site/docs/api/plot-api.en.md
+++ b/site/docs/api/plot-api.en.md
@@ -77,7 +77,7 @@ Destroy the entire canvas completely, recycle all resources, and keep only the D
 plot.on(event: string, callback: Function);
 ```
 
-Keep listening to a plot event and trigger a callback function. The event mechanism is transimitted transparently through G2 events. See [G2 event mechanism](https://g2.antv.vision/zh/docs/api/general/event) for all event lists and callback function parameters.
+Keep listening to a plot event and trigger a callback function. The event mechanism is transmitted transparently through G2 events. See [G2 event mechanism](https://g2.antv.vision/zh/docs/api/general/event) for all event lists and callback function parameters.
 
 ### 8. once
 

--- a/site/docs/api/plots/funnel.en.md
+++ b/site/docs/api/plots/funnel.en.md
@@ -54,7 +54,7 @@ Whether the plot is transposed.
 
 <description>**optional** _boolean_ _default:_ `false`</description>
 
-Whether the height is dynamic. When set to `true`, the height of each elemnet in funnel plot is directly proportional to the corresponding value of yField.
+Whether the height is dynamic. When set to `true`, the height of each element in funnel plot is directly proportional to the corresponding value of yField.
 
 #### maxSize
 

--- a/site/docs/api/plots/violin.en.md
+++ b/site/docs/api/plots/violin.en.md
@@ -80,7 +80,7 @@ type BoxOption = {
 
 <description>**optional** _'smooth'|'hollow'|'hollow-smooth'_</description>
 
-The shape of violin geometry. Could be 'smooth', 'hollow' or 'hollow-smooth'. Defaults to rough, solid voilins.
+The shape of violin geometry. Could be 'smooth', 'hollow' or 'hollow-smooth'. Defaults to rough, solid violins.
 
 #### violinStyle
 


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- site/docs/api/plot-api.en.md
- site/docs/api/plots/funnel.en.md
- site/docs/api/plots/violin.en.md

Fixes:
- Should read `violins` rather than `voilins`.
- Should read `transmitted` rather than `transimitted`.
- Should read `element` rather than `elemnet`.
- Should read `details` rather than `detials`.
- Should read `congratulations` rather than `congradulations`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md