### PR TITLE
fix(column): 修复柱图 color 回调导致 slider 显示异常

### DIFF
--- a/__tests__/unit/plots/column/index-spec.ts
+++ b/__tests__/unit/plots/column/index-spec.ts
@@ -83,6 +83,32 @@ describe('column', () => {
     column.destroy();
   });
 
+  it('x*y with color callback', () => {
+    const column = new Column(createDiv('x*y with color callback'), {
+      width: 400,
+      height: 300,
+      data: salesByArea,
+      xField: 'area',
+      yField: 'sales',
+      slider: {
+        start: 0,
+        end: 0.5,
+      },
+      color: (datum) => (datum.sales > 100 ? 'red' : 'green'),
+    });
+
+    column.render();
+
+    const geometry = column.chart.geometries[0];
+
+    expect(geometry.getAttribute('color')).toBeUndefined();
+    expect(geometry.getAttribute('style').getFields()).toEqual(['area']);
+    expect(column.chart.getGroupScales()).toHaveLength(0);
+    expect(geometry.elements[0].shape.attr('fill')).toBe('green');
+
+    column.destroy();
+  });
+
   it('grouped column', () => {
     const column = new Column(createDiv('grouped column'), {
       width: 400,

--- a/src/adaptor/geometries/base.ts
+++ b/src/adaptor/geometries/base.ts
@@ -126,17 +126,22 @@ export function getMappingFunction(mappingFields: string[], func: (datum: Datum)
   if (!func) return undefined;
   // 返回函数
   return (...args: any[]) => {
-    const params: Datum = {};
-
-    mappingFields.forEach((f: string, idx: number) => {
-      params[f] = args[idx];
-    });
-
-    // 删除 undefined
-    delete params['undefined'];
-
+    const params = getMappingDatum(mappingFields, args);
     return func(params);
   };
+}
+
+function getMappingDatum(mappingFields: string[], args: any[]): Datum {
+  const params: Datum = {};
+
+  mappingFields.forEach((f: string, idx: number) => {
+    params[f] = args[idx];
+  });
+
+  // 删除 undefined
+  delete params['undefined'];
+
+  return params;
 }
 
 /**
@@ -170,6 +175,9 @@ export function geometry<O extends GeometryOptions>(params: Params<O>): Params<O
 
   // 创建 geometry
   const geometry = chart[type](args).position(`${xField}*${yField}`);
+  let colorStyleFields: string[] = [];
+  let colorStyleMappingField: string;
+  let colorStyleCallback: (datum: Datum) => string;
 
   /**
    * color 的几种情况
@@ -182,7 +190,13 @@ export function geometry<O extends GeometryOptions>(params: Params<O>): Params<O
     colorField ? geometry.color(colorField, color) : geometry.color(color);
   } else if (isFunction(color)) {
     const { mappingFields, tileMappingField } = getMappingField(options, 'color');
-    geometry.color(customMappingField || tileMappingField, getMappingFunction(mappingFields, color));
+    if (type === 'interval' && !colorField) {
+      colorStyleFields = mappingFields;
+      colorStyleMappingField = customMappingField || tileMappingField;
+      colorStyleCallback = color;
+    } else {
+      geometry.color(customMappingField || tileMappingField, getMappingFunction(mappingFields, color));
+    }
   } else {
     colorField && geometry.color(colorField, color);
   }
@@ -224,7 +238,24 @@ export function geometry<O extends GeometryOptions>(params: Params<O>): Params<O
    * g.style({ fill: 'red' });
    * g.style('x*y*color', (x, y, color) => ({ fill: 'red' }));
    */
-  if (isFunction(style)) {
+  if (!isEmpty(colorStyleFields)) {
+    if (isFunction(style)) {
+      const { mappingFields } = getMappingField(options, 'style');
+      const fields = uniq([...colorStyleFields, ...mappingFields]);
+      geometry.style(fields.join('*'), (...args: any[]) => {
+        const datum = getMappingDatum(fields, args);
+        return {
+          fill: colorStyleCallback(datum),
+          ...style(datum),
+        };
+      });
+    } else {
+      geometry.style(colorStyleMappingField, (...args: any[]) => ({
+        fill: getMappingFunction(colorStyleFields, colorStyleCallback)(...args),
+        ...(isObject(style) ? style : {}),
+      }));
+    }
+  } else if (isFunction(style)) {
     const { mappingFields, tileMappingField } = getMappingField(options, 'style');
     geometry.style(tileMappingField, getMappingFunction(mappingFields, style));
   } else if (isObject(style)) {

--- a/src/adaptor/geometries/base.ts
+++ b/src/adaptor/geometries/base.ts
@@ -251,7 +251,7 @@ export function geometry<O extends GeometryOptions>(params: Params<O>): Params<O
       });
     } else {
       geometry.style(colorStyleMappingField, (...args: any[]) => ({
-        fill: getMappingFunction(colorStyleFields, colorStyleCallback)(...args),
+        fill: colorStyleCallback(getMappingDatum(colorStyleFields, args)),
         ...(isObject(style) ? style : {}),
       }));
     }


### PR DESCRIPTION
### PR includes

- [x] fixes #3750
- [x] add / modify test cases
- [ ] documents, demos

### Description

当柱图未配置 `seriesField`，但 `color` 使用函数回调时，原逻辑会将回调绑定到 `xField` 的 color 通道上，导致 G2 将其作为分组字段处理，从而影响 slider 场景下的裁剪显示。

本 PR 在无 `colorField` 的 `interval` 图形中，将函数型 `color` 的结果映射到 `style.fill`，避免生成额外的 color 分组 scale，同时保留自定义颜色效果。

### Changes

- 调整函数型 `color` 在无拆分字段的 `interval` 图形中的映射方式
- 增加柱图 `color callback + slider` 的回归用例

### Screenshot

Before
<img width="1601" height="810" alt="image" src="https://github.com/user-attachments/assets/8aef00cf-43cb-4a66-90cc-066621f2c9b5" />

After
<img width="1601" height="832" alt="image" src="https://github.com/user-attachments/assets/0649d450-e318-4734-8263-35d214ef3eae" />

### Test

- `npm run lib:cjs`
