### PR TITLE
docs

### DIFF
--- a/site/docs/api/components/axis.zh.md
+++ b/site/docs/api/components/axis.zh.md
@@ -48,7 +48,9 @@ xAxis: false; // 隐藏 x 轴
 
 ```ts
 xAxis: {
-  text: 'x 轴标题'
+  title: {
+     text: 'x 轴标题'
+  }
 }
 ```
 


### PR DESCRIPTION
原有示例不对，xAxis 配置中没有text属性，text属性，需要放在title属性里边

### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [docs] Axis 配置的示例不对，xAxis 配置中没有text属性，text属性，需要放在title属性里边

### Screenshot

|  Before  |  After  |
|----|----|
|  ![image](https://github.com/antvis/G2Plot/assets/900931/15b86f1e-2082-46c3-9276-6bde066505f1)|  ✅  |
