### PR TITLE
fix: 修复双轴图缩略不同步问题

### DIFF
--- a/__tests__/unit/plots/bullet/index-spec.ts
+++ b/__tests__/unit/plots/bullet/index-spec.ts
@@ -134,7 +134,7 @@ describe('bullet', () => {
       xField: 'title',
       yField: 'measures',
     });
-    expect(measureGeometry.getAttribute('color').values).toEqual('#ff0000');
+    expect(measureGeometry.getAttribute('color').values).toEqual('#000000');
 
     bullet.destroy();
   });

--- a/src/plots/dual-axes/util/render-sider.ts
+++ b/src/plots/dual-axes/util/render-sider.ts
@@ -21,8 +21,8 @@ export const doSliderFilter = (view: View, sliderValue: [number, number]) => {
   const values = valuesOfKey(data, xScale.field);
   const xValues = isHorizontal ? values : values.reverse();
   const xTickCount = size(xValues);
-  const minIndex = Math.floor(min * (xTickCount - 1));
-  const maxIndex = Math.floor(max * (xTickCount - 1));
+  const minIndex = Math.round(min * (xTickCount - 1));
+  const maxIndex = Math.round(max * (xTickCount - 1));
 
   // 增加 x 轴的过滤器
   view.filter(xScale.field, (value: any) => {


### PR DESCRIPTION
### PR includes
<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

![image](https://github.com/user-attachments/assets/01010b84-3439-46cf-848a-edd4bbbce001)
g2 代码里取值用的 Math.round，而 G2Plot 这边用的 Math.floor，导致双轴缩略不同步
### Screenshot


|  Before  |  After  |
|----|----|
|![image](https://github.com/user-attachments/assets/1b661bf9-af69-436c-84fd-968b75d910d3) |   ![image](https://github.com/user-attachments/assets/cd39ee0e-c232-48d9-ae52-956392b7dd58)
