### PR TITLE
fix: 修复未清除size-sensor缓存在全局变量上的实例,导致页面内存泄漏

### DIFF
--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -1,7 +1,7 @@
 import EE from '@antv/event-emitter';
 import { Chart, Element, Event, View } from '@antv/g2';
 import { each } from '@antv/util';
-import { bind } from 'size-sensor';
+import { bind, clear } from 'size-sensor';
 import { Annotation, Options, Size, StateCondition, StateName, StateObject } from '../types';
 import { deepAssign, getAllElementsRecursively, getContainerSize, pick } from '../utils';
 import { Adaptor } from './adaptor';
@@ -285,6 +285,8 @@ export abstract class Plot<O extends PickOptions> extends EE {
    * 销毁
    */
   public destroy() {
+    // 清除size-sensor缓存在全局变量上的实例
+    this.clearSizeSensorCache();
     // 取消 size-sensor 的绑定
     this.unbindSizeSensor();
     // G2 的销毁
@@ -350,6 +352,14 @@ export abstract class Plot<O extends PickOptions> extends EE {
     if (this.unbind) {
       this.unbind();
       this.unbind = undefined;
+    }
+  }
+  /**
+   * 清除缓存
+   */
+  private clearSizeSensorCache() {
+    if (this.container) {
+      clear(this.container);
     }
   }
 }


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

### Screenshot
* size-sensor 源码示例
![image](https://github.com/antvis/G2Plot/assets/67814702/5f80a758-a4c9-48e6-9c99-6e2cfcfed213)
* Before
![1693892672334](https://github.com/antvis/G2Plot/assets/67814702/aa037e05-3721-4be3-94ec-94315db3cc3b)
* After
内存和detached dom均正常回收,
![1693892672953](https://github.com/antvis/G2Plot/assets/67814702/8f6d74cd-6f1d-4815-a0e9-1395ca2eff5f) 

