### PR TITLE
chore: update version of @antv/component to 0.8.33 for dist build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+#### 2.4.30 (2023-05-05)
+
+* upgrade version of @antv/component to [0.8.33] for dist build.
+
 #### 2.4.29 (2023-04-03)
+
+*  update version in index.ts ([#3513](https://github.com/antvis/G2plot/pull/3513)) ([eff8d4d0](https://github.com/antvis/G2plot/commit/eff8d4d0a0ff923f1ed4f4018caeba107d32326a))
 
 * upgrade version of @antv/component to [0.8.33](https://github.com/antvis/component/pull/299).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2plot",
-  "version": "2.4.29",
+  "version": "2.4.30",
   "description": "An interactive and responsive charting library",
   "keywords": [
     "chart",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const version = '2.4.29';
+export const version = '2.4.30';
 
 // G2 自定义能力透出
 import * as G2 from '@antv/g2';


### PR DESCRIPTION
发上一个版本的时候本地 node_modules 安装了错误的 component 0.8.32 版本，导致 dist 相应的修改没有生效。准备更新本地依赖之后，重新发布一次。